### PR TITLE
Streamline marketplace header layout

### DIFF
--- a/src/app/api/routes/root.py
+++ b/src/app/api/routes/root.py
@@ -472,6 +472,7 @@ async def read_marketplace(request: Request) -> HTMLResponse:
                     "origin_type": "Brand Partner",
                     "category": "Parfum Artisan",
                     "notes": ["Jasmine sambac", "Vetiver Bali", "Cedar Atlas"],
+                    "perfumer": "Ayu Prameswari",
                     "price": "Rp420K",
                     "media_class": "parfum-aurora",
                     "tags": ["Bestseller", "Signature"],
@@ -482,6 +483,7 @@ async def read_marketplace(request: Request) -> HTMLResponse:
                     "origin_type": "Brand Partner",
                     "category": "Signature Blend",
                     "notes": ["Ylang-ylang", "Patchouli Sulawesi", "Amber Praline"],
+                    "perfumer": "Devi Larasati",
                     "price": "Rp380K",
                     "media_class": "parfum-tropis",
                     "tags": ["Baru", "Eksklusif"],
@@ -492,6 +494,7 @@ async def read_marketplace(request: Request) -> HTMLResponse:
                     "origin_type": "Kreator Komunitas",
                     "category": "Kolaborasi Sambatan",
                     "notes": ["Sea salt accord", "Kelopak kenanga", "Oud Kalimantan"],
+                    "perfumer": "Rara Widyanti",
                     "price": "Mulai Rp250K",
                     "media_class": "community-lagoon",
                     "sambatan": {
@@ -559,8 +562,8 @@ async def read_marketplace(request: Request) -> HTMLResponse:
             ],
         },
         {
-            "slug": "lainlain",
-            "label": "Lainlain",
+            "slug": "lain-lain",
+            "label": "Lain-lain",
             "description": "Dukungan lain mulai dari kemasan hingga pengalaman workshop untuk memperluas bisnis parfum Anda.",
             "products": [
                 {

--- a/src/app/web/static/css/base.css
+++ b/src/app/web/static/css/base.css
@@ -286,56 +286,35 @@ p {
   max-width: 540px;
 }
 
-.hero-actions {
-  display: flex;
-  gap: 1rem;
-  flex-wrap: wrap;
-  margin-top: 1.5rem;
-}
-
-.marketplace-hero {
-  display: grid;
-  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
-  gap: 2rem;
-  margin-bottom: 2.5rem;
-  padding: 2.5rem;
-  align-items: stretch;
-}
-
-.marketplace-hero .hero-intro {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
-
-.marketplace-hero .hero-intro h1 {
-  font-size: clamp(2rem, 2.8vw, 3rem);
-}
-
-.hero-filters {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-  background: rgba(15, 23, 42, 0.55);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  padding: 2rem;
-}
-
-.filter-heading h2 {
-  font-size: 1.25rem;
-}
-
-.filter-heading p {
-  color: var(--text-secondary);
-  font-size: 0.95rem;
-  margin-top: 0.35rem;
-}
-
 .filter-form {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 1rem;
   align-items: flex-end;
+}
+
+.filter-form.single-field {
+  grid-template-columns: 1fr;
+}
+
+.filter-hint {
+  grid-column: 1 / -1;
+  font-size: 0.85rem;
+  color: var(--text-tertiary);
+  margin: 0;
+}
+
+.section-search {
+  max-width: min(380px, 100%);
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  margin-left: auto;
+}
+
+.section-search .filter-hint {
+  margin-top: 0.25rem;
 }
 
 .field {
@@ -776,10 +755,26 @@ p {
   max-width: 640px;
 }
 
+.empty-state {
+  font-size: 0.9rem;
+  color: var(--text-tertiary);
+  margin: 0;
+}
+
 .product-availability {
   margin-top: 0.75rem;
   font-size: 0.85rem;
   color: var(--text-secondary);
+}
+
+.product-perfumer {
+  font-size: 0.85rem;
+  color: var(--accent-primary);
+  margin: 0.35rem 0 0;
+}
+
+.product-card.is-filtered-out {
+  display: none;
 }
 
 .sambatan {

--- a/src/app/web/templates/marketplace.html
+++ b/src/app/web/templates/marketplace.html
@@ -1,69 +1,33 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<section class="marketplace-hero glass-surface">
-  <div class="hero-intro">
-    <span class="badge">Eksplorasi Marketplace</span>
-    <h1>Kurasi parfum artisan dan karya komunitas dalam satu etalase.</h1>
-    <p>
-      Bandingkan koleksi brand terpilih dengan kreasi komunitas Nusantarum, cek ketersediaan
-      sambatan, dan lanjutkan kolaborasi langsung dari dashboard Anda.
-    </p>
-    <div class="hero-actions">
-      <a class="btn gradient-button" href="#marketplace-catalog">Lihat katalog</a>
-    </div>
-  </div>
-  <div class="hero-filters glass-card">
-    <div class="filter-heading">
-      <h2>Pencarian cepat</h2>
-      <p>Gunakan filter untuk mempersempit aroma, status sambatan, dan kisaran harga.</p>
-    </div>
-    <form class="filter-form" aria-label="Filter marketplace parfum">
-      <label class="field">
-        <span>Kata kunci</span>
-        <input type="search" name="q" placeholder="Cari brand, notes, atau kreator" />
-      </label>
-      <label class="field">
-        <span>Kategori</span>
-        <select name="category">
-          <option value="">Semua kategori</option>
-          {% for tab in marketplace_catalog %}
-          <option value="{{ tab.slug }}">{{ tab.label }}</option>
-          {% endfor %}
-        </select>
-      </label>
-      <label class="field">
-        <span>Status Sambatan</span>
-        <select name="sambatan">
-          <option>Semua</option>
-          <option>Aktif</option>
-          <option>Menjelang penuh</option>
-          <option>Selesai</option>
-        </select>
-      </label>
-      <label class="field range">
-        <span>Kisaran harga</span>
-        <div class="range-inputs">
-          <input type="number" name="min" placeholder="Rp150K" min="0" />
-          <span class="divider">—</span>
-          <input type="number" name="max" placeholder="Rp500K" min="0" />
-        </div>
-      </label>
-      <button class="btn gradient-button" type="submit">Terapkan filter</button>
-    </form>
-  </div>
-</section>
-
 <section class="marketplace-section" id="marketplace-catalog">
   <div class="section-header">
     <div>
       <span class="badge brand">Katalog Marketplace</span>
-      <h2>Produk brand partner dan kreator komunitas</h2>
+      <h1>Telusuri produk brand partner dan kreator komunitas</h1>
       <p>
         Gunakan tab kategori untuk beralih antara parfum siap pakai, bahan baku, peralatan, dan opsi
         pendukung lainnya.
       </p>
     </div>
+    <form
+      class="filter-form single-field section-search"
+      role="search"
+      aria-label="Cari produk marketplace"
+    >
+      <label class="field">
+        <span>Pencarian</span>
+        <input
+          type="search"
+          name="q"
+          placeholder="Contoh: Pelangi Senja atau Ayu Prameswari"
+          autocomplete="off"
+          data-marketplace-search
+        />
+      </label>
+      <p class="filter-hint">Ketik nama produk, brand, atau perfumer untuk menelusuri katalog.</p>
+    </form>
   </div>
 
   <div class="catalog-tabs" role="tablist">
@@ -92,9 +56,16 @@
     {% if not loop.first %}hidden{% endif %}
   >
     <p class="panel-description">{{ tab.description }}</p>
+    <p class="empty-state" data-empty-message hidden>Belum ada produk yang cocok dengan pencarian Anda.</p>
     <div class="product-grid marketplace-grid">
       {% for product in tab.products %}
-      <article class="product-card glass-card">
+      <article
+        class="product-card glass-card"
+        data-product-card
+        data-name="{{ product.name }}"
+        data-brand="{{ product.origin }}"
+        data-perfumer="{{ product.perfumer or '' }}"
+      >
         <div class="product-media {{ product.media_class }}"></div>
         <div class="product-content">
           <div class="product-meta">
@@ -102,6 +73,9 @@
             <span class="product-owner">{{ product.origin }}</span>
           </div>
           <h3>{{ product.name }}</h3>
+          {% if product.perfumer %}
+          <p class="product-perfumer">Diracik oleh {{ product.perfumer }}</p>
+          {% endif %}
           {% if product.description %}
           <p class="product-description">{{ product.description }}</p>
           {% elif product.notes %}
@@ -141,6 +115,7 @@
   (function () {
     const tabButtons = document.querySelectorAll('[data-tab]');
     const tabPanels = document.querySelectorAll('[data-tab-panel]');
+    const searchInput = document.querySelector('[data-marketplace-search]');
 
     tabButtons.forEach((button) => {
       button.addEventListener('click', () => {
@@ -157,8 +132,55 @@
           panel.classList.toggle('is-hidden', !match);
           panel.toggleAttribute('hidden', !match);
         });
+
+        if (searchInput && searchInput.value.trim()) {
+          applySearchFilter();
+        }
       });
     });
+
+    function normalise(value) {
+      return value
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/\p{Diacritic}/gu, '');
+    }
+
+    function applySearchFilter() {
+      const keyword = normalise(searchInput.value.trim());
+
+      tabPanels.forEach((panel) => {
+        const cards = panel.querySelectorAll('[data-product-card]');
+        const emptyMessage = panel.querySelector('[data-empty-message]');
+        let visibleCount = 0;
+
+        cards.forEach((card) => {
+          const name = normalise(card.dataset.name || '');
+          const brand = normalise(card.dataset.brand || '');
+          const perfumer = normalise(card.dataset.perfumer || '');
+          const haystack = `${name} ${brand} ${perfumer}`.trim();
+          const matches = !keyword || haystack.includes(keyword);
+
+          card.classList.toggle('is-filtered-out', !matches);
+          card.toggleAttribute('hidden', !matches);
+
+          if (matches) {
+            visibleCount += 1;
+          }
+        });
+
+        const shouldShowEmpty = visibleCount === 0 && keyword;
+        if (emptyMessage) {
+          emptyMessage.toggleAttribute('hidden', !shouldShowEmpty);
+        }
+      });
+    }
+
+    if (searchInput) {
+      ['input', 'change'].forEach((eventName) => {
+        searchInput.addEventListener(eventName, applySearchFilter);
+      });
+    }
   })();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove the hero/cta block so the marketplace catalog starts immediately under the navbar
- relocate the search form into the catalog header with refreshed styling for the compact layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d7dbcc55208327b5f2e6b5195472af