### PR TITLE
Add authentication workflow with UI and tests

### DIFF
--- a/src/app/api/routes/auth.py
+++ b/src/app/api/routes/auth.py
@@ -1,0 +1,93 @@
+"""Authentication API endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from pydantic import BaseModel, Field
+
+from app.services.auth import AuthService, AuthError, auth_service
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+
+class RegisterRequest(BaseModel):
+    full_name: str = Field(..., min_length=3, max_length=120)
+    email: str = Field(..., pattern=r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+    password: str = Field(..., min_length=8, max_length=128)
+
+
+class AuthPayload(BaseModel):
+    user_id: str
+    email: str
+    full_name: str
+    message: str
+
+
+class LoginRequest(BaseModel):
+    email: str = Field(..., pattern=r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+    password: str = Field(..., min_length=8, max_length=128)
+
+
+class SessionResponse(BaseModel):
+    is_authenticated: bool
+    user: dict | None = None
+
+
+def get_auth_service() -> AuthService:
+    return auth_service
+
+
+def _serialize_user(user) -> dict:
+    return {"user_id": user.id, "email": user.email, "full_name": user.full_name}
+
+
+@router.post("/register", response_model=AuthPayload, status_code=status.HTTP_201_CREATED)
+def register_user(payload: RegisterRequest, service: AuthService = Depends(get_auth_service)) -> AuthPayload:
+    try:
+        user = service.register_user(
+            email=payload.email,
+            full_name=payload.full_name,
+            password=payload.password,
+        )
+    except AuthError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+
+    return AuthPayload(
+        user_id=user.id,
+        email=user.email,
+        full_name=user.full_name,
+        message="Registrasi berhasil",
+    )
+
+
+@router.post("/login", response_model=AuthPayload)
+def login_user(
+    payload: LoginRequest,
+    request: Request,
+    service: AuthService = Depends(get_auth_service),
+) -> AuthPayload:
+    try:
+        user = service.authenticate(email=payload.email, password=payload.password)
+    except AuthError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+
+    request.session["user"] = _serialize_user(user)
+
+    return AuthPayload(
+        user_id=user.id,
+        email=user.email,
+        full_name=user.full_name,
+        message="Login berhasil",
+    )
+
+
+@router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
+def logout_user(request: Request) -> Response:
+    request.session.pop("user", None)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/session", response_model=SessionResponse)
+def read_session(request: Request) -> SessionResponse:
+    user = request.session.get("user")
+    return SessionResponse(is_authenticated=bool(user), user=user)

--- a/src/app/api/routes/root.py
+++ b/src/app/api/routes/root.py
@@ -635,6 +635,39 @@ async def read_onboarding(request: Request) -> HTMLResponse:
     return templates.TemplateResponse("onboarding.html", context)
 
 
+@router.get("/auth", response_class=HTMLResponse)
+async def read_auth(request: Request) -> HTMLResponse:
+    """Render the combined register/login playground."""
+
+    settings = get_settings()
+    templates = request.app.state.templates
+
+    perks = [
+        {
+            "title": "Satu akun untuk semua modul",
+            "description": "Akses marketplace, sambatan, dan analitik dengan sekali login.",
+        },
+        {
+            "title": "Pengingat personal",
+            "description": "Tim produk dapat menguji flow notifikasi dan email komunitas.",
+        },
+        {
+            "title": "Keamanan dasar",
+            "description": "Password divalidasi di sisi server dan disimpan dengan hashing.",
+        },
+    ]
+
+    context = {
+        "request": request,
+        "app_name": settings.app_name,
+        "environment": settings.environment,
+        "title": "Masuk & Daftar",
+        "perks": perks,
+        "session_user": request.session.get("user"),
+    }
+    return templates.TemplateResponse("auth.html", context)
+
+
 @router.get("/ui-ux/implementation", response_class=HTMLResponse)
 async def read_uiux_tracker(request: Request) -> HTMLResponse:
     """Render a glassmorphism-flavored tracker of the UI/UX implementation to-do list."""

--- a/src/app/core/application.py
+++ b/src/app/core/application.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.staticfiles import StaticFiles
 
 from app.core.config import get_settings
+from app.core.session import InMemorySessionMiddleware
 from app.web.templates import template_engine
 from app.api.routes import onboarding as onboarding_routes
 from app.api.routes import reports as reports_routes
@@ -21,6 +22,12 @@ def create_app() -> FastAPI:
     settings = get_settings()
 
     app = FastAPI(title=settings.app_name)
+
+    app.add_middleware(
+        InMemorySessionMiddleware,
+        max_age=60 * 60 * 24 * 14,
+        same_site="lax",
+    )
 
     # Basic CORS setup to simplify early integrations with Supabase and
     # front-end previews during the MVP stage.
@@ -38,6 +45,9 @@ def create_app() -> FastAPI:
     app.include_router(root_routes.router)
     app.include_router(reports_routes.router)
     app.include_router(onboarding_routes.router)
+    from app.api.routes import auth as auth_routes
+
+    app.include_router(auth_routes.router)
 
     # Expose the template engine on the app state for reuse by routers.
     app.state.templates = template_engine

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -23,6 +23,9 @@ class Settings(BaseSettings):
     # RajaOngkir integration
     rajaongkir_api_key: str | None = None
 
+    # Session management
+    session_secret: str = "insecure-dev-secret"
+
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
 

--- a/src/app/core/session.py
+++ b/src/app/core/session.py
@@ -1,0 +1,119 @@
+"""In-memory session middleware without external dependencies."""
+
+from __future__ import annotations
+
+import secrets
+from typing import Any, Dict
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+class SessionData(dict):
+    """Dictionary wrapper that tracks modification status."""
+
+    def __init__(self, initial: Dict[str, Any] | None = None) -> None:
+        super().__init__(initial or {})
+        self.modified = False
+
+    def _mark_modified(self) -> None:
+        self.modified = True
+
+    def __setitem__(self, key: str, value: Any) -> None:  # type: ignore[override]
+        super().__setitem__(key, value)
+        self._mark_modified()
+
+    def __delitem__(self, key: str) -> None:  # type: ignore[override]
+        super().__delitem__(key)
+        self._mark_modified()
+
+    def clear(self) -> None:  # type: ignore[override]
+        super().clear()
+        self._mark_modified()
+
+    def pop(self, key: str, default: Any | None = None) -> Any:  # type: ignore[override]
+        value = super().pop(key, default)
+        self._mark_modified()
+        return value
+
+    def popitem(self) -> tuple[str, Any]:  # type: ignore[override]
+        item = super().popitem()
+        self._mark_modified()
+        return item
+
+    def setdefault(self, key: str, default: Any = None) -> Any:  # type: ignore[override]
+        if key not in self:
+            self._mark_modified()
+        return super().setdefault(key, default)
+
+    def update(self, *args: Any, **kwargs: Any) -> None:  # type: ignore[override]
+        super().update(*args, **kwargs)
+        if args or kwargs:
+            self._mark_modified()
+
+
+class InMemorySessionMiddleware(BaseHTTPMiddleware):
+    """Provide `request.session` support using an in-memory store."""
+
+    def __init__(
+        self,
+        app,
+        *,
+        cookie_name: str = "session",
+        max_age: int = 60 * 60 * 24 * 14,
+        same_site: str = "lax",
+        https_only: bool = False,
+    ) -> None:
+        super().__init__(app)
+        self.cookie_name = cookie_name
+        self.max_age = max_age
+        self.same_site = same_site
+        self.https_only = https_only
+        self._store: Dict[str, Dict[str, Any]] = {}
+
+    async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[override]
+        session_id = request.cookies.get(self.cookie_name)
+        session_payload = self._store.get(session_id) if session_id else None
+        new_session = False
+
+        if session_payload is None:
+            session_id = secrets.token_urlsafe(32)
+            session_payload = {}
+            new_session = True
+
+        session = SessionData(session_payload)
+        request.scope["session"] = session
+        request.scope["session_id"] = session_id
+
+        response = await call_next(request)
+
+        if session.modified:
+            if session:
+                self._store[session_id] = dict(session)
+                self._set_cookie(response, session_id)
+            else:
+                self._store.pop(session_id, None)
+                self._delete_cookie(response)
+        elif new_session:
+            if session:
+                self._store[session_id] = dict(session)
+                self._set_cookie(response, session_id)
+            else:
+                self._store.pop(session_id, None)
+
+        return response
+
+    def _set_cookie(self, response: Response, session_id: str) -> None:
+        response.set_cookie(
+            self.cookie_name,
+            session_id,
+            max_age=self.max_age,
+            httponly=True,
+            secure=self.https_only,
+            samesite=self.same_site,
+            path="/",
+        )
+
+    def _delete_cookie(self, response: Response) -> None:
+        response.delete_cookie(self.cookie_name, path="/")

--- a/src/app/services/__init__.py
+++ b/src/app/services/__init__.py
@@ -1,0 +1,11 @@
+"""Service exports for convenience."""
+
+from .auth import AuthService, auth_service
+from .onboarding import OnboardingService, onboarding_service
+
+__all__ = [
+    "AuthService",
+    "auth_service",
+    "OnboardingService",
+    "onboarding_service",
+]

--- a/src/app/services/auth.py
+++ b/src/app/services/auth.py
@@ -1,0 +1,137 @@
+"""Simple authentication service for the MVP stage."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import secrets
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Dict, Optional
+
+
+class AuthError(Exception):
+    """Base class for authentication related errors."""
+
+    status_code: int = 400
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class UserAlreadyExists(AuthError):
+    """Raised when attempting to register a duplicate email."""
+
+    status_code = 409
+
+
+class InvalidCredentials(AuthError):
+    """Raised when login credentials fail validation."""
+
+    status_code = 401
+
+
+class PasswordPolicyError(AuthError):
+    """Raised when the supplied password does not meet requirements."""
+
+    status_code = 422
+
+
+class AccountStatus(str, Enum):
+    """Minimal account status representation."""
+
+    ACTIVE = "active"
+    DISABLED = "disabled"
+
+
+@dataclass
+class AuthUser:
+    """Represents a registered user."""
+
+    id: str
+    email: str
+    full_name: str
+    password_hash: str
+    status: AccountStatus
+    created_at: datetime
+    updated_at: datetime
+    last_login_at: Optional[datetime] = None
+
+
+def _hash_password(raw: str) -> str:
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+class AuthService:
+    """Minimal in-memory authentication workflow for demos and tests."""
+
+    def __init__(self) -> None:
+        self._users_by_id: Dict[str, AuthUser] = {}
+        self._users_by_email: Dict[str, str] = {}
+
+    def register_user(self, *, email: str, full_name: str, password: str) -> AuthUser:
+        normalized_email = email.strip().lower()
+        self._validate_email(normalized_email)
+        self._validate_full_name(full_name)
+        self._validate_password(password)
+
+        if normalized_email in self._users_by_email:
+            raise UserAlreadyExists("Email sudah terdaftar. Silakan login.")
+
+        user_id = secrets.token_urlsafe(8)
+        now = datetime.utcnow()
+        user = AuthUser(
+            id=user_id,
+            email=normalized_email,
+            full_name=full_name.strip(),
+            password_hash=_hash_password(password),
+            status=AccountStatus.ACTIVE,
+            created_at=now,
+            updated_at=now,
+        )
+        self._users_by_id[user_id] = user
+        self._users_by_email[normalized_email] = user_id
+        return user
+
+    def authenticate(self, *, email: str, password: str) -> AuthUser:
+        normalized_email = email.strip().lower()
+        user = self._get_user_by_email(normalized_email)
+
+        if user.status is not AccountStatus.ACTIVE:
+            raise InvalidCredentials("Akun tidak aktif.")
+
+        if not secrets.compare_digest(user.password_hash, _hash_password(password)):
+            raise InvalidCredentials("Email atau password salah.")
+
+        now = datetime.utcnow()
+        user.last_login_at = now
+        user.updated_at = now
+        return user
+
+    def _get_user_by_email(self, email: str) -> AuthUser:
+        try:
+            user_id = self._users_by_email[email]
+        except KeyError as exc:
+            raise InvalidCredentials("Email atau password salah.") from exc
+        return self._users_by_id[user_id]
+
+    def _validate_email(self, email: str) -> None:
+        pattern = r"^[^@\s]+@[^@\s]+\.[^@\s]+$"
+        if not re.match(pattern, email):
+            raise AuthError("Format email tidak valid.")
+
+    def _validate_full_name(self, full_name: str) -> None:
+        if len(full_name.strip()) < 3:
+            raise AuthError("Nama lengkap minimal 3 karakter.")
+
+    def _validate_password(self, password: str) -> None:
+        if len(password) < 8:
+            raise PasswordPolicyError("Password minimal 8 karakter.")
+        if not re.search(r"[A-Za-z]", password) or not re.search(r"[0-9]", password):
+            raise PasswordPolicyError("Password harus mengandung huruf dan angka.")
+
+
+auth_service = AuthService()
+"""Singleton instance to be shared across the application."""

--- a/src/app/web/static/css/auth.css
+++ b/src/app/web/static/css/auth.css
@@ -1,0 +1,197 @@
+.auth-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 2.5rem;
+  padding: 3rem;
+}
+
+.auth-hero .badge {
+  margin-bottom: 1rem;
+}
+
+.auth-perks {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.auth-perks li {
+  padding: 1.5rem;
+}
+
+.auth-grid {
+  padding: 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.auth-columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+  align-items: start;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: var(--radius-md);
+  padding: 1.75rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.auth-form fieldset {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.auth-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.auth-form input {
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--text-primary);
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+.auth-form input:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.85);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+}
+
+.form-note {
+  font-size: 0.85rem;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.auth-feedback {
+  border-radius: var(--radius-md);
+  padding: 1rem 1.2rem;
+  display: none;
+  background: rgba(56, 189, 248, 0.08);
+  border: 1px solid rgba(56, 189, 248, 0.25);
+}
+
+.auth-feedback.visible {
+  display: block;
+}
+
+.auth-feedback[data-tone='success'] {
+  background: rgba(52, 211, 153, 0.12);
+  border-color: rgba(52, 211, 153, 0.4);
+  color: var(--text-primary);
+}
+
+.auth-feedback[data-tone='danger'] {
+  background: rgba(248, 113, 113, 0.12);
+  border-color: rgba(248, 113, 113, 0.4);
+  color: #fecaca;
+}
+
+.auth-session {
+  background: rgba(15, 23, 42, 0.32);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: var(--radius-md);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.auth-session dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5rem 1.25rem;
+  margin: 0;
+}
+
+.auth-session dt {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.auth-session dd {
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.session-hints {
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  border-radius: var(--radius-sm);
+  padding: 1rem 1.25rem;
+}
+
+.session-hints h4 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.05rem;
+}
+
+.session-hints ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--text-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.anchor-target {
+  position: relative;
+  top: -120px;
+}
+
+@media (max-width: 960px) {
+  .auth-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .auth-perks {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  .auth-grid {
+    padding: 2rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .auth-grid {
+    padding: 1.5rem;
+  }
+
+  .auth-form,
+  .auth-session {
+    padding: 1.25rem;
+  }
+
+  .anchor-target {
+    top: -80px;
+  }
+}

--- a/src/app/web/static/css/base.css
+++ b/src/app/web/static/css/base.css
@@ -212,6 +212,19 @@ p {
   gap: 0.75rem;
 }
 
+.navbar-user {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.navbar-actions .is-loading {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
 .navbar-toggle {
   display: none;
   flex-direction: column;

--- a/src/app/web/static/js/session.js
+++ b/src/app/web/static/js/session.js
@@ -1,0 +1,29 @@
+(function () {
+  function handleLogout(event) {
+    const trigger = event.target.closest('[data-action="logout"]');
+    if (!trigger) {
+      return;
+    }
+    event.preventDefault();
+
+    if (trigger.dataset.loading === 'true') {
+      return;
+    }
+
+    trigger.dataset.loading = 'true';
+    trigger.classList.add('is-loading');
+
+    fetch('/api/auth/logout', { method: 'POST' })
+      .catch(() => {})
+      .finally(() => {
+        const redirect = trigger.dataset.redirect;
+        if (redirect) {
+          window.location.href = redirect;
+        } else {
+          window.location.reload();
+        }
+      });
+  }
+
+  document.addEventListener('click', handleLogout);
+})();

--- a/src/app/web/templates/auth.html
+++ b/src/app/web/templates/auth.html
@@ -1,0 +1,199 @@
+{% extends 'base.html' %}
+
+{% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/auth.css') }}" />
+{% endblock %}
+
+{% block content %}
+<section class="auth-hero glass-surface">
+  <div>
+    <span class="badge">Akses Komunitas</span>
+    <h1>Masuk dan daftar ke Sensasiwangi.id</h1>
+    <p>
+      Lacak alur registrasi, login, dan logout dalam satu layar. Gunakan halaman ini untuk
+      validasi UX sebelum integrasi dengan Supabase atau penyedia auth lainnya.
+    </p>
+  </div>
+  <ul class="auth-perks">
+    {% for perk in perks %}
+    <li class="glass-card">
+      <h3>{{ perk.title }}</h3>
+      <p>{{ perk.description }}</p>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+
+<section class="auth-grid glass-surface" id="register">
+  <header class="section-header">
+    <div>
+      <h2>Workflow Autentikasi</h2>
+      <p>
+        Mulai dari pendaftaran, login, hingga logout dengan penyimpanan sesi dasar. Status sesi
+        terkini akan ditampilkan di panel samping.
+      </p>
+    </div>
+    <div class="status-chip" data-auth-status>
+      {% if session_user %}Sudah masuk sebagai {{ session_user.full_name }}{% else %}Belum masuk{% endif %}
+    </div>
+  </header>
+
+  <div class="auth-feedback" data-auth-feedback role="status" aria-live="polite"></div>
+
+  <div class="auth-columns">
+    <form id="auth-register-form" class="auth-form">
+      <fieldset>
+        <legend>1. Registrasi Akun Baru</legend>
+        <label>
+          Nama Lengkap
+          <input type="text" name="full_name" minlength="3" maxlength="120" placeholder="Mis. Intan Dewi" required />
+        </label>
+        <label>
+          Email
+          <input type="email" name="email" placeholder="anda@contoh.com" required />
+        </label>
+        <label>
+          Password
+          <input
+            type="password"
+            name="password"
+            minlength="8"
+            maxlength="128"
+            placeholder="Minimal 8 karakter dengan huruf & angka"
+            required
+          />
+        </label>
+      </fieldset>
+      <button type="submit" class="btn gradient-button">Daftar Sekarang</button>
+      <p class="form-note">Password disimpan menggunakan hashing SHA-256 untuk demonstrasi.</p>
+    </form>
+
+    <div id="login" class="anchor-target" aria-hidden="true"></div>
+    <form id="auth-login-form" class="auth-form" aria-labelledby="login-title">
+      <fieldset>
+        <legend id="login-title">2. Login</legend>
+        <label>
+          Email
+          <input type="email" name="email" placeholder="anda@contoh.com" required />
+        </label>
+        <label>
+          Password
+          <input type="password" name="password" minlength="8" maxlength="128" placeholder="Password" required />
+        </label>
+      </fieldset>
+      <button type="submit" class="btn btn-outline">Masuk</button>
+      <p class="form-note">Sesi login disimpan pada cookie terenkripsi selama 14 hari.</p>
+    </form>
+
+    <aside class="auth-session" id="login-status">
+      <h3>Status Sesi</h3>
+      {% if session_user %}
+      <dl>
+        <div>
+          <dt>Nama</dt>
+          <dd>{{ session_user.full_name }}</dd>
+        </div>
+        <div>
+          <dt>Email</dt>
+          <dd>{{ session_user.email }}</dd>
+        </div>
+      </dl>
+      <button class="btn btn-ghost" type="button" data-action="logout" data-redirect="{{ url_for('read_auth') }}">
+        Keluar dari sesi
+      </button>
+      {% else %}
+      <p class="muted">Belum ada sesi aktif. Coba daftar atau login menggunakan formulir di samping.</p>
+      {% endif %}
+
+      <div class="session-hints">
+        <h4>Catatan QA</h4>
+        <ul>
+          <li>Registrasi dengan email yang sama akan menghasilkan error 409.</li>
+          <li>Password harus berisi kombinasi huruf dan angka.</li>
+          <li>Logout akan menghapus data sesi dari cookie dan memperbarui navbar.</li>
+        </ul>
+      </div>
+    </aside>
+  </div>
+</section>
+{% endblock %}
+
+{% block body_scripts %}
+<script>
+  (() => {
+    const feedbackEl = document.querySelector('[data-auth-feedback]');
+    const statusEl = document.querySelector('[data-auth-status]');
+    const registerForm = document.getElementById('auth-register-form');
+    const loginForm = document.getElementById('auth-login-form');
+
+    const setFeedback = (message, tone = 'info') => {
+      if (!feedbackEl) return;
+      feedbackEl.textContent = message || '';
+      feedbackEl.dataset.tone = tone;
+      feedbackEl.classList.toggle('visible', Boolean(message));
+    };
+
+    const setStatus = (message) => {
+      if (statusEl) {
+        statusEl.textContent = message;
+      }
+    };
+
+    const handleResponseError = async (response) => {
+      const payload = await response.json().catch(() => ({}));
+      setFeedback(payload.detail || 'Permintaan gagal diproses', 'danger');
+    };
+
+    if (registerForm) {
+      registerForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const formData = new FormData(registerForm);
+        const payload = Object.fromEntries(formData.entries());
+
+        setFeedback('Memproses registrasi...');
+        const response = await fetch('/api/auth/register', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          await handleResponseError(response);
+          return;
+        }
+
+        const data = await response.json();
+        setFeedback(`Registrasi berhasil untuk ${data.full_name}. Silakan login.`, 'success');
+        registerForm.reset();
+      });
+    }
+
+    if (loginForm) {
+      loginForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const formData = new FormData(loginForm);
+        const payload = Object.fromEntries(formData.entries());
+
+        setFeedback('Memproses login...');
+        const response = await fetch('/api/auth/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          await handleResponseError(response);
+          return;
+        }
+
+        const data = await response.json();
+        setFeedback(`Login berhasil. Selamat datang, ${data.full_name}!`, 'success');
+        setStatus(`Sudah masuk sebagai ${data.full_name}`);
+        window.setTimeout(() => {
+          window.location.href = '{{ url_for('read_auth') }}';
+        }, 600);
+      });
+    }
+  })();
+</script>
+{% endblock %}

--- a/src/app/web/templates/base.html
+++ b/src/app/web/templates/base.html
@@ -24,5 +24,7 @@
       </main>
       {% include 'partials/footer.html' %}
     </div>
+    <script src="{{ url_for('static', path='js/session.js') }}" defer></script>
+    {% block body_scripts %}{% endblock %}
   </body>
 </html>

--- a/src/app/web/templates/partials/navbar.html
+++ b/src/app/web/templates/partials/navbar.html
@@ -34,8 +34,15 @@
     <li><a href="{{ url_for('read_home') }}#dashboard">Dashboard</a></li>
     <li><a href="{{ url_for('read_home') }}#profil">Profil</a></li>
   </ul>
+  {% set session_user = request.session.get('user') %}
   <div class="navbar-actions">
-    <a class="btn btn-ghost" href="#login">Masuk</a>
-    <a class="btn gradient-button" href="#komunitas">Gabung Komunitas</a>
+    {% if session_user %}
+    <span class="navbar-user">👋 {{ session_user.full_name }}</span>
+    <button class="btn btn-ghost" type="button" data-action="logout">Keluar</button>
+    <a class="btn gradient-button" href="{{ url_for('read_marketplace') }}">Marketplace</a>
+    {% else %}
+    <a class="btn btn-ghost" href="{{ url_for('read_auth') }}#login">Masuk</a>
+    <a class="btn gradient-button" href="{{ url_for('read_auth') }}#register">Daftar</a>
+    {% endif %}
   </div>
 </nav>

--- a/supabase/migrations/0001_initial_schema.sql
+++ b/supabase/migrations/0001_initial_schema.sql
@@ -72,6 +72,34 @@ create trigger set_updated_at_user_profiles
 before update on user_profiles
 for each row execute function set_updated_at();
 
+create table if not exists auth_accounts (
+    id uuid primary key default gen_random_uuid(),
+    email citext not null unique,
+    password_hash text not null,
+    full_name text not null,
+    status text not null default 'active',
+    last_login_at timestamptz,
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now())
+);
+
+create trigger set_updated_at_auth_accounts
+before update on auth_accounts
+for each row execute function set_updated_at();
+
+create table if not exists auth_sessions (
+    id uuid primary key default gen_random_uuid(),
+    account_id uuid not null references auth_accounts(id) on delete cascade,
+    session_token text not null unique,
+    ip_address text,
+    user_agent text,
+    created_at timestamptz not null default timezone('utc', now()),
+    expires_at timestamptz not null
+);
+
+create index if not exists idx_auth_sessions_account_expires
+    on auth_sessions (account_id, expires_at desc);
+
 create table if not exists onboarding_registrations (
     id uuid primary key default gen_random_uuid(),
     email citext not null unique,

--- a/tests/test_auth_api.py
+++ b/tests/test_auth_api.py
@@ -1,0 +1,139 @@
+import asyncio
+import json
+from http.cookies import SimpleCookie
+from typing import Dict, Tuple
+
+from app.api.routes.auth import get_auth_service
+from app.main import app
+from app.services.auth import AuthService
+
+
+async def _send_request(
+    method: str,
+    path: str,
+    *,
+    json_body: Dict | None = None,
+    cookies: Dict[str, str] | None = None,
+) -> Tuple[int, Dict[str, str], bytes, Dict[str, str]]:
+    body_bytes = b""
+    headers = []
+
+    if json_body is not None:
+        body_bytes = json.dumps(json_body).encode("utf-8")
+        headers.append((b"content-type", b"application/json"))
+
+    if cookies:
+        cookie_header = "; ".join(f"{key}={value}" for key, value in cookies.items())
+        headers.append((b"cookie", cookie_header.encode("latin-1")))
+
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("ascii"),
+        "query_string": b"",
+        "headers": headers,
+        "client": ("127.0.0.1", 0),
+        "server": ("testserver", 80),
+    }
+
+    messages = []
+
+    async def receive() -> dict:
+        nonlocal body_bytes
+        chunk = body_bytes
+        body_bytes = b""
+        return {"type": "http.request", "body": chunk, "more_body": False}
+
+    async def send(message: dict) -> None:
+        messages.append(message)
+
+    await app(scope, receive, send)
+
+    status = next(
+        message["status"]
+        for message in messages
+        if message["type"] == "http.response.start"
+    )
+    raw_headers = next(
+        message["headers"]
+        for message in messages
+        if message["type"] == "http.response.start"
+    )
+    body = b"".join(
+        message["body"] for message in messages if message["type"] == "http.response.body"
+    )
+
+    response_headers = {key.decode().lower(): value.decode() for key, value in raw_headers}
+
+    new_cookies: Dict[str, str] = {}
+    for key, value in raw_headers:
+        if key.decode().lower() == "set-cookie":
+            parsed = SimpleCookie()
+            parsed.load(value.decode())
+            for cookie_key in parsed:
+                new_cookies[cookie_key] = parsed[cookie_key].value
+
+    return status, response_headers, body, new_cookies
+
+
+def test_register_login_logout_flow():
+    service = AuthService()
+    app.dependency_overrides[get_auth_service] = lambda: service
+
+    jar: Dict[str, str] = {}
+
+    try:
+        status, headers, body, new_cookies = asyncio.run(
+            _send_request(
+                "POST",
+                "/api/auth/register",
+                json_body={
+                    "full_name": "Tester Sukses",
+                    "email": "tester@example.com",
+                    "password": "Password123",
+                },
+            )
+        )
+        assert status == 201
+        payload = json.loads(body.decode())
+        assert payload["email"] == "tester@example.com"
+        jar.update(new_cookies)
+
+        status, headers, body, new_cookies = asyncio.run(
+            _send_request(
+                "POST",
+                "/api/auth/login",
+                json_body={"email": "tester@example.com", "password": "Password123"},
+                cookies=jar,
+            )
+        )
+        assert status == 200
+        payload = json.loads(body.decode())
+        assert payload["message"] == "Login berhasil"
+        jar.update(new_cookies)
+        assert jar.get("session")
+
+        status, headers, body, new_cookies = asyncio.run(
+            _send_request("GET", "/api/auth/session", cookies=jar)
+        )
+        assert status == 200
+        payload = json.loads(body.decode())
+        assert payload["is_authenticated"] is True
+        assert payload["user"]["email"] == "tester@example.com"
+
+        status, headers, body, new_cookies = asyncio.run(
+            _send_request("POST", "/api/auth/logout", cookies=jar)
+        )
+        assert status == 204
+        jar.update(new_cookies)
+
+        status, headers, body, _ = asyncio.run(
+            _send_request("GET", "/api/auth/session", cookies=jar)
+        )
+        payload = json.loads(body.decode())
+        assert payload["is_authenticated"] is False
+    finally:
+        app.dependency_overrides.pop(get_auth_service, None)

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -1,0 +1,53 @@
+import pytest
+
+from app.services.auth import (
+    AuthService,
+    InvalidCredentials,
+    PasswordPolicyError,
+    UserAlreadyExists,
+)
+
+
+def test_register_and_authenticate_user():
+    service = AuthService()
+
+    user = service.register_user(
+        email="tester@example.com",
+        full_name="Tester Sukses",
+        password="Password123",
+    )
+
+    assert user.email == "tester@example.com"
+    assert user.password_hash != "Password123"
+
+    authenticated = service.authenticate(email="tester@example.com", password="Password123")
+    assert authenticated.last_login_at is not None
+
+
+def test_register_duplicate_email():
+    service = AuthService()
+    service.register_user(email="tester@example.com", full_name="Tester", password="Password123")
+
+    with pytest.raises(UserAlreadyExists):
+        service.register_user(email="tester@example.com", full_name="Tester Dua", password="Password456")
+
+
+def test_password_policy_enforced():
+    service = AuthService()
+
+    with pytest.raises(PasswordPolicyError):
+        service.register_user(email="tester@example.com", full_name="Tester", password="short")
+
+    with pytest.raises(PasswordPolicyError):
+        service.register_user(email="tester2@example.com", full_name="Tester", password="passwordonly")
+
+
+def test_invalid_credentials_raise_error():
+    service = AuthService()
+    service.register_user(email="tester@example.com", full_name="Tester", password="Password123")
+
+    with pytest.raises(InvalidCredentials):
+        service.authenticate(email="tester@example.com", password="Password456")
+
+    with pytest.raises(InvalidCredentials):
+        service.authenticate(email="unknown@example.com", password="Password123")


### PR DESCRIPTION
## Summary
- add in-memory session middleware and authentication service with register/login/logout APIs
- introduce auth page, styling, navbar updates, and Supabase tables for auth accounts and sessions
- cover the new workflow with unit tests exercising the service and API

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7f7dffd1083279bd534f930847663