### PR TITLE
Configure setuptools to find src packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,6 @@ ignore = ["E501"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+
+[tool.setuptools.packages.find]
+where = ["src"]


### PR DESCRIPTION
## Summary
- configure setuptools to discover packages from the src directory so the app package can be installed

## Testing
- pip install -e .[dev]
- python -c "import app"


------
https://chatgpt.com/codex/tasks/task_e_68d75c6babb48327afabe60101aa33bf