### PR TITLE
Add onboarding flow backend, UI, and tests

### DIFF
--- a/src/app/api/routes/onboarding.py
+++ b/src/app/api/routes/onboarding.py
@@ -1,0 +1,207 @@
+"""API endpoints for the onboarding workflow."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from app.services.onboarding import (
+    OnboardingEvent,
+    OnboardingService,
+    OnboardingStatus,
+    OnboardingError,
+    onboarding_service,
+)
+
+router = APIRouter(prefix="/api/onboarding", tags=["onboarding"])
+
+
+class RegistrationRequest(BaseModel):
+    email: str = Field(..., pattern=r"^[^@\s]+@[^@\s]+\.[^@\s]+$", description="Email utama pengguna")
+    full_name: str = Field(..., min_length=3, max_length=120)
+    password: str = Field(..., min_length=8, max_length=128)
+    marketing_opt_in: bool | None = Field(False, description="Apakah pengguna ingin menerima email komunitas")
+
+
+class RegistrationResponse(BaseModel):
+    onboarding_id: str
+    status: OnboardingStatus
+    verification_expires_at: datetime | None
+    progress: Dict[str, Any]
+    verification_token: str | None = Field(None, description="Token debug yang disediakan untuk lingkungan pengujian")
+
+
+class VerificationRequest(BaseModel):
+    onboarding_id: str
+    token: str = Field(..., min_length=4, max_length=64)
+
+
+class VerificationResponse(BaseModel):
+    onboarding_id: str
+    status: OnboardingStatus
+    progress: Dict[str, Any]
+
+
+class ProfileRequest(BaseModel):
+    onboarding_id: str
+    display_name: str = Field(..., min_length=2, max_length=80)
+    business_goal: str = Field(..., min_length=3, max_length=160)
+    experience_level: str = Field(..., min_length=3, max_length=120)
+
+
+class ProfileResponse(BaseModel):
+    onboarding_id: str
+    status: OnboardingStatus
+    profile: Dict[str, Any]
+    progress: Dict[str, Any]
+
+
+class EventLogResponse(BaseModel):
+    onboarding_id: str
+    events: List[Dict[str, Any]]
+
+
+class ResendRequest(BaseModel):
+    onboarding_id: str
+
+
+def get_onboarding_service() -> OnboardingService:
+    return onboarding_service
+
+
+def _serialize_events(events: List[OnboardingEvent]) -> List[Dict[str, Any]]:
+    return [
+        {
+            "event": event.event,
+            "timestamp": event.timestamp.isoformat(),
+            "metadata": event.metadata,
+        }
+        for event in events
+    ]
+
+
+def _serialize_progress(service: OnboardingService, onboarding_id: str) -> Dict[str, Any]:
+    return service.get_progress(onboarding_id)
+
+
+def _handle_error(exc: OnboardingError) -> None:
+    raise HTTPException(status_code=exc.status_code, detail=exc.message)
+
+
+@router.post("/register", response_model=RegistrationResponse, status_code=status.HTTP_201_CREATED)
+def register_user(
+    payload: RegistrationRequest,
+    service: OnboardingService = Depends(get_onboarding_service),
+) -> RegistrationResponse:
+    try:
+        user = service.register_user(
+            email=payload.email,
+            full_name=payload.full_name,
+            password=payload.password,
+            marketing_opt_in=bool(payload.marketing_opt_in),
+        )
+    except OnboardingError as exc:
+        _handle_error(exc)
+
+    progress = _serialize_progress(service, user.id)
+    return RegistrationResponse(
+        onboarding_id=user.id,
+        status=user.status,
+        verification_expires_at=progress["verification"]["expires_at"],
+        progress=progress,
+        verification_token=user.verification_token,
+    )
+
+
+@router.post("/verify", response_model=VerificationResponse)
+def verify_email(
+    payload: VerificationRequest,
+    service: OnboardingService = Depends(get_onboarding_service),
+) -> VerificationResponse:
+    try:
+        user = service.verify_email(
+            onboarding_id=payload.onboarding_id,
+            token=payload.token,
+        )
+    except OnboardingError as exc:
+        _handle_error(exc)
+
+    progress = _serialize_progress(service, user.id)
+    return VerificationResponse(onboarding_id=user.id, status=user.status, progress=progress)
+
+
+@router.post("/profile", response_model=ProfileResponse)
+def complete_profile(
+    payload: ProfileRequest,
+    service: OnboardingService = Depends(get_onboarding_service),
+) -> ProfileResponse:
+    try:
+        user = service.complete_profile(
+            onboarding_id=payload.onboarding_id,
+            display_name=payload.display_name,
+            business_goal=payload.business_goal,
+            experience_level=payload.experience_level,
+        )
+    except OnboardingError as exc:
+        _handle_error(exc)
+
+    progress = _serialize_progress(service, user.id)
+    profile = progress["profile"] or {}
+    return ProfileResponse(
+        onboarding_id=user.id,
+        status=user.status,
+        profile=profile,
+        progress=progress,
+    )
+
+
+@router.post("/resend", response_model=RegistrationResponse)
+def resend_token(
+    payload: ResendRequest,
+    service: OnboardingService = Depends(get_onboarding_service),
+) -> RegistrationResponse:
+    try:
+        token = service.resend_verification_token(onboarding_id=payload.onboarding_id)
+        user = service.get_user(payload.onboarding_id)
+    except OnboardingError as exc:
+        _handle_error(exc)
+
+    progress = _serialize_progress(service, user.id)
+    return RegistrationResponse(
+        onboarding_id=user.id,
+        status=user.status,
+        verification_expires_at=progress["verification"]["expires_at"],
+        progress=progress,
+        verification_token=token,
+    )
+
+
+@router.get("/progress/{onboarding_id}", response_model=VerificationResponse)
+def get_progress(
+    onboarding_id: str,
+    service: OnboardingService = Depends(get_onboarding_service),
+) -> VerificationResponse:
+    try:
+        user = service.get_user(onboarding_id)
+    except OnboardingError as exc:
+        _handle_error(exc)
+
+    progress = _serialize_progress(service, user.id)
+    return VerificationResponse(onboarding_id=user.id, status=user.status, progress=progress)
+
+
+@router.get("/events/{onboarding_id}", response_model=EventLogResponse)
+def get_event_log(
+    onboarding_id: str,
+    service: OnboardingService = Depends(get_onboarding_service),
+) -> EventLogResponse:
+    try:
+        service.get_user(onboarding_id)
+    except OnboardingError as exc:
+        _handle_error(exc)
+
+    events = _serialize_events(service.get_events(onboarding_id))
+    return EventLogResponse(onboarding_id=onboarding_id, events=events)

--- a/src/app/api/routes/root.py
+++ b/src/app/api/routes/root.py
@@ -164,3 +164,38 @@ async def read_marketplace(request: Request) -> HTMLResponse:
         "marketplace_catalog": marketplace_catalog,
     }
     return templates.TemplateResponse("marketplace.html", context)
+
+
+@router.get("/onboarding", response_class=HTMLResponse)
+async def read_onboarding(request: Request) -> HTMLResponse:
+    """Render the onboarding flow playground used by the product team."""
+
+    settings = get_settings()
+    templates = request.app.state.templates
+
+    steps = [
+        {
+            "key": "register",
+            "title": "Buat Akun",
+            "description": "Isi data dasar dan konfirmasi email untuk mulai eksplorasi Sensasiwangi.",
+        },
+        {
+            "key": "verify",
+            "title": "Verifikasi Email",
+            "description": "Masukkan kode yang kami kirim dan pantau batas waktunya secara real-time.",
+        },
+        {
+            "key": "profile",
+            "title": "Lengkapi Profil",
+            "description": "Beritahu kami tujuan bisnis parfum Anda untuk rekomendasi kurasi.",
+        },
+    ]
+
+    context = {
+        "request": request,
+        "app_name": settings.app_name,
+        "environment": settings.environment,
+        "title": "Onboarding Pengguna",
+        "steps": steps,
+    }
+    return templates.TemplateResponse("onboarding.html", context)

--- a/src/app/core/application.py
+++ b/src/app/core/application.py
@@ -8,6 +8,7 @@ from starlette.staticfiles import StaticFiles
 
 from app.core.config import get_settings
 from app.web.templates import template_engine
+from app.api.routes import onboarding as onboarding_routes
 from app.api.routes import reports as reports_routes
 from app.api.routes import root as root_routes
 
@@ -36,6 +37,7 @@ def create_app() -> FastAPI:
     # Register routers for server-rendered pages and API endpoints.
     app.include_router(root_routes.router)
     app.include_router(reports_routes.router)
+    app.include_router(onboarding_routes.router)
 
     # Expose the template engine on the app state for reuse by routers.
     app.state.templates = template_engine

--- a/src/app/services/onboarding.py
+++ b/src/app/services/onboarding.py
@@ -1,0 +1,370 @@
+"""Services and data structures to orchestrate the onboarding flow."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Dict, Iterable, List, MutableMapping, Optional
+
+
+class OnboardingError(Exception):
+    """Base class for onboarding related errors."""
+
+    status_code: int = 400
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class EmailAlreadyRegistered(OnboardingError):
+    status_code = 409
+
+
+class RegistrationRateLimited(OnboardingError):
+    status_code = 429
+
+
+class OnboardingNotFound(OnboardingError):
+    status_code = 404
+
+
+class VerificationTokenExpired(OnboardingError):
+    status_code = 410
+
+
+class VerificationAttemptsExceeded(OnboardingError):
+    status_code = 423
+
+
+class InvalidVerificationToken(OnboardingError):
+    status_code = 400
+
+
+class ProfileIncomplete(OnboardingError):
+    status_code = 400
+
+
+class OnboardingStatus(str, Enum):
+    """Represents the current step of a user in the onboarding flow."""
+
+    REGISTERED = "registered"
+    EMAIL_VERIFIED = "email_verified"
+    PROFILE_COMPLETED = "profile_completed"
+
+
+@dataclass
+class OnboardingEvent:
+    """Represents a log entry generated during the onboarding flow."""
+
+    onboarding_id: str
+    event: str
+    timestamp: datetime
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class OnboardingProfile:
+    """Stores optional profile information collected during onboarding."""
+
+    display_name: str
+    business_goal: str
+    experience_level: str
+
+
+@dataclass
+class OnboardingUser:
+    """Aggregates onboarding state for a specific user."""
+
+    id: str
+    email: str
+    full_name: str
+    password_hash: str
+    status: OnboardingStatus
+    created_at: datetime
+    updated_at: datetime
+    verification_token: Optional[str] = None
+    verification_expires_at: Optional[datetime] = None
+    verification_attempts: int = 0
+    profile: Optional[OnboardingProfile] = None
+
+
+def _hash_password(raw: str) -> str:
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+class OnboardingService:
+    """Coordinator for the onboarding workflow."""
+
+    TOKEN_TTL = timedelta(minutes=15)
+    RATE_LIMIT_WINDOW = timedelta(seconds=10)
+    MAX_VERIFICATION_ATTEMPTS = 3
+
+    def __init__(self) -> None:
+        self._users_by_id: Dict[str, OnboardingUser] = {}
+        self._users_by_email: Dict[str, str] = {}
+        self._events: List[OnboardingEvent] = []
+        self._rate_limit: MutableMapping[str, datetime] = {}
+
+    def register_user(
+        self,
+        *,
+        email: str,
+        full_name: str,
+        password: str,
+        marketing_opt_in: bool = False,
+        now: Optional[datetime] = None,
+    ) -> OnboardingUser:
+        """Register a new onboarding user and issue an email token."""
+
+        now = now or datetime.utcnow()
+
+        normalized_email = email.strip().lower()
+        self._validate_email(normalized_email)
+        self._validate_password(password)
+        self._validate_full_name(full_name)
+
+        last_attempt = self._rate_limit.get(normalized_email)
+        if last_attempt and now - last_attempt < self.RATE_LIMIT_WINDOW:
+            retry_after = int((self.RATE_LIMIT_WINDOW - (now - last_attempt)).total_seconds()) + 1
+            raise RegistrationRateLimited(
+                f"Percobaan registrasi terlalu sering. Coba lagi dalam {retry_after} detik."
+            )
+
+        if normalized_email in self._users_by_email:
+            raise EmailAlreadyRegistered("Email sudah terdaftar untuk onboarding.")
+
+        onboarding_id = secrets.token_urlsafe(8)
+        password_hash = _hash_password(password)
+
+        user = OnboardingUser(
+            id=onboarding_id,
+            email=normalized_email,
+            full_name=full_name.strip(),
+            password_hash=password_hash,
+            status=OnboardingStatus.REGISTERED,
+            created_at=now,
+            updated_at=now,
+        )
+
+        self._issue_verification_token(user, now=now)
+
+        self._users_by_id[onboarding_id] = user
+        self._users_by_email[normalized_email] = onboarding_id
+        self._rate_limit[normalized_email] = now
+
+        self._log(
+            user.id,
+            "registered",
+            now,
+            {"email": normalized_email, "marketing_opt_in": marketing_opt_in},
+        )
+        self._log(
+            user.id,
+            "verification_token_issued",
+            now,
+            {
+                "expires_at": user.verification_expires_at.isoformat() if user.verification_expires_at else None,
+                "dispatch_ms": 1200,
+            },
+        )
+
+        return user
+
+    def verify_email(
+        self,
+        *,
+        onboarding_id: str,
+        token: str,
+        now: Optional[datetime] = None,
+    ) -> OnboardingUser:
+        """Validate an email verification token."""
+
+        now = now or datetime.utcnow()
+        user = self._get_user(onboarding_id)
+
+        if user.verification_attempts >= self.MAX_VERIFICATION_ATTEMPTS:
+            raise VerificationAttemptsExceeded(
+                "Percobaan verifikasi melebihi batas. Hubungi dukungan kami."
+            )
+
+        if not user.verification_token or not user.verification_expires_at:
+            raise InvalidVerificationToken("Tidak ada token verifikasi aktif.")
+
+        if now > user.verification_expires_at:
+            user.verification_token = None
+            raise VerificationTokenExpired("Token verifikasi telah kedaluwarsa.")
+
+        if secrets.compare_digest(user.verification_token, token.strip()):
+            user.status = OnboardingStatus.EMAIL_VERIFIED
+            user.verification_token = None
+            user.verification_expires_at = None
+            user.verification_attempts = 0
+            user.updated_at = now
+            self._log(user.id, "email_verified", now)
+        else:
+            user.verification_attempts += 1
+            self._log(
+                user.id,
+                "verification_failed",
+                now,
+                {"attempts": user.verification_attempts},
+            )
+            raise InvalidVerificationToken("Token verifikasi tidak valid.")
+
+        return user
+
+    def resend_verification_token(
+        self,
+        *,
+        onboarding_id: str,
+        now: Optional[datetime] = None,
+    ) -> str:
+        """Generate a new verification token for a user."""
+
+        now = now or datetime.utcnow()
+        user = self._get_user(onboarding_id)
+
+        if user.status is not OnboardingStatus.REGISTERED:
+            raise OnboardingError("Email sudah terverifikasi, token baru tidak diperlukan.")
+
+        token = self._issue_verification_token(user, now=now)
+        self._log(
+            user.id,
+            "verification_token_resent",
+            now,
+            {"expires_at": user.verification_expires_at.isoformat()},
+        )
+        return token
+
+    def complete_profile(
+        self,
+        *,
+        onboarding_id: str,
+        display_name: str,
+        business_goal: str,
+        experience_level: str,
+        now: Optional[datetime] = None,
+    ) -> OnboardingUser:
+        """Mark the onboarding profile as completed."""
+
+        now = now or datetime.utcnow()
+        user = self._get_user(onboarding_id)
+
+        if user.status is not OnboardingStatus.EMAIL_VERIFIED:
+            raise ProfileIncomplete("Email harus terverifikasi sebelum melengkapi profil.")
+
+        profile = OnboardingProfile(
+            display_name=display_name.strip(),
+            business_goal=business_goal.strip(),
+            experience_level=experience_level.strip(),
+        )
+        user.profile = profile
+        user.status = OnboardingStatus.PROFILE_COMPLETED
+        user.updated_at = now
+        self._log(
+            user.id,
+            "profile_completed",
+            now,
+            {"experience_level": experience_level.strip()},
+        )
+        return user
+
+    def get_progress(self, onboarding_id: str) -> dict:
+        user = self._get_user(onboarding_id)
+        step_index = {
+            OnboardingStatus.REGISTERED: 1,
+            OnboardingStatus.EMAIL_VERIFIED: 2,
+            OnboardingStatus.PROFILE_COMPLETED: 3,
+        }[user.status]
+
+        return {
+            "onboarding_id": user.id,
+            "email": user.email,
+            "status": user.status.value,
+            "step_index": step_index,
+            "total_steps": 3,
+            "is_complete": user.status is OnboardingStatus.PROFILE_COMPLETED,
+            "profile": (
+                {
+                    "display_name": user.profile.display_name,
+                    "business_goal": user.profile.business_goal,
+                    "experience_level": user.profile.experience_level,
+                }
+                if user.profile
+                else None
+            ),
+            "verification": {
+                "active": bool(user.verification_token),
+                "expires_at": user.verification_expires_at.isoformat()
+                if user.verification_expires_at
+                else None,
+            },
+        }
+
+    def get_events(self, onboarding_id: str) -> List[OnboardingEvent]:
+        return [event for event in self._events if event.onboarding_id == onboarding_id]
+
+    def get_user(self, onboarding_id: str) -> OnboardingUser:
+        return self._get_user(onboarding_id)
+
+    def iter_users(self) -> Iterable[OnboardingUser]:
+        return list(self._users_by_id.values())
+
+    def _get_user(self, onboarding_id: str) -> OnboardingUser:
+        try:
+            return self._users_by_id[onboarding_id]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise OnboardingNotFound("Onboarding ID tidak ditemukan.") from exc
+
+    def _issue_verification_token(
+        self,
+        user: OnboardingUser,
+        *,
+        now: datetime,
+    ) -> str:
+        token = secrets.token_urlsafe(6)
+        user.verification_token = token
+        user.verification_expires_at = now + self.TOKEN_TTL
+        user.updated_at = now
+        user.verification_attempts = 0
+        return token
+
+    def _log(
+        self,
+        onboarding_id: str,
+        event: str,
+        timestamp: datetime,
+        metadata: Optional[dict] = None,
+    ) -> None:
+        self._events.append(
+            OnboardingEvent(
+                onboarding_id=onboarding_id,
+                event=event,
+                timestamp=timestamp,
+                metadata=metadata or {},
+            )
+        )
+
+    def _validate_email(self, email: str) -> None:
+        pattern = r"^[^@\s]+@[^@\s]+\.[^@\s]+$"
+        if not re.match(pattern, email):
+            raise OnboardingError("Format email tidak valid.")
+
+    def _validate_password(self, password: str) -> None:
+        if len(password) < 8:
+            raise OnboardingError("Password minimal 8 karakter.")
+        if not re.search(r"[A-Za-z]", password) or not re.search(r"[0-9]", password):
+            raise OnboardingError("Password harus mengandung huruf dan angka.")
+
+    def _validate_full_name(self, full_name: str) -> None:
+        if len(full_name.strip()) < 3:
+            raise OnboardingError("Nama lengkap minimal 3 karakter.")
+
+
+onboarding_service = OnboardingService()
+"""Singleton instance used across the application."""

--- a/src/app/web/static/css/base.css
+++ b/src/app/web/static/css/base.css
@@ -1084,3 +1084,298 @@ p {
     padding: 2rem;
   }
 }
+
+/* --------------------------------------------------------------- */
+/* Onboarding playground styles                                     */
+/* --------------------------------------------------------------- */
+
+.onboarding-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  padding: 2.5rem;
+  align-items: center;
+}
+
+.hero-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.progress-bar {
+  width: 100%;
+  height: 10px;
+  background: rgba(148, 163, 184, 0.22);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  width: 0%;
+  height: 100%;
+  background: var(--accent-primary);
+  transition: width var(--transition-base);
+}
+
+.progress-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.progress-step {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid transparent;
+}
+
+.progress-step .step-index {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  border: 2px solid rgba(148, 163, 184, 0.45);
+  font-weight: 600;
+}
+
+.progress-step.active {
+  border-color: rgba(56, 189, 248, 0.5);
+  background: rgba(56, 189, 248, 0.08);
+}
+
+.progress-step.active .step-index {
+  border-color: var(--accent-secondary);
+  color: var(--accent-secondary);
+}
+
+.progress-step.completed {
+  border-color: rgba(52, 211, 153, 0.4);
+  background: rgba(16, 185, 129, 0.12);
+}
+
+.progress-step.completed .step-index {
+  border-color: var(--success);
+  color: var(--success);
+}
+
+.onboarding-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 2.5rem;
+}
+
+.onboarding-main {
+  padding: 2.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.section-header h2 {
+  margin-bottom: 0.35rem;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.feedback {
+  min-height: 1.75rem;
+  border-radius: var(--radius-sm);
+  padding: 0.5rem 0.85rem;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  font-size: 0.95rem;
+  opacity: 0;
+  transition: opacity var(--transition-base);
+}
+
+.feedback.visible {
+  opacity: 1;
+}
+
+.feedback[data-tone="success"] {
+  border-color: rgba(52, 211, 153, 0.45);
+  color: var(--success);
+}
+
+.feedback[data-tone="danger"] {
+  border-color: rgba(248, 113, 113, 0.45);
+  color: var(--danger);
+}
+
+.onboarding-forms {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.onboarding-form {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: var(--radius-md);
+  padding: 1.75rem;
+  display: grid;
+  gap: 1.25rem;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.onboarding-form fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.onboarding-form legend {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.onboarding-form label {
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.95rem;
+}
+
+.onboarding-form input,
+.onboarding-form select {
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  padding: 0.65rem 0.85rem;
+  background: rgba(15, 23, 42, 0.75);
+  color: var(--text-primary);
+  font-size: 1rem;
+}
+
+.onboarding-form input:focus,
+.onboarding-form select:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.65);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+}
+
+.checkbox {
+  display: flex !important;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.checkbox input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: #f97316;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.form-help {
+  font-size: 0.9rem;
+  color: rgba(203, 213, 225, 0.8);
+}
+
+.debug-token {
+  font-family: "Fira Code", "Consolas", monospace;
+  font-size: 0.85rem;
+  color: rgba(125, 211, 252, 0.9);
+}
+
+.onboarding-sidebar {
+  padding: 2.25rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.event-log {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.event-log li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 0.6rem 0.9rem;
+  font-size: 0.9rem;
+}
+
+.event-time {
+  font-family: "Fira Code", monospace;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.event-name {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.qa-notes {
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  padding: 1.25rem;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.qa-notes h3 {
+  margin-bottom: 0.75rem;
+}
+
+.qa-notes ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: rgba(203, 213, 225, 0.85);
+  display: grid;
+  gap: 0.35rem;
+}
+
+@media (max-width: 960px) {
+  .onboarding-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .section-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 720px) {
+  .onboarding-hero {
+    padding: 2rem;
+  }
+
+  .onboarding-form {
+    padding: 1.5rem;
+  }
+}

--- a/src/app/web/templates/onboarding.html
+++ b/src/app/web/templates/onboarding.html
@@ -1,0 +1,361 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<section class="onboarding-hero glass-surface">
+  <div class="hero-copy">
+    <span class="badge">Alur 3 Langkah</span>
+    <h1>Onboarding pengguna baru Sensasiwangi.id</h1>
+    <p>
+      Validasi alur registrasi, verifikasi email, dan pengisian profil dalam satu layar.
+      Halaman ini membantu tim mengecek feedback langsung sebelum dirilis ke publik.
+    </p>
+  </div>
+  <div class="hero-progress">
+    <div class="progress-bar">
+      <div class="progress-fill" data-progress-fill></div>
+    </div>
+    <ol class="progress-steps">
+      {% for step in steps %}
+      <li class="progress-step" data-progress-step data-step-key="{{ step.key }}">
+        <span class="step-index">{{ loop.index }}</span>
+        <div>
+          <p class="step-title">{{ step.title }}</p>
+          <p class="step-description">{{ step.description }}</p>
+        </div>
+      </li>
+      {% endfor %}
+    </ol>
+  </div>
+</section>
+
+<section class="onboarding-layout">
+  <div class="onboarding-main glass-surface">
+    <header class="section-header">
+      <div>
+        <h2>Langkah-langkah</h2>
+        <p>Lakukan 3 langkah sederhana untuk menyelesaikan onboarding.</p>
+      </div>
+      <div class="status-chip" data-status-label>Belum mulai</div>
+    </header>
+
+    <div id="onboarding-feedback" class="feedback" role="alert" aria-live="polite"></div>
+
+    <div class="onboarding-forms">
+      <form id="registration-form" data-step="register" class="onboarding-form">
+        <fieldset>
+          <legend>1. Registrasi Pengguna</legend>
+          <label>
+            Nama Lengkap
+            <input type="text" name="full_name" minlength="3" maxlength="120" placeholder="Mis. Ayu Laras" required />
+          </label>
+          <label>
+            Email
+            <input type="email" name="email" placeholder="nama@contoh.com" required />
+          </label>
+          <label>
+            Password
+            <input type="password" name="password" minlength="8" maxlength="128" placeholder="Minimal 8 karakter" required />
+          </label>
+          <label class="checkbox">
+            <input type="checkbox" name="marketing_opt_in" value="true" />
+            Kirimkan update komunitas via email
+          </label>
+        </fieldset>
+        <button type="submit" class="btn gradient-button">Daftar &amp; Kirim Token</button>
+      </form>
+
+      <form id="verification-form" data-step="verify" class="onboarding-form" aria-disabled="true">
+        <fieldset>
+          <legend>2. Verifikasi Email</legend>
+          <p class="form-help">
+            Masukkan token verifikasi yang dikirim ke email Anda. Token berlaku selama <span id="verification-countdown">--</span>.
+          </p>
+          <label>
+            Token Verifikasi
+            <input type="text" name="token" minlength="4" maxlength="64" placeholder="Masukkan token" required disabled />
+          </label>
+        </fieldset>
+        <div class="form-actions">
+          <button type="submit" class="btn btn-outline" disabled>Verifikasi Email</button>
+          <button type="button" class="btn btn-ghost" data-resend disabled>Kirim Ulang Token</button>
+        </div>
+        <p class="debug-token" data-debug-token hidden></p>
+      </form>
+
+      <form id="profile-form" data-step="profile" class="onboarding-form" aria-disabled="true">
+        <fieldset>
+          <legend>3. Lengkapi Profil</legend>
+          <label>
+            Nama Brand / Tampilan
+            <input type="text" name="display_name" minlength="2" maxlength="80" placeholder="Mis. Studio Senja" required disabled />
+          </label>
+          <label>
+            Tujuan Bergabung
+            <input type="text" name="business_goal" minlength="3" maxlength="160" placeholder="Mis. skala produksi parfum" required disabled />
+          </label>
+          <label>
+            Pengalaman Meracik
+            <select name="experience_level" required disabled>
+              <option value="">Pilih pengalaman</option>
+              <option value="Pemula">Pemula</option>
+              <option value="Eksperimen Mandiri">Eksperimen Mandiri</option>
+              <option value="Profesional">Profesional</option>
+            </select>
+          </label>
+        </fieldset>
+        <button type="submit" class="btn gradient-button" disabled>Selesaikan Onboarding</button>
+      </form>
+    </div>
+  </div>
+
+  <aside class="onboarding-sidebar glass-surface">
+    <h2>Log Aktivitas</h2>
+    <p>Pantau setiap event yang terjadi selama onboarding. Data ini juga tersimpan oleh backend untuk audit.</p>
+    <ul id="onboarding-events" class="event-log"></ul>
+
+    <div class="qa-notes">
+      <h3>Checklist QA Mini</h3>
+      <ul>
+        <li>Token kedaluwarsa otomatis dalam 15 menit.</li>
+        <li>Batasi percobaan verifikasi maksimal 3 kali.</li>
+        <li>Profil baru hanya dapat dikirim setelah email tervalidasi.</li>
+      </ul>
+    </div>
+  </aside>
+</section>
+
+<script>
+  const state = {
+    onboardingId: null,
+    progress: null,
+    verificationToken: null,
+    countdownTimer: null,
+  };
+
+  const feedbackEl = document.getElementById("onboarding-feedback");
+  const progressFill = document.querySelector("[data-progress-fill]");
+  const statusLabel = document.querySelector("[data-status-label]");
+  const stepElements = document.querySelectorAll("[data-progress-step]");
+  const eventList = document.getElementById("onboarding-events");
+
+  const registrationForm = document.getElementById("registration-form");
+  const verificationForm = document.getElementById("verification-form");
+  const profileForm = document.getElementById("profile-form");
+  const resendButton = verificationForm.querySelector("[data-resend]");
+  const debugTokenEl = verificationForm.querySelector("[data-debug-token]");
+  const countdownEl = document.getElementById("verification-countdown");
+
+  function setFeedback(message, tone = "info") {
+    feedbackEl.textContent = message;
+    feedbackEl.dataset.tone = tone;
+    if (message) {
+      feedbackEl.classList.add("visible");
+    } else {
+      feedbackEl.classList.remove("visible");
+    }
+  }
+
+  function updateProgress(progress) {
+    state.progress = progress;
+    const ratio = progress.total_steps > 1 ? (progress.step_index - 1) / (progress.total_steps - 1) : 0;
+    const percent = Math.max(0, Math.min(ratio, 1)) * 100;
+    progressFill.style.width = `${percent}%`;
+    stepElements.forEach((element) => {
+      const index = Number(element.querySelector(".step-index").textContent);
+      element.classList.toggle("completed", index < progress.step_index);
+      element.classList.toggle("active", index === progress.step_index);
+    });
+    statusLabel.textContent =
+      progress.is_complete ? "Onboarding selesai" : `Langkah ${progress.step_index} dari ${progress.total_steps}`;
+  }
+
+  function enableForm(formEl, enabled) {
+    formEl.dataset.enabled = String(enabled);
+    formEl.setAttribute("aria-disabled", String(!enabled));
+    const controls = formEl.querySelectorAll("input, select, button");
+    controls.forEach((control) => {
+      control.disabled = !enabled;
+    });
+  }
+
+  function syncForms() {
+    const status = state.progress ? state.progress.status : "registered";
+    enableForm(verificationForm, Boolean(state.onboardingId) && status === "registered");
+    enableForm(profileForm, status === "email_verified");
+  }
+
+  function refreshCountdown(expiresAt) {
+    if (state.countdownTimer) {
+      clearInterval(state.countdownTimer);
+    }
+
+    if (!expiresAt) {
+      countdownEl.textContent = "--";
+      return;
+    }
+
+    const expiry = new Date(expiresAt);
+    function tick() {
+      const remaining = expiry - new Date();
+      if (remaining <= 0) {
+        clearInterval(state.countdownTimer);
+        countdownEl.textContent = "kedaluwarsa";
+        return;
+      }
+      const minutes = Math.floor(remaining / 60000);
+      const seconds = Math.floor((remaining % 60000) / 1000);
+      countdownEl.textContent = `${minutes}m ${seconds}s`;
+    }
+
+    tick();
+    state.countdownTimer = setInterval(tick, 1000);
+  }
+
+  function renderEvents(events) {
+    eventList.innerHTML = "";
+    events.forEach((event) => {
+      const item = document.createElement("li");
+      const time = new Date(event.timestamp).toLocaleTimeString("id-ID", {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      });
+      item.innerHTML = `<span class="event-time">${time}</span><span class="event-name">${event.event}</span>`;
+      eventList.appendChild(item);
+    });
+  }
+
+  async function fetchEvents() {
+    if (!state.onboardingId) return;
+    const response = await fetch(`/api/onboarding/events/${state.onboardingId}`);
+    if (!response.ok) return;
+    const data = await response.json();
+    renderEvents(data.events);
+  }
+
+  async function handleRegister(event) {
+    event.preventDefault();
+    const formData = new FormData(registrationForm);
+    const payload = Object.fromEntries(formData.entries());
+    payload.marketing_opt_in = Boolean(payload.marketing_opt_in);
+
+    setFeedback("Memproses registrasi...");
+    const response = await fetch("/api/onboarding/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      setFeedback(error.detail || "Registrasi gagal", "danger");
+      return;
+    }
+
+    const data = await response.json();
+    state.onboardingId = data.onboarding_id;
+    state.verificationToken = data.verification_token;
+    verificationForm.reset();
+    profileForm.reset();
+    updateProgress(data.progress);
+    syncForms();
+    refreshCountdown(data.verification_expires_at);
+    debugTokenEl.textContent = `Token verifikasi: ${state.verificationToken}`;
+    debugTokenEl.hidden = !state.verificationToken;
+    setFeedback("Registrasi berhasil. Token verifikasi telah dikirim.", "success");
+    await fetchEvents();
+  }
+
+  async function handleVerification(event) {
+    event.preventDefault();
+    if (!state.onboardingId) return;
+
+    const formData = new FormData(verificationForm);
+    const payload = { onboarding_id: state.onboardingId, token: formData.get("token") };
+
+    setFeedback("Memeriksa token...");
+    const response = await fetch("/api/onboarding/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      setFeedback(data.detail || "Token tidak valid", "danger");
+      await fetchEvents();
+      return;
+    }
+
+    updateProgress(data.progress);
+    syncForms();
+    refreshCountdown(data.progress.verification.expires_at);
+    verificationForm.reset();
+    setFeedback("Email berhasil diverifikasi.", "success");
+    await fetchEvents();
+  }
+
+  async function handleResend() {
+    if (!state.onboardingId) return;
+    setFeedback("Meminta token baru...");
+    const response = await fetch("/api/onboarding/resend", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ onboarding_id: state.onboardingId }),
+    });
+    if (!response.ok) {
+      setFeedback("Gagal memperbarui token", "danger");
+      return;
+    }
+    const data = await response.json();
+    state.verificationToken = data.verification_token;
+    updateProgress(data.progress);
+    refreshCountdown(data.verification_expires_at);
+    debugTokenEl.textContent = `Token verifikasi: ${state.verificationToken}`;
+    debugTokenEl.hidden = !state.verificationToken;
+    verificationForm.reset();
+    setFeedback("Token baru dikirim. Cek email Anda.", "success");
+    await fetchEvents();
+  }
+
+  async function handleProfile(event) {
+    event.preventDefault();
+    if (!state.onboardingId) return;
+
+    const formData = new FormData(profileForm);
+    const payload = {
+      onboarding_id: state.onboardingId,
+      display_name: formData.get("display_name"),
+      business_goal: formData.get("business_goal"),
+      experience_level: formData.get("experience_level"),
+    };
+
+    setFeedback("Menyimpan profil...");
+    const response = await fetch("/api/onboarding/profile", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      setFeedback(data.detail || "Profil tidak valid", "danger");
+      return;
+    }
+
+    updateProgress(data.progress);
+    syncForms();
+    setFeedback("Profil berhasil disimpan. Onboarding selesai!", "success");
+    profileForm.reset();
+    await fetchEvents();
+  }
+
+  registrationForm.addEventListener("submit", handleRegister);
+  verificationForm.addEventListener("submit", handleVerification);
+  profileForm.addEventListener("submit", handleProfile);
+  resendButton.addEventListener("click", handleResend);
+
+  updateProgress({ step_index: 1, total_steps: 3, is_complete: false, status: "registered", verification: { active: false, expires_at: null } });
+  syncForms();
+</script>
+{% endblock %}

--- a/src/app/web/templates/partials/navbar.html
+++ b/src/app/web/templates/partials/navbar.html
@@ -16,6 +16,11 @@
         Marketplace
       </a>
     </li>
+    <li>
+      <a href="{{ url_for('read_onboarding') }}" class="{% if request.url.path.startswith('/onboarding') %}active{% endif %}">
+        Onboarding
+      </a>
+    </li>
     <li><a href="{{ url_for('read_home') }}#sambatan">Sambatan</a></li>
     <li><a href="{{ url_for('read_home') }}#nusantarum">Nusantarum</a></li>
     <li><a href="{{ url_for('read_home') }}#dashboard">Dashboard</a></li>

--- a/tests/test_onboarding_api.py
+++ b/tests/test_onboarding_api.py
@@ -1,0 +1,84 @@
+import pytest
+from fastapi import HTTPException
+
+from app.api.routes.onboarding import (
+    RegistrationRequest,
+    VerificationRequest,
+    ProfileRequest,
+    ResendRequest,
+    register_user,
+    verify_email,
+    complete_profile,
+    get_event_log,
+    resend_token,
+)
+from app.services.onboarding import OnboardingService
+
+
+def test_onboarding_flow_handlers():
+    service = OnboardingService()
+
+    registration = register_user(
+        RegistrationRequest(
+            email="artisan@sensasiwangi.id",
+            full_name="Ayu Laras",
+            password="secret123",
+        ),
+        service=service,
+    )
+
+    assert registration.status.value == "registered"
+    assert registration.verification_token is not None
+
+    verification = verify_email(
+        VerificationRequest(onboarding_id=registration.onboarding_id, token=registration.verification_token or ""),
+        service=service,
+    )
+
+    assert verification.status.value == "email_verified"
+
+    profile = complete_profile(
+        ProfileRequest(
+            onboarding_id=registration.onboarding_id,
+            display_name="Studio Senja",
+            business_goal="Skala produksi parfum",
+            experience_level="Eksperimen Mandiri",
+        ),
+        service=service,
+    )
+
+    assert profile.progress["is_complete"] is True
+
+    events = get_event_log(registration.onboarding_id, service=service)
+    event_names = [event["event"] for event in events.events]
+    assert "registered" in event_names
+    assert "email_verified" in event_names
+    assert "profile_completed" in event_names
+
+    with pytest.raises(HTTPException) as excinfo:
+        resend_token(ResendRequest(onboarding_id=registration.onboarding_id), service=service)
+    assert excinfo.value.status_code == 400
+
+
+def test_verify_email_with_invalid_token():
+    service = OnboardingService()
+    registration = register_user(
+        RegistrationRequest(
+            email="artisan@sensasiwangi.id",
+            full_name="Ayu Laras",
+            password="secret123",
+        ),
+        service=service,
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        verify_email(
+            VerificationRequest(onboarding_id=registration.onboarding_id, token="SALAH"),
+            service=service,
+        )
+
+    assert excinfo.value.status_code == 400
+    assert "Token" in excinfo.value.detail
+
+    resend = resend_token(ResendRequest(onboarding_id=registration.onboarding_id), service=service)
+    assert resend.verification_token is not None

--- a/tests/test_onboarding_service.py
+++ b/tests/test_onboarding_service.py
@@ -1,0 +1,193 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.services.onboarding import (
+    OnboardingService,
+    OnboardingStatus,
+    RegistrationRateLimited,
+    VerificationTokenExpired,
+    VerificationAttemptsExceeded,
+    InvalidVerificationToken,
+    ProfileIncomplete,
+    OnboardingError,
+)
+
+
+def test_register_user_generates_token_and_logs():
+    service = OnboardingService()
+    now = datetime(2024, 4, 1, 9, 0, 0)
+
+    user = service.register_user(
+        email="artisan@sensasiwangi.id",
+        full_name="Ayu Laras",
+        password="secret123",
+        now=now,
+    )
+
+    assert user.status is OnboardingStatus.REGISTERED
+    assert user.verification_token is not None
+
+    progress = service.get_progress(user.id)
+    assert progress["step_index"] == 1
+    assert progress["verification"]["expires_at"] is not None
+
+    events = service.get_events(user.id)
+    assert [event.event for event in events][:2] == ["registered", "verification_token_issued"]
+
+
+def test_register_user_rate_limited():
+    service = OnboardingService()
+    now = datetime(2024, 4, 1, 9, 0, 0)
+
+    service.register_user(
+        email="artisan@sensasiwangi.id",
+        full_name="Ayu Laras",
+        password="secret123",
+        now=now,
+    )
+
+    with pytest.raises(RegistrationRateLimited):
+        service.register_user(
+            email="artisan@sensasiwangi.id",
+            full_name="Ayu Laras",
+            password="secret123",
+            now=now + timedelta(seconds=5),
+        )
+
+
+def test_verify_email_success_and_attempts_reset():
+    service = OnboardingService()
+    now = datetime(2024, 4, 1, 9, 0, 0)
+    user = service.register_user(
+        email="artisan@sensasiwangi.id",
+        full_name="Ayu Laras",
+        password="secret123",
+        now=now,
+    )
+
+    with pytest.raises(InvalidVerificationToken):
+        service.verify_email(
+            onboarding_id=user.id,
+            token="salah",
+            now=now + timedelta(minutes=1),
+        )
+
+    assert service.get_user(user.id).verification_attempts == 1
+
+    service.verify_email(
+        onboarding_id=user.id,
+        token=user.verification_token or "",
+        now=now + timedelta(minutes=2),
+    )
+
+    verified = service.get_user(user.id)
+    assert verified.status is OnboardingStatus.EMAIL_VERIFIED
+    assert verified.verification_token is None
+    assert verified.verification_attempts == 0
+
+
+def test_verify_email_expired_token():
+    service = OnboardingService()
+    now = datetime(2024, 4, 1, 9, 0, 0)
+    user = service.register_user(
+        email="artisan@sensasiwangi.id",
+        full_name="Ayu Laras",
+        password="secret123",
+        now=now,
+    )
+
+    with pytest.raises(VerificationTokenExpired):
+        service.verify_email(
+            onboarding_id=user.id,
+            token=user.verification_token or "",
+            now=now + service.TOKEN_TTL + timedelta(seconds=1),
+        )
+
+
+def test_complete_profile_requires_verification():
+    service = OnboardingService()
+    now = datetime(2024, 4, 1, 9, 0, 0)
+    user = service.register_user(
+        email="artisan@sensasiwangi.id",
+        full_name="Ayu Laras",
+        password="secret123",
+        now=now,
+    )
+
+    with pytest.raises(ProfileIncomplete):
+        service.complete_profile(
+            onboarding_id=user.id,
+            display_name="Studio Senja",
+            business_goal="Skala produksi parfum",
+            experience_level="Eksperimen Mandiri",
+            now=now,
+        )
+
+    service.verify_email(
+        onboarding_id=user.id,
+        token=user.verification_token or "",
+        now=now + timedelta(minutes=2),
+    )
+
+    service.complete_profile(
+        onboarding_id=user.id,
+        display_name="Studio Senja",
+        business_goal="Skala produksi parfum",
+        experience_level="Eksperimen Mandiri",
+        now=now + timedelta(minutes=5),
+    )
+
+    progress = service.get_progress(user.id)
+    assert progress["is_complete"] is True
+    assert progress["profile"]["display_name"] == "Studio Senja"
+
+
+def test_verification_attempt_limit():
+    service = OnboardingService()
+    now = datetime(2024, 4, 1, 9, 0, 0)
+    user = service.register_user(
+        email="artisan@sensasiwangi.id",
+        full_name="Ayu Laras",
+        password="secret123",
+        now=now,
+    )
+
+    for attempt in range(3):
+        with pytest.raises(InvalidVerificationToken):
+            service.verify_email(
+                onboarding_id=user.id,
+                token="tidak cocok",
+                now=now + timedelta(minutes=attempt + 1),
+            )
+
+    with pytest.raises(VerificationAttemptsExceeded):
+        service.verify_email(
+            onboarding_id=user.id,
+            token="tidak cocok",
+            now=now + timedelta(minutes=5),
+        )
+
+
+def test_resend_token_only_for_unverified():
+    service = OnboardingService()
+    now = datetime(2024, 4, 1, 9, 0, 0)
+    user = service.register_user(
+        email="artisan@sensasiwangi.id",
+        full_name="Ayu Laras",
+        password="secret123",
+        now=now,
+    )
+
+    original_token = user.verification_token
+    new_token = service.resend_verification_token(onboarding_id=user.id, now=now + timedelta(minutes=1))
+    assert new_token != original_token
+
+    service.verify_email(
+        onboarding_id=user.id,
+        token=new_token,
+        now=now + timedelta(minutes=2),
+    )
+
+    with pytest.raises(OnboardingError):
+        service.resend_verification_token(onboarding_id=user.id)


### PR DESCRIPTION
## Summary
- implement in-memory onboarding service with registration, verification, and profile completion states plus logging
- expose onboarding REST endpoints and server-rendered onboarding page with progress UI and supporting styles
- add API and service unit tests covering success cases, rate limiting, retry limits, and profile completion

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7a85961d08327aa7ce8169d5ae7ea