### PR TITLE
Add UI/UX implementation tracker page

### DIFF
--- a/docs/ui-ux-implementation-todo.md
+++ b/docs/ui-ux-implementation-todo.md
@@ -1,64 +1,106 @@
-# Daftar To-Do Implementasi UI/UX Sensasiwangi.id
+# Daftar To-Do Implementasi UI/UX Sensasiwangi.id (Versi Tanpa Figma)
 
-Dokumen ini merinci langkah implementasi UI/UX dari fondasi desain ke dalam antarmuka yang siap dikembangkan. Urutan tugas disusun berdasarkan prioritas delivery MVP.
+Dokumen ini memetakan pekerjaan UI/UX langsung ke artefak kode pada stack FastAPI + HTMX + Jinja2. Referensi visual utama menggunakan contoh mockup (glassmorphism futuristik) yang sudah diberikan, sehingga setiap tugas berfokus pada implementasi HTML/CSS/JS dan dokumentasi teknis tanpa perantara file desain.
 
-## 1. Setup Desain & Sistem Komponen
-- [ ] Siapkan file desain kolaboratif (Figma/penyunting setara) dengan gaya glassmorphism sesuai panduan foundation.
-- [ ] Definisikan style guide global: warna, tipografi (Playfair Display & Inter), ukuran heading, dan states warna teks.
-- [ ] Bangun library komponen dasar (button, card, input, badge, progress bar) lengkap dengan variasi state (default, hover, aktif, disabled).
-- [ ] Buat auto-layout/grid responsif untuk breakpoint desktop, tablet, dan mobile.
+Legenda status: ☐ belum mulai · ◐ in-progress · ✅ selesai.
+
+## 0. Panduan Visual & Prinsip Umum
+
+| Status | Task | Deskripsi Implementasi | Deliverable |
+| --- | --- | --- | --- |
+| ☐ | Kanvas inspirasi UI | Tangkap elemen kunci dari mockup (palet, tipografi serif+sans, bubble glass, refleksi) dan tuangkan ke dokumen panduan kode. Sertakan referensi ukuran dan behavior animasi dasar. | `docs/ui-style-reference.md` berisi moodboard singkat + token awal. |
+| ☐ | Susun token desain berbasis CSS | Definisikan CSS custom properties untuk warna, radius, blur, shadow, gradient dan timing animasi sesuai mockup. Token dideklarasikan di `:root` dan dipublikasikan melalui `static/css/tokens.css`. | File `src/app/web/static/css/tokens.css` berisi token komprehensif. |
+| ☐ | Setup tipografi & ikon | Implementasi font Playfair Display + Inter (atau alternatif open source mirip) via `@font-face`/Google Fonts, serta siapkan set ikon Feather/Phosphor yang akan dipakai. | Update `base.html` + `static/css/base.css` untuk import font & ikon. |
+
+## 1. Sistem Desain Berbasis Kode
+
+| Status | Task | Deskripsi Implementasi | Deliverable |
+| --- | --- | --- | --- |
+| ☐ | Utilitas glassmorphism | Buat kelas utilitas (mis. `.glass-card`, `.glass-panel`, `.blur-pill`) yang mengatur backdrop-filter, border, dan shadow sesuai inspirasi UI. | `static/css/glass.css` + dokumentasi pemakaian di `docs/ui-style-reference.md`. |
+| ☐ | Komponen tombol & chip | Rancang varian tombol utama/sekunder/ghost serta chip filter dengan state hover/active menggunakan CSS variables & HTMX states. | Partial `templates/components/button.html` + CSS di `static/css/components/button.css`. |
+| ☐ | Komponen kartu & badge status | Implementasikan kartu produk dengan preview gambar, badge sambatan, dan progress bar radial sesuai sample 3D. Sediakan versi horizontal dan grid. | `templates/components/product-card.html` + CSS & script animasi progress. |
+| ☐ | Layout responsif dasar | Definisikan grid dan spacing untuk breakpoint desktop/tablet/mobile menggunakan CSS Grid/Flex. Sertakan helper kelas `container-xl`, `stack-lg` dsb. | `static/css/layout.css` + README singkat pada file yang sama. |
 
 ## 2. Navigasi & Struktur Global
-- [ ] Rancang layout navbar sticky dengan versi desktop dan mobile (hamburger drawer).
-- [ ] Definisikan struktur footer lengkap (CTA newsletter, tautan legal, sosial, highlight komunitas).
-- [ ] Siapkan breadcrumb template untuk halaman dalam (Dashboard, Profil).
+
+| Status | Task | Deskripsi Implementasi | Deliverable |
+| --- | --- | --- | --- |
+| ☐ | Navbar sticky adaptif | Implementasikan navbar glass dengan menu utama, indikator halaman aktif, CTA login/signup, serta varian mobile (drawer). Gunakan HTMX untuk aksi open/close. | `templates/partials/navbar.html`, CSS di `static/css/components/navbar.css`, dan skrip `static/js/navbar.js`. |
+| ☐ | Footer komunitas | Bangun footer dengan CTA newsletter, link legal, sosial, dan highlight komunitas. Pastikan layout stack rapi di mobile. | `templates/partials/footer.html` + CSS pendukung. |
+| ☐ | Breadcrumb reusable | Buat component breadcrumb HTML dengan data-props Jinja (list tuple). Sediakan styling glass pill dan fallback mobile (horizontal scroll). | `templates/components/breadcrumb.html` + CSS. |
 
 ## 3. Halaman Prioritas MVP
+
 ### 3.1 Landing Page / Marketplace Overview
-- [ ] Desain hero section dengan headline, subcopy, CTA ganda, dan kartu statistik.
-- [ ] Implementasikan tab kategori, filter kaca, search bar, dan sort chip.
-- [ ] Buat grid produk responsif dengan states hover dan indikator sambatan (progress bar + deadline).
-- [ ] Rancang carousel highlight Nusantarum.
-- [ ] Bangun footer CTA komunitas + newsletter.
+
+| Status | Task | Deskripsi Implementasi | Deliverable |
+| --- | --- | --- | --- |
+| ☐ | Hero interaktif | Bangun hero dengan headline besar, subcopy, CTA ganda, slider produk unggulan dan latar bubble 3D (SVG atau Lottie). Sertakan animasi hover subtle. | `templates/pages/landing.html` (section hero) + asset di `static/media/hero`. |
+| ☐ | Tab kategori & filter | Implementasikan tab + filter kaca menggunakan HTMX untuk swap konten tanpa reload. Sediakan chip active/hover, search bar, dan sort toggle. | Partial `templates/components/category-tabs.html` + JS `static/js/tabs.js`. |
+| ☐ | Grid produk responsif | Layout grid dengan indikator sambatan (progress bar + deadline) dan varian card untuk desktop/tablet/mobile. Pastikan `aria` label lengkap. | Block pada landing.html + CSS di `components/product-grid.css`. |
+| ☐ | Carousel highlight Nusantarum | Implementasikan carousel horizontal dengan pill navigation dan auto-play opsional menggunakan Swiper.js atau implementasi custom. | Partial `templates/components/story-carousel.html` + JS `static/js/carousel.js`. |
+| ☐ | Footer CTA komunitas | Section CTA akhir dengan glass panel dan call-to-action bergaya mockup. | Section di landing.html + CSS section. |
 
 ### 3.2 Detail Produk
-- [ ] Siapkan galeri foto dengan thumbnail dan view utama.
-- [ ] Desain panel informasi produk (harga, stok, deskripsi aroma, CTA Sambatan/Pesanan).
-- [ ] Buat modul info brand dan tautan cerita Nusantarum.
-- [ ] Implementasikan panel sambatan (progress circle, slot tersisa, countdown, kontributor terbaru).
 
-### 3.3 Dashboard Internal (Tim Ops)
-- [ ] Susun layout dengan sidebar kaca dan konten utama.
-- [ ] Definisikan header ringkasan metrik (kartu KPI).
-- [ ] Buat tabel pesanan dengan filter status dan tombol ekspor.
-- [ ] Desain panel drawer detail pesanan yang muncul saat baris dipilih.
+| Status | Task | Deskripsi Implementasi | Deliverable |
+| --- | --- | --- | --- |
+| ☐ | Galeri foto produk | Implementasikan viewer utama + thumbnail scroll dengan efek parallax ringan. Dukungan keyboard navigation dan fallback non-JS. | Partial `templates/components/product-gallery.html` + JS `static/js/gallery.js`. |
+| ☐ | Panel informasi produk | Panel kanan berisi harga, stok, deskripsi aroma, CTA Sambatan/Pesanan dengan badge status. Pastikan sticky di desktop. | `templates/pages/product_detail.html` section info + CSS. |
+| ☐ | Modul info brand | Kartu brand kaca dengan logo, sertifikasi, link Nusantarum, CTA follow. | Partial `templates/components/brand-module.html`. |
+| ☐ | Panel sambatan | Komponen progress radial, slot tersisa, countdown realtime (menggunakan Stimulus/HTMX). Varian state aktif/penuh/tutup. | JS `static/js/sambatan-panel.js` + partial HTML & CSS. |
+
+### 3.3 Dashboard Internal (Ops)
+
+| Status | Task | Deskripsi Implementasi | Deliverable |
+| --- | --- | --- | --- |
+| ☐ | Layout dashboard | Sidebar kaca, topbar, dan konten utama responsif. Gunakan CSS Grid dua kolom + collapse mobile. | `templates/pages/dashboard/index.html` + CSS `static/css/dashboard.css`. |
+| ☐ | Header metrik | Kartu KPI dengan gradient glow, icon, delta up/down. Animated counters optional. | Partial `templates/components/kpi-card.html` + JS kecil untuk animasi angka. |
+| ☐ | Tabel pesanan | Tabel dengan filter status (tabs), tombol ekspor, empty state ilustrasi. Responsif via CSS `display: block` di mobile. | Partial `templates/components/order-table.html` + CSS/JS filter. |
+| ☐ | Drawer detail pesanan | Drawer kanan yang muncul saat klik baris, menampilkan detail & log. Implementasi HTMX swap + overlay backdrop. | Template `templates/components/order-drawer.html` + JS `static/js/drawer.js`. |
 
 ### 3.4 Nusantarum Hub
-- [ ] Desain hero kaca dengan headline kuratorial.
-- [ ] Buat panel filter (kategori aroma, wilayah, kurator) untuk desktop & mobile.
-- [ ] Rancang kartu cerita Nusantarum termasuk tag brand/perfumer.
-- [ ] Siapkan CTA "Ajukan cerita" dengan state hover.
+
+| Status | Task | Deskripsi Implementasi | Deliverable |
+| --- | --- | --- | --- |
+| ☐ | Hero kuratorial | Hero kaca dengan headline, subcopy, CTA, background partikel (canvas/SVG). | Section `templates/pages/nusantarum.html` + asset. |
+| ☐ | Panel filter multiplatform | Panel filter desktop + bottom sheet mobile (dialog). Gunakan CSS `position: sticky` dan HTMX update results. | `templates/components/nusantarum-filter.html` + JS `static/js/filter-sheet.js`. |
+| ☐ | Kartu cerita | Kartu cerita dengan foto, tag brand/perfumer, CTA. Pastikan variant grid/list. | Partial `templates/components/story-card.html`. |
+| ☐ | CTA ajukan cerita | Form CTA dengan state hover, disabled, dan note integrasi backend. | Section + CSS. |
 
 ### 3.5 Profil Pengguna
-- [ ] Bangun header profil (avatar kaca, nama, preferensi aroma chip).
-- [ ] Implementasikan tab Aktivitas, Favorit, Sambatan Saya.
-- [ ] Desain timeline aktivitas dengan kartu kaca.
-- [ ] Buat grid favorit dan daftar sambatan dengan indikator status.
+
+| Status | Task | Deskripsi Implementasi | Deliverable |
+| --- | --- | --- | --- |
+| ☐ | Header profil | Header kaca dengan avatar, nama, preferensi aroma chip, dan tombol edit. | Section `templates/pages/profile.html` + CSS. |
+| ☐ | Tab aktivitas/favorit/sambatan | Tab berbasis HTMX untuk switch konten tanpa reload, dengan animasi underline. | `templates/components/profile-tabs.html` + JS `static/js/profile-tabs.js`. |
+| ☐ | Timeline aktivitas | Komponen timeline card dengan icon status, timestamp, deskripsi. | Partial `templates/components/activity-card.html`. |
+| ☐ | Grid favorit & daftar sambatan | Layout grid/list dengan status indicator & CTA lanjutkan. | Blocks di profile.html + CSS. |
 
 ## 4. Interaksi & Animasi
-- [ ] Definisikan animasi hover umum (translateY -2px, glow border) dan timing function.
-- [ ] Rancang transisi antar halaman (mis. fade-in + blur subtle) untuk menjaga kesan premium.
-- [ ] Siapkan guideline microinteraction untuk tombol, progress bar, dan badge sambatan.
 
-## 5. Aset & Dokumentasi Developer Handoff
-- [ ] Export ikon Feather dengan gaya garis tipis + efek neon bila diperlukan.
-- [ ] Siapkan placeholder foto produk/brand dengan kontainer kaca dan drop shadow.
-- [ ] Dokumentasikan spesifikasi spacing, padding, dan shadow di setiap komponen.
-- [ ] Susun checklist QA visual sebelum handoff (kontras, keterbacaan, konsistensi grid).
+| Status | Task | Deskripsi Implementasi | Deliverable |
+| --- | --- | --- | --- |
+| ☐ | Token animasi global | Definisikan utilitas animasi (hover lift, fade-blur, glow pulse) dalam `static/css/animation.css` dan contoh di dokumentasi. | File animasi + update doc gaya. |
+| ☐ | Transisi antar halaman | Implementasi transisi halus menggunakan HTMX `hx-boost` + CSS `view-transition` (jika didukung) atau fallback fade. | Skrip `static/js/page-transitions.js` + konfigurasi di base template. |
+| ☐ | Microinteraction komponen | Tambahkan feedback state untuk tombol, progress bar, badge sambatan (pulse countdown). Deskripsikan perilaku di dokumentasi. | Update CSS/JS terkait + section dokumentasi. |
+
+## 5. Aset & Dokumentasi Handoff Developer
+
+| Status | Task | Deskripsi Implementasi | Deliverable |
+| --- | --- | --- | --- |
+| ☐ | Paket ikon & ilustrasi | Kumpulkan ikon SVG dan ilustrasi latar bubble sesuai gaya. Optimasi via SVGO. | Direktori `static/icons/` & `static/illustrations/` + README listing. |
+| ☐ | Placeholder produk & brand | Sediakan placeholder gambar dengan efek kaca (PNG/WebP) untuk fallback. | Folder `static/media/placeholders/`. |
+| ☐ | Dokumentasi spacing & shadow | Tuliskan guideline di `docs/ui-style-reference.md` terkait jarak, layering, depth. | Update dokumen referensi. |
+| ☐ | Checklist QA visual | Buat checklist HTML/Markdown untuk review kontras, responsive, accesibility (keyboard, aria). | `docs/ui-qa-checklist.md`. |
 
 ## 6. Integrasi & Validasi
-- [ ] Kolaborasikan dengan tim frontend untuk mapping komponen desain ke stack teknologi.
-- [ ] Buat prototipe interaktif utama (landing, detail produk, dashboard) untuk validasi flow.
-- [ ] Lakukan usability testing ringan (5-7 pengguna internal) dan catat temuan prioritas.
-- [ ] Revisi desain berdasarkan feedback dan siapkan versi final untuk development sprint.
 
+| Status | Task | Deskripsi Implementasi | Deliverable |
+| --- | --- | --- | --- |
+| ☐ | Mapping komponen ke backend | Dokumentasikan bagaimana tiap komponen template menerima data (context dict). Sertakan contoh payload. | `docs/ui-component-contracts.md`. |
+| ☐ | Prototipe interaktif via Storybook/Pattern Library | Setup Storybook (atau alternatif minimal `docs/site` dengan `npm run dev`) untuk preview komponen glass secara isolasi. | Konfigurasi Storybook di `story/` + panduan run. |
+| ☐ | Usability testing ringan | Jalankan tes internal (5-7 orang) menggunakan build SSR aktual, catat temuan. | Laporan `docs/research/usability-round1.md`. |
+| ☐ | Revisi & finalisasi | Terapkan feedback, tandai komponen siap produksi, update changelog. | Update doc + commit changelog di `docs/ui-style-reference.md`. |
+
+> Catatan: seluruh deliverable harus versioned di repo ini. Gunakan screenshot dari implementasi aktual (bukan Figma) untuk dokumentasi visual.

--- a/src/app/api/routes/root.py
+++ b/src/app/api/routes/root.py
@@ -8,6 +8,437 @@ from app.core.config import get_settings
 router = APIRouter()
 
 
+STATUS_META = {
+    "todo": {"icon": "☐", "label": "Belum mulai"},
+    "progress": {"icon": "◐", "label": "Sedang berjalan"},
+    "done": {"icon": "✅", "label": "Selesai"},
+}
+
+
+UIUX_IMPLEMENTATION_PLAN = [
+    {
+        "section": "0. Panduan Visual & Prinsip Umum",
+        "slug": "panduan-visual",
+        "tasks": [
+            {
+                "status": "todo",
+                "title": "Kanvas inspirasi UI",
+                "description": (
+                    "Tangkap elemen kunci dari mockup (palet, tipografi serif+sans, bubble glass, "
+                    "refleksi) dan tuangkan ke dokumen panduan kode. Sertakan referensi ukuran dan "
+                    "behavior animasi dasar."
+                ),
+                "deliverable": "docs/ui-style-reference.md",
+            },
+            {
+                "status": "todo",
+                "title": "Susun token desain berbasis CSS",
+                "description": (
+                    "Definisikan CSS custom properties untuk warna, radius, blur, shadow, gradient dan "
+                    "timing animasi sesuai mockup. Token dideklarasikan di :root dan dipublikasikan "
+                    "melalui static/css/tokens.css."
+                ),
+                "deliverable": "src/app/web/static/css/tokens.css",
+            },
+            {
+                "status": "todo",
+                "title": "Setup tipografi & ikon",
+                "description": (
+                    "Implementasi font Playfair Display + Inter (atau alternatif open source mirip) via "
+                    "@font-face/Google Fonts, serta siapkan set ikon Feather/Phosphor yang akan dipakai."
+                ),
+                "deliverable": "Perbarui base.html & static/css/base.css",
+            },
+        ],
+    },
+    {
+        "section": "1. Sistem Desain Berbasis Kode",
+        "slug": "sistem-desain",
+        "tasks": [
+            {
+                "status": "todo",
+                "title": "Utilitas glassmorphism",
+                "description": (
+                    "Buat kelas utilitas (mis. .glass-card, .glass-panel, .blur-pill) yang mengatur "
+                    "backdrop-filter, border, dan shadow sesuai inspirasi UI."
+                ),
+                "deliverable": "static/css/glass.css + dokumentasi di docs/ui-style-reference.md",
+            },
+            {
+                "status": "todo",
+                "title": "Komponen tombol & chip",
+                "description": (
+                    "Rancang varian tombol utama/sekunder/ghost serta chip filter dengan state hover/active "
+                    "menggunakan CSS variables & HTMX states."
+                ),
+                "deliverable": "templates/components/button.html + static/css/components/button.css",
+            },
+            {
+                "status": "todo",
+                "title": "Komponen kartu & badge status",
+                "description": (
+                    "Implementasikan kartu produk dengan preview gambar, badge sambatan, dan progress bar radial "
+                    "sesuai sample 3D. Sediakan versi horizontal dan grid."
+                ),
+                "deliverable": "templates/components/product-card.html + aset animasi progress",
+            },
+            {
+                "status": "todo",
+                "title": "Layout responsif dasar",
+                "description": (
+                    "Definisikan grid dan spacing untuk breakpoint desktop/tablet/mobile menggunakan CSS Grid/Flex. "
+                    "Sertakan helper kelas container-xl, stack-lg dsb."
+                ),
+                "deliverable": "static/css/layout.css + catatan README",
+            },
+        ],
+    },
+    {
+        "section": "2. Navigasi & Struktur Global",
+        "slug": "navigasi",
+        "tasks": [
+            {
+                "status": "todo",
+                "title": "Navbar sticky adaptif",
+                "description": (
+                    "Implementasikan navbar glass dengan menu utama, indikator halaman aktif, CTA login/signup, serta "
+                    "varian mobile (drawer). Gunakan HTMX untuk aksi open/close."
+                ),
+                "deliverable": "templates/partials/navbar.html + static/css/components/navbar.css + static/js/navbar.js",
+            },
+            {
+                "status": "todo",
+                "title": "Footer komunitas",
+                "description": (
+                    "Bangun footer dengan CTA newsletter, link legal, sosial, dan highlight komunitas. Pastikan layout "
+                    "stack rapi di mobile."
+                ),
+                "deliverable": "templates/partials/footer.html + CSS pendukung",
+            },
+            {
+                "status": "todo",
+                "title": "Breadcrumb reusable",
+                "description": (
+                    "Buat component breadcrumb HTML dengan data-props Jinja (list tuple). Sediakan styling glass pill dan "
+                    "fallback mobile (horizontal scroll)."
+                ),
+                "deliverable": "templates/components/breadcrumb.html + CSS",
+            },
+        ],
+    },
+    {
+        "section": "3. Halaman Prioritas MVP",
+        "slug": "halaman-prioritas",
+        "groups": [
+            {
+                "title": "3.1 Landing Page / Marketplace Overview",
+                "tasks": [
+                    {
+                        "status": "todo",
+                        "title": "Hero interaktif",
+                        "description": (
+                            "Bangun hero dengan headline besar, subcopy, CTA ganda, slider produk unggulan dan latar bubble 3D (SVG "
+                            "atau Lottie). Sertakan animasi hover subtle."
+                        ),
+                        "deliverable": "templates/pages/landing.html section hero + asset di static/media/hero",
+                    },
+                    {
+                        "status": "todo",
+                        "title": "Tab kategori & filter",
+                        "description": (
+                            "Implementasikan tab + filter kaca menggunakan HTMX untuk swap konten tanpa reload. Sediakan chip "
+                            "active/hover, search bar, dan sort toggle."
+                        ),
+                        "deliverable": "templates/components/category-tabs.html + static/js/tabs.js",
+                    },
+                    {
+                        "status": "todo",
+                        "title": "Grid produk responsif",
+                        "description": (
+                            "Layout grid dengan indikator sambatan (progress bar + deadline) dan varian card untuk desktop/tablet/"
+                            "mobile. Pastikan aria label lengkap."
+                        ),
+                        "deliverable": "Blok di landing.html + static/css/components/product-grid.css",
+                    },
+                    {
+                        "status": "todo",
+                        "title": "Carousel highlight Nusantarum",
+                        "description": (
+                            "Implementasikan carousel horizontal dengan pill navigation dan auto-play opsional menggunakan Swiper.js "
+                            "atau implementasi custom."
+                        ),
+                        "deliverable": "templates/components/story-carousel.html + static/js/carousel.js",
+                    },
+                    {
+                        "status": "todo",
+                        "title": "Footer CTA komunitas",
+                        "description": (
+                            "Section CTA akhir dengan glass panel dan call-to-action bergaya mockup."
+                        ),
+                        "deliverable": "Section di landing.html + styling khusus",
+                    },
+                ],
+            },
+            {
+                "title": "3.2 Detail Produk",
+                "tasks": [
+                    {
+                        "status": "todo",
+                        "title": "Galeri foto produk",
+                        "description": (
+                            "Implementasikan viewer utama + thumbnail scroll dengan efek parallax ringan. Dukungan keyboard navigation "
+                            "dan fallback non-JS."
+                        ),
+                        "deliverable": "templates/components/product-gallery.html + static/js/gallery.js",
+                    },
+                    {
+                        "status": "todo",
+                        "title": "Panel informasi produk",
+                        "description": (
+                            "Panel kanan berisi harga, stok, deskripsi aroma, CTA Sambatan/Pesanan dengan badge status. Pastikan sticky di desktop."
+                        ),
+                        "deliverable": "templates/pages/product_detail.html section info + CSS",
+                    },
+                    {
+                        "status": "todo",
+                        "title": "Modul info brand",
+                        "description": (
+                            "Kartu brand kaca dengan logo, sertifikasi, link Nusantarum, CTA follow."
+                        ),
+                        "deliverable": "templates/components/brand-module.html",
+                    },
+                    {
+                        "status": "todo",
+                        "title": "Panel sambatan",
+                        "description": (
+                            "Komponen progress radial, slot tersisa, countdown realtime (menggunakan Stimulus/HTMX). Varian state aktif/penuh/tutup."
+                        ),
+                        "deliverable": "static/js/sambatan-panel.js + partial HTML & CSS",
+                    },
+                ],
+            },
+            {
+                "title": "3.3 Dashboard Internal (Ops)",
+                "tasks": [
+                    {
+                        "status": "todo",
+                        "title": "Layout dashboard",
+                        "description": (
+                            "Sidebar kaca, topbar, dan konten utama responsif. Gunakan CSS Grid dua kolom + collapse mobile."
+                        ),
+                        "deliverable": "templates/pages/dashboard/index.html + static/css/dashboard.css",
+                    },
+                    {
+                        "status": "todo",
+                        "title": "Header metrik",
+                        "description": (
+                            "Kartu KPI dengan gradient glow, icon, delta up/down. Animated counters optional."
+                        ),
+                        "deliverable": "templates/components/kpi-card.html + animasi angka",
+                    },
+                    {
+                        "status": "todo",
+                        "title": "Tabel pesanan",
+                        "description": (
+                            "Tabel dengan filter status (tabs), tombol ekspor, empty state ilustrasi. Responsif via CSS display: block di mobile."
+                        ),
+                        "deliverable": "templates/components/order-table.html + CSS/JS filter",
+                    },
+                    {
+                        "status": "todo",
+                        "title": "Drawer detail pesanan",
+                        "description": (
+                            "Drawer kanan yang muncul saat klik baris, menampilkan detail & log. Implementasi HTMX swap + overlay backdrop."
+                        ),
+                        "deliverable": "templates/components/order-drawer.html + static/js/drawer.js",
+                    },
+                ],
+            },
+            {
+                "title": "3.4 Nusantarum Hub",
+                "tasks": [
+                    {
+                        "status": "todo",
+                        "title": "Hero kuratorial",
+                        "description": (
+                            "Hero kaca dengan headline, subcopy, CTA, background partikel (canvas/SVG)."
+                        ),
+                        "deliverable": "templates/pages/nusantarum.html section hero + asset",
+                    },
+                    {
+                        "status": "todo",
+                        "title": "Panel filter multiplatform",
+                        "description": (
+                            "Panel filter desktop + bottom sheet mobile (dialog). Gunakan CSS position: sticky dan HTMX update results."
+                        ),
+                        "deliverable": "templates/components/nusantarum-filter.html + static/js/filter-sheet.js",
+                    },
+                    {
+                        "status": "todo",
+                        "title": "Kartu cerita",
+                        "description": (
+                            "Kartu cerita dengan foto, tag brand/perfumer, CTA. Pastikan variant grid/list."
+                        ),
+                        "deliverable": "templates/components/story-card.html",
+                    },
+                    {
+                        "status": "todo",
+                        "title": "CTA ajukan cerita",
+                        "description": (
+                            "Form CTA dengan state hover, disabled, dan note integrasi backend."
+                        ),
+                        "deliverable": "Section + CSS di nusantarum.html",
+                    },
+                ],
+            },
+            {
+                "title": "3.5 Profil Pengguna",
+                "tasks": [
+                    {
+                        "status": "todo",
+                        "title": "Header profil",
+                        "description": (
+                            "Header kaca dengan avatar, nama, preferensi aroma chip, dan tombol edit."
+                        ),
+                        "deliverable": "templates/pages/profile.html section header + CSS",
+                    },
+                    {
+                        "status": "todo",
+                        "title": "Tab aktivitas/favorit/sambatan",
+                        "description": (
+                            "Tab berbasis HTMX untuk switch konten tanpa reload, dengan animasi underline."
+                        ),
+                        "deliverable": "templates/components/profile-tabs.html + static/js/profile-tabs.js",
+                    },
+                    {
+                        "status": "todo",
+                        "title": "Timeline aktivitas",
+                        "description": (
+                            "Komponen timeline card dengan icon status, timestamp, deskripsi."
+                        ),
+                        "deliverable": "templates/components/activity-card.html",
+                    },
+                    {
+                        "status": "todo",
+                        "title": "Grid favorit & daftar sambatan",
+                        "description": (
+                            "Layout grid/list dengan status indicator & CTA lanjutkan."
+                        ),
+                        "deliverable": "Blok di profile.html + CSS",
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        "section": "4. Interaksi & Animasi",
+        "slug": "interaksi",
+        "tasks": [
+            {
+                "status": "todo",
+                "title": "Token animasi global",
+                "description": (
+                    "Definisikan utilitas animasi (hover lift, fade-blur, glow pulse) dalam static/css/animation.css dan contoh di dokumentasi."
+                ),
+                "deliverable": "static/css/animation.css + update docs/ui-style-reference.md",
+            },
+            {
+                "status": "todo",
+                "title": "Transisi antar halaman",
+                "description": (
+                    "Implementasi transisi halus menggunakan HTMX hx-boost + CSS view-transition (jika didukung) atau fallback fade."
+                ),
+                "deliverable": "static/js/page-transitions.js + konfigurasi di base template",
+            },
+            {
+                "status": "todo",
+                "title": "Microinteraction komponen",
+                "description": (
+                    "Tambahkan feedback state untuk tombol, progress bar, badge sambatan (pulse countdown). Deskripsikan perilaku di dokumentasi."
+                ),
+                "deliverable": "Update CSS/JS terkait + dokumentasi",
+            },
+        ],
+    },
+    {
+        "section": "5. Aset & Dokumentasi Handoff Developer",
+        "slug": "aset-dokumentasi",
+        "tasks": [
+            {
+                "status": "todo",
+                "title": "Paket ikon & ilustrasi",
+                "description": (
+                    "Kumpulkan ikon SVG dan ilustrasi latar bubble sesuai gaya. Optimasi via SVGO."
+                ),
+                "deliverable": "Direktori static/icons/ & static/illustrations/ + README listing",
+            },
+            {
+                "status": "todo",
+                "title": "Placeholder produk & brand",
+                "description": (
+                    "Sediakan placeholder gambar dengan efek kaca (PNG/WebP) untuk fallback."
+                ),
+                "deliverable": "Folder static/media/placeholders/",
+            },
+            {
+                "status": "todo",
+                "title": "Dokumentasi spacing & shadow",
+                "description": (
+                    "Tuliskan guideline di docs/ui-style-reference.md terkait jarak, layering, depth."
+                ),
+                "deliverable": "Update docs/ui-style-reference.md",
+            },
+            {
+                "status": "todo",
+                "title": "Checklist QA visual",
+                "description": (
+                    "Buat checklist HTML/Markdown untuk review kontras, responsive, accesibility (keyboard, aria)."
+                ),
+                "deliverable": "docs/ui-qa-checklist.md",
+            },
+        ],
+    },
+    {
+        "section": "6. Integrasi & Validasi",
+        "slug": "integrasi",
+        "tasks": [
+            {
+                "status": "todo",
+                "title": "Mapping komponen ke backend",
+                "description": (
+                    "Dokumentasikan bagaimana tiap komponen template menerima data (context dict). Sertakan contoh payload."
+                ),
+                "deliverable": "docs/ui-component-contracts.md",
+            },
+            {
+                "status": "todo",
+                "title": "Prototipe interaktif via Storybook/Pattern Library",
+                "description": (
+                    "Setup Storybook (atau alternatif minimal docs/site dengan npm run dev) untuk preview komponen glass secara isolasi."
+                ),
+                "deliverable": "Konfigurasi Storybook di story/ + panduan run",
+            },
+            {
+                "status": "todo",
+                "title": "Usability testing ringan",
+                "description": (
+                    "Jalankan tes internal (5-7 orang) menggunakan build SSR aktual, catat temuan."
+                ),
+                "deliverable": "docs/research/usability-round1.md",
+            },
+            {
+                "status": "todo",
+                "title": "Revisi & finalisasi",
+                "description": (
+                    "Terapkan feedback, tandai komponen siap produksi, update changelog."
+                ),
+                "deliverable": "Update docs/ui-style-reference.md",
+            },
+        ],
+    },
+]
+
+
 @router.get("/", response_class=HTMLResponse)
 async def read_home(request: Request) -> HTMLResponse:
     """Render the marketplace landing page placeholder."""
@@ -199,3 +630,21 @@ async def read_onboarding(request: Request) -> HTMLResponse:
         "steps": steps,
     }
     return templates.TemplateResponse("onboarding.html", context)
+
+
+@router.get("/ui-ux/implementation", response_class=HTMLResponse)
+async def read_uiux_tracker(request: Request) -> HTMLResponse:
+    """Render a glassmorphism-flavored tracker of the UI/UX implementation to-do list."""
+
+    settings = get_settings()
+    templates = request.app.state.templates
+
+    context = {
+        "request": request,
+        "app_name": settings.app_name,
+        "environment": settings.environment,
+        "title": "UI/UX Implementation Tracker",
+        "status_meta": STATUS_META,
+        "sections": UIUX_IMPLEMENTATION_PLAN,
+    }
+    return templates.TemplateResponse("ui_ux_tracker.html", context)

--- a/src/app/web/static/css/ui-ux-tracker.css
+++ b/src/app/web/static/css/ui-ux-tracker.css
@@ -1,0 +1,283 @@
+.top-anchor {
+  position: relative;
+  top: -120px;
+}
+
+.tracker-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  padding: 2.5rem;
+  align-items: start;
+}
+
+.tracker-hero .badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 1rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.tracker-hero h1 {
+  margin-top: 1.2rem;
+  margin-bottom: 1rem;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+}
+
+.tracker-hero p {
+  margin: 0.75rem 0;
+  max-width: 36ch;
+}
+
+.tracker-hero .hero-subcopy {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.status-legend {
+  padding: 1.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.status-legend h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.status-legend ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.status-legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-weight: 500;
+}
+
+.status-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 0.75rem;
+  background: rgba(148, 163, 184, 0.12);
+  font-size: 1rem;
+}
+
+.status-todo {
+  color: var(--muted);
+}
+
+.status-progress {
+  color: var(--accent-secondary);
+}
+
+.status-done {
+  color: var(--success);
+}
+
+.section-nav {
+  display: grid;
+  gap: 1rem;
+  padding: 1.8rem 2rem;
+}
+
+.section-nav h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.section-nav ol {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.section-nav a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  position: relative;
+}
+
+.section-nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.2rem;
+  width: 100%;
+  height: 2px;
+  background: var(--accent-primary);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--transition-base);
+}
+
+.section-nav a:hover::after,
+.section-nav a:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.tracker-section {
+  padding: 2.25rem 2.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.section-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.section-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.section-header h2 {
+  margin: 0.25rem 0 0;
+  font-size: clamp(1.5rem, 3vw, 2.1rem);
+}
+
+.section-top-link {
+  text-decoration: none;
+  color: var(--text-secondary);
+  font-size: 1.4rem;
+  transition: color var(--transition-base), transform var(--transition-base);
+}
+
+.section-top-link:hover,
+.section-top-link:focus-visible {
+  color: var(--accent-secondary);
+  transform: translateY(-2px);
+}
+
+.task-grid {
+  display: grid;
+  gap: 1.4rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.task-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.6rem;
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 20px 45px rgba(8, 15, 29, 0.35);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.task-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 28px 60px rgba(8, 15, 29, 0.4);
+}
+
+.task-card header {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.task-card h3,
+.task-card h4 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.task-card p {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.task-card footer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-top: auto;
+  font-size: 0.9rem;
+}
+
+.task-card .label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.task-card .deliverable {
+  word-break: break-word;
+  color: var(--text-primary);
+}
+
+.task-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.6rem 1.8rem;
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.task-group h3 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.grouped-section {
+  display: grid;
+  gap: 1.6rem;
+}
+
+.tracker-note {
+  padding: 2rem 2.3rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.tracker-note h2 {
+  margin: 0;
+}
+
+@media (max-width: 720px) {
+  .tracker-hero {
+    padding: 2rem;
+  }
+
+  .section-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .section-top-link {
+    align-self: flex-end;
+  }
+
+  .task-group {
+    padding: 1.4rem;
+  }
+}

--- a/src/app/web/templates/base.html
+++ b/src/app/web/templates/base.html
@@ -10,9 +10,10 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="https://unpkg.com/modern-css-reset/dist/reset.min.css" />
-    <link rel="stylesheet" href="{{ url_for('static', path='css/base.css') }}" />
-    <script src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-9gCsk+S4iigFsMghvYDn8ApX2HFqRSbuuSSMzdg3NofM8JrIoYNewc19hXtF87dj" crossorigin="anonymous"></script>
+      <link rel="stylesheet" href="https://unpkg.com/modern-css-reset/dist/reset.min.css" />
+      <link rel="stylesheet" href="{{ url_for('static', path='css/base.css') }}" />
+      {% block head_extra %}{% endblock %}
+      <script src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-9gCsk+S4iigFsMghvYDn8ApX2HFqRSbuuSSMzdg3NofM8JrIoYNewc19hXtF87dj" crossorigin="anonymous"></script>
   </head>
   <body>
     <div class="background-aurora"></div>

--- a/src/app/web/templates/partials/navbar.html
+++ b/src/app/web/templates/partials/navbar.html
@@ -21,6 +21,14 @@
         Onboarding
       </a>
     </li>
+    <li>
+      <a
+        href="{{ url_for('read_uiux_tracker') }}"
+        class="{% if request.url.path.startswith('/ui-ux') %}active{% endif %}"
+      >
+        UI/UX Tracker
+      </a>
+    </li>
     <li><a href="{{ url_for('read_home') }}#sambatan">Sambatan</a></li>
     <li><a href="{{ url_for('read_home') }}#nusantarum">Nusantarum</a></li>
     <li><a href="{{ url_for('read_home') }}#dashboard">Dashboard</a></li>

--- a/src/app/web/templates/ui_ux_tracker.html
+++ b/src/app/web/templates/ui_ux_tracker.html
@@ -1,0 +1,104 @@
+{% extends 'base.html' %}
+
+{% block head_extra %}
+      <link rel="stylesheet" href="{{ url_for('static', path='css/ui-ux-tracker.css') }}" />
+{% endblock %}
+
+{% block content %}
+<div id="top" class="top-anchor" aria-hidden="true"></div>
+<section class="tracker-hero glass-surface">
+  <div class="hero-copy">
+    <span class="badge">Implementasi UI/UX</span>
+    <h1>Blueprint implementasi Sensasiwangi.id tanpa bergantung pada Figma.</h1>
+    <p>
+      Halaman ini memvisualisasikan backlog <strong>docs/ui-ux-implementation-todo.md</strong> dalam bentuk tracker interaktif.
+      Setiap bagian memetakan pekerjaan desain langsung ke artefak HTML, CSS, dan HTMX yang akan dibangun pada MVP.
+    </p>
+    <p class="hero-subcopy">
+      Gunakan anchor pada sidebar mini untuk melompat ke domain kerja tertentu dan pantau progresnya secara berkala bersama tim
+      front-end serta produk.
+    </p>
+  </div>
+  <div class="status-legend glass-card">
+    <h2>Legenda Status</h2>
+    <ul>
+      {% for key, info in status_meta.items() %}
+      <li>
+        <span class="status-icon status-{{ key }}">{{ info.icon }}</span>
+        <span class="status-label">{{ info.label }}</span>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+</section>
+
+<nav class="section-nav glass-card" aria-label="Navigasi bagian">
+  <h2>Peta Bagian</h2>
+  <ol>
+    {% for section in sections %}
+    <li><a href="#{{ section.slug }}">{{ section.section }}</a></li>
+    {% endfor %}
+  </ol>
+</nav>
+
+{% for section in sections %}
+<section id="{{ section.slug }}" class="tracker-section glass-card">
+  <header class="section-header">
+    <div>
+      <p class="section-eyebrow">Domain kerja</p>
+      <h2>{{ section.section }}</h2>
+    </div>
+    <a class="section-top-link" href="#top" aria-label="Kembali ke atas">↑</a>
+  </header>
+
+  {% if section.tasks %}
+  <div class="task-grid">
+    {% for task in section.tasks %}
+    <article class="task-card" data-status="{{ task.status }}">
+      <header>
+        <span class="status-icon status-{{ task.status }}">{{ status_meta[task.status].icon }}</span>
+        <h3>{{ task.title }}</h3>
+      </header>
+      <p>{{ task.description }}</p>
+      <footer>
+        <span class="label">Deliverable</span>
+        <span class="deliverable">{{ task.deliverable }}</span>
+      </footer>
+    </article>
+    {% endfor %}
+  </div>
+  {% elif section.groups %}
+  <div class="grouped-section">
+    {% for group in section.groups %}
+    <section class="task-group">
+      <h3>{{ group.title }}</h3>
+      <div class="task-grid">
+        {% for task in group.tasks %}
+        <article class="task-card" data-status="{{ task.status }}">
+          <header>
+            <span class="status-icon status-{{ task.status }}">{{ status_meta[task.status].icon }}</span>
+            <h4>{{ task.title }}</h4>
+          </header>
+          <p>{{ task.description }}</p>
+          <footer>
+            <span class="label">Deliverable</span>
+            <span class="deliverable">{{ task.deliverable }}</span>
+          </footer>
+        </article>
+        {% endfor %}
+      </div>
+    </section>
+    {% endfor %}
+  </div>
+  {% endif %}
+</section>
+{% endfor %}
+
+<section class="tracker-note glass-card">
+  <h2>Catatan Implementasi</h2>
+  <p>
+    Seluruh deliverable wajib ada di repositori ini. Dokumentasikan bukti visual menggunakan screenshot dari implementasi SSR yang
+    berjalan, bukan mockup Figma, untuk menjaga konsistensi referensi lintas tim.
+  </p>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add structured data and a FastAPI route that render the UI/UX implementation backlog as a live tracker page
- build a dedicated Jinja template and glassmorphism styling so the tracker mirrors the repository to-do document in a web-friendly layout
- expose the tracker from the global navigation and allow templates to inject page-specific assets via a new head block

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7c3079efc8327a1ff081d0732b8a1