### PR TITLE
Add purchase workflow blueprint page

### DIFF
--- a/src/app/api/routes/root.py
+++ b/src/app/api/routes/root.py
@@ -439,6 +439,230 @@ UIUX_IMPLEMENTATION_PLAN = [
 ]
 
 
+PURCHASE_FLOW_STATUS_META = {
+    "in-discovery": {
+        "label": "Discovery",
+        "icon": "🔍",
+        "description": "Sedang dimatangkan oleh tim produk & riset pengguna.",
+    },
+    "in-design": {
+        "label": "Desain",
+        "icon": "🎨",
+        "description": "UI/UX sedang distabilisasi berdasarkan panduan glassmorphism.",
+    },
+    "ready": {
+        "label": "Siap Implementasi",
+        "icon": "🚀",
+        "description": "Spesifikasi visual dan interaksi sudah dikunci untuk developer.",
+    },
+    "live": {
+        "label": "Telah Dibangun",
+        "icon": "✅",
+        "description": "Flow sudah tersedia di staging/production build MVP.",
+    },
+}
+
+
+PURCHASE_FLOW_BLUEPRINT = [
+    {
+        "slug": "regular",
+        "title": "Belanja Produk Regular",
+        "summary": "Flow standar untuk pembelian katalog marketplace tanpa mekanisme sambatan.",
+        "status": "ready",
+        "persona": "Pembeli retail dan B2B ringan yang ingin checkout cepat.",
+        "success_metrics": [
+            "Waktu dari landing ke checkout < 3 menit",
+            "Rasio keranjang → pembayaran sukses > 60%",
+            "Validasi alamat berhasil dalam satu kali input",
+        ],
+        "steps": [
+            {
+                "stage": "Eksplorasi & Pencarian",
+                "goal": "Menemukan produk yang relevan",
+                "status": "live",
+                "touchpoints": [
+                    "Landing/Marketplace menampilkan search bar kaca dengan auto-suggest",
+                    "Filter aroma dan sort toggle untuk mempersonalisasi katalog",
+                    "Grid kartu produk dengan foto, harga, dan badge stok",
+                ],
+                "notes": [
+                    "Microcopy jumlah hasil dan skeleton loading saat filter berubah",
+                    "Optimasi keyboard navigation untuk aksesibilitas",
+                ],
+            },
+            {
+                "stage": "Melihat Detail Produk",
+                "goal": "Memahami deskripsi dan manfaat",
+                "status": "ready",
+                "touchpoints": [
+                    "Halaman detail dengan galeri foto dan deskripsi top-mid-base notes",
+                    "Panel info brand serta highlight review singkat",
+                    "CTA utama 'Tambah ke Keranjang' dengan varian quantity stepper",
+                ],
+                "notes": [
+                    "Toast info saat varian berubah dan disabled state ketika stok habis",
+                    "Badge Sambatan disembunyikan untuk produk non-sambatan",
+                ],
+            },
+            {
+                "stage": "Menambahkan ke Keranjang",
+                "goal": "Mengelola item yang akan dibeli",
+                "status": "ready",
+                "touchpoints": [
+                    "Drawer keranjang kaca dari sisi kanan dengan daftar item",
+                    "Kontrol kuantitas in-line dan subtotal dinamis",
+                    "CTA 'Checkout' dan aksi 'Lanjutkan Belanja'",
+                ],
+                "notes": [
+                    "Badge jumlah item pada ikon navbar diperbarui real time",
+                    "Toast sukses ketika produk berhasil masuk keranjang",
+                ],
+            },
+            {
+                "stage": "Checkout Informasi",
+                "goal": "Mengisi data pengiriman & opsi pengiriman",
+                "status": "in-design",
+                "touchpoints": [
+                    "Checkout multi-step dengan breadcrumb Keranjang → Alamat → Pengiriman → Pembayaran",
+                    "Form alamat kaca dengan auto-complete dan opsi simpan alamat default",
+                    "Pilihan pengiriman (Reguler, Same Day) dalam kartu radio glass",
+                ],
+                "notes": [
+                    "Validasi inline dengan ikon cek/eror",
+                    "Order summary sticky di kanan menampilkan estimasi tiba",
+                ],
+            },
+            {
+                "stage": "Pembayaran",
+                "goal": "Memilih metode dan melakukan pembayaran",
+                "status": "in-discovery",
+                "touchpoints": [
+                    "Opsi e-wallet, transfer bank, dan kartu kredit dengan ikon brand",
+                    "Panel instruksi dinamis setelah metode dipilih",
+                    "Countdown batas waktu pembayaran dan CTA salin nomor tujuan",
+                ],
+                "notes": [
+                    "State tombol lanjut disabled sampai metode dipilih",
+                    "Rencana integrasi webhook pembayaran untuk update status otomatis",
+                ],
+            },
+            {
+                "stage": "Pelacakan & Penerimaan",
+                "goal": "Memantau status sampai barang diterima",
+                "status": "in-design",
+                "touchpoints": [
+                    "Timeline status di riwayat pesanan (Dibuat → Diproses → Dikirim → Selesai)",
+                    "Notifikasi email/push saat status berubah",
+                    "CTA 'Konfirmasi Terima Barang' saat status dikirim",
+                ],
+                "notes": [
+                    "Setelah konfirmasi, munculkan prompt rating produk",
+                    "Simpan log aktivitas untuk dashboard ops",
+                ],
+            },
+        ],
+    },
+    {
+        "slug": "sambatan",
+        "title": "Belanja Produk Sambatan",
+        "summary": "Flow kolaboratif ketika produk dijual melalui kampanye sambatan komunitas.",
+        "status": "in-design",
+        "persona": "Kontributor komunitas yang berbagi slot pembelian batch.",
+        "success_metrics": [
+            "80% kampanye mencapai target slot sebelum deadline",
+            "< 24 jam untuk menyelesaikan checkout akhir setelah sambatan sukses",
+            "Minim pertanyaan support terkait status sambatan berkat UI jelas",
+        ],
+        "steps": [
+            {
+                "stage": "Eksplorasi Sambatan",
+                "goal": "Menemukan kampanye sambatan aktif",
+                "status": "ready",
+                "touchpoints": [
+                    "Tab Sambatan di landing dengan kartu progress radial dan badge deadline",
+                    "Filter tambahan untuk kategori sambatan dan progress",
+                    "Label urgensi seperti 'Butuh 5 lagi' untuk sense of urgency",
+                ],
+                "notes": [
+                    "Progress bar beranimasi saat hover",
+                    "Tooltip menjelaskan istilah sambatan untuk pendatang baru",
+                ],
+            },
+            {
+                "stage": "Detail Kampanye",
+                "goal": "Memahami mekanisme sambatan dan benefit",
+                "status": "ready",
+                "touchpoints": [
+                    "Panel progres besar dengan countdown dan daftar kontribusi terbaru",
+                    "Breakdown harga normal vs sambatan dan minimum slot",
+                    "CTA utama 'Gabung Sambatan' serta CTA sekunder 'Tanya Tim'",
+                ],
+                "notes": [
+                    "Banner info saat kampanye hampir penuh atau mendekati deadline",
+                    "Tooltip untuk istilah teknis dan modul FAQ ringan",
+                ],
+            },
+            {
+                "stage": "Gabung Sambatan",
+                "goal": "Memilih jumlah slot dan komitmen pembayaran",
+                "status": "in-design",
+                "touchpoints": [
+                    "Modal stepper: pilih jumlah slot → konfirmasi total → pilih metode pembayaran",
+                    "Konfirmasi bahwa dana ditahan (escrow) sampai slot terpenuhi",
+                    "Badge status 'Menunggu Slot Terpenuhi' di akhir modal",
+                ],
+                "notes": [
+                    "Notifikasi email/in-app berisi ringkasan komitmen",
+                    "Pertimbangkan progress share untuk ajak teman (link copy)",
+                ],
+            },
+            {
+                "stage": "Progres Sambatan",
+                "goal": "Memantau apakah sambatan terpenuhi",
+                "status": "in-design",
+                "touchpoints": [
+                    "Halaman profil > Sambatan Saya dengan progress radial besar",
+                    "Countdown dan CTA 'Ajak Teman' untuk membagikan kampanye",
+                    "Status otomatis berubah menjadi 'Sambatan Terkonfirmasi' saat target tercapai",
+                ],
+                "notes": [
+                    "Notifikasi otomatis ketika progress menyentuh 80%",
+                    "State fallback 'Sambatan Gagal' menampilkan estimasi refund",
+                ],
+            },
+            {
+                "stage": "Checkout Akhir",
+                "goal": "Menuntaskan detail pengiriman setelah sambatan sukses",
+                "status": "in-discovery",
+                "touchpoints": [
+                    "Redirect ke flow checkout reguler dengan harga final sambatan",
+                    "Form alamat pre-populated bila sudah pernah diisi",
+                    "Banner hijau 'Selamat! Sambatan berhasil' dengan countdown pembayaran akhir",
+                ],
+                "notes": [
+                    "Validasi ulang jadwal produksi/pengiriman batch",
+                    "Instruksi pembayaran bertahap bila metode tersebut dipilih",
+                ],
+            },
+            {
+                "stage": "Pemrosesan & Penerimaan",
+                "goal": "Menunggu produksi/pengiriman kolektif",
+                "status": "in-discovery",
+                "touchpoints": [
+                    "Timeline status menambahkan fase 'Produksi/Batching' sebelum dikirim",
+                    "Notifikasi di setiap tahapan dan update refund jika gagal",
+                    "Permintaan testimoni sambatan setelah barang tiba",
+                ],
+                "notes": [
+                    "Tampilkan estimasi waktu refund di status gagal",
+                    "Log detail tersedia untuk tim ops di dashboard",
+                ],
+            },
+        ],
+    },
+]
+
+
 @router.get("/", response_class=HTMLResponse)
 async def read_home(request: Request) -> HTMLResponse:
     """Render the marketplace landing page placeholder."""
@@ -684,3 +908,21 @@ async def read_uiux_tracker(request: Request) -> HTMLResponse:
         "sections": UIUX_IMPLEMENTATION_PLAN,
     }
     return templates.TemplateResponse("ui_ux_tracker.html", context)
+
+
+@router.get("/ui-ux/foundation/purchase", response_class=HTMLResponse)
+async def read_purchase_foundation(request: Request) -> HTMLResponse:
+    """Render the product purchase workflow blueprint derived from the foundation document."""
+
+    settings = get_settings()
+    templates = request.app.state.templates
+
+    context = {
+        "request": request,
+        "app_name": settings.app_name,
+        "environment": settings.environment,
+        "title": "Blueprint Flow Pembelian",
+        "flow_status_meta": PURCHASE_FLOW_STATUS_META,
+        "flows": PURCHASE_FLOW_BLUEPRINT,
+    }
+    return templates.TemplateResponse("purchase_workflow.html", context)

--- a/src/app/web/static/css/purchase-workflow.css
+++ b/src/app/web/static/css/purchase-workflow.css
@@ -1,0 +1,341 @@
+.purchase-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 320px);
+  gap: 2rem;
+  padding: 2.5rem;
+  align-items: start;
+}
+
+.purchase-hero .hero-copy h1 {
+  font-size: clamp(2.2rem, 3vw, 2.8rem);
+  margin-bottom: 1rem;
+}
+
+.purchase-hero .hero-copy p {
+  margin: 0;
+}
+
+.purchase-hero .badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 1rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.12);
+  color: var(--accent-secondary);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: 1.5rem;
+}
+
+.status-legend h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.35rem;
+}
+
+.status-legend ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.status-legend li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.status-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+  font-size: 1.25rem;
+}
+
+.status-label {
+  margin: 0;
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.status-description {
+  margin: 0.35rem 0 0;
+  font-size: 0.95rem;
+}
+
+.flow-nav {
+  padding: 1.75rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.flow-nav h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.flow-nav ol {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.flow-nav a {
+  color: var(--text-primary);
+  text-decoration: none;
+  font-weight: 600;
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.45);
+  transition: transform var(--transition-base), border-color var(--transition-base);
+}
+
+.flow-nav a:hover {
+  transform: translateY(-2px);
+  border-color: rgba(56, 189, 248, 0.6);
+}
+
+.flow-section {
+  padding: 2.25rem;
+  display: grid;
+  gap: 2rem;
+}
+
+.flow-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 0.8fr);
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.flow-summary {
+  color: var(--text-secondary);
+  margin-bottom: 0.75rem;
+}
+
+.flow-persona {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.flow-meta {
+  display: grid;
+  gap: 1.5rem;
+  justify-items: start;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1.2rem;
+  border-radius: 999px;
+  font-weight: 600;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.5);
+}
+
+.metric-list {
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: var(--radius-md);
+  padding: 1.25rem 1.5rem;
+  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.08);
+}
+
+.metric-list h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.1rem;
+}
+
+.metric-list ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.flow-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.flow-step {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 1.75rem;
+  box-shadow: 0 16px 45px rgba(8, 15, 29, 0.35);
+  backdrop-filter: blur(18px);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.flow-step:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 55px rgba(8, 15, 29, 0.45);
+}
+
+.step-header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 1.25rem;
+  align-items: center;
+  margin-bottom: 1.25rem;
+}
+
+.step-index {
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent-primary);
+  color: #0f172a;
+  font-weight: 700;
+  font-size: 1.2rem;
+  box-shadow: 0 12px 30px rgba(249, 115, 22, 0.25);
+}
+
+.step-stage {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.85rem;
+  color: var(--accent-secondary);
+}
+
+.step-header h3 {
+  margin: 0.25rem 0 0;
+  font-size: 1.35rem;
+}
+
+.step-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-weight: 600;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.step-body {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.step-body h4 {
+  margin-top: 0;
+  font-size: 1.05rem;
+}
+
+.step-body ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.foundation-notes {
+  padding: 2rem 2.25rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.foundation-notes ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+/* Status color accents */
+.step-status.status-live,
+.status-chip.status-live,
+.status-icon.status-live {
+  border-color: rgba(52, 211, 153, 0.4);
+  background: rgba(52, 211, 153, 0.18);
+}
+
+.step-status.status-ready,
+.status-chip.status-ready,
+.status-icon.status-ready {
+  border-color: rgba(56, 189, 248, 0.45);
+  background: rgba(56, 189, 248, 0.16);
+}
+
+.step-status.status-in-design,
+.status-chip.status-in-design,
+.status-icon.status-in-design {
+  border-color: rgba(192, 132, 252, 0.4);
+  background: rgba(192, 132, 252, 0.16);
+}
+
+.step-status.status-in-discovery,
+.status-chip.status-in-discovery,
+.status-icon.status-in-discovery {
+  border-color: rgba(248, 180, 0, 0.4);
+  background: rgba(248, 180, 0, 0.2);
+}
+
+@media (max-width: 1024px) {
+  .purchase-hero {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .status-legend {
+    order: 2;
+  }
+
+  .flow-header {
+    grid-template-columns: 1fr;
+  }
+
+  .flow-meta {
+    justify-items: stretch;
+  }
+
+  .step-body {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .purchase-hero,
+  .flow-section,
+  .foundation-notes {
+    padding: 1.75rem;
+  }
+
+  .flow-nav ol {
+    flex-direction: column;
+  }
+
+  .step-header {
+    grid-template-columns: 1fr;
+    justify-items: start;
+  }
+
+  .step-status {
+    margin-top: 0.75rem;
+  }
+}

--- a/src/app/web/templates/partials/navbar.html
+++ b/src/app/web/templates/partials/navbar.html
@@ -24,9 +24,17 @@
     <li>
       <a
         href="{{ url_for('read_uiux_tracker') }}"
-        class="{% if request.url.path.startswith('/ui-ux') %}active{% endif %}"
+        class="{% if request.url.path.startswith('/ui-ux/implementation') %}active{% endif %}"
       >
         UI/UX Tracker
+      </a>
+    </li>
+    <li>
+      <a
+        href="{{ url_for('read_purchase_foundation') }}"
+        class="{% if request.url.path.startswith('/ui-ux/foundation') %}active{% endif %}"
+      >
+        Flow Pembelian
       </a>
     </li>
     <li><a href="{{ url_for('read_home') }}#sambatan">Sambatan</a></li>

--- a/src/app/web/templates/purchase_workflow.html
+++ b/src/app/web/templates/purchase_workflow.html
@@ -1,0 +1,120 @@
+{% extends 'base.html' %}
+
+{% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/purchase-workflow.css') }}" />
+{% endblock %}
+
+{% block content %}
+<section class="purchase-hero glass-surface">
+  <div class="hero-copy">
+    <span class="badge">UI Foundation</span>
+    <h1>Blueprint workflow pembelian produk Sensasiwangi.id</h1>
+    <p>
+      Halaman ini menerjemahkan <strong>docs/ui-ux-foundation.md</strong> menjadi artefak visual
+      untuk dua skenario pembelian utama: checkout reguler dan sambatan komunitas. Informasi
+      disusun agar tim engineering dapat langsung menerapkan interaksi glassmorphism, validasi,
+      serta state notifikasi yang dibutuhkan tanpa menunggu mockup lanjutan.
+    </p>
+  </div>
+  <aside class="status-legend glass-card">
+    <h2>Status Implementasi</h2>
+    <ul>
+      {% for key, meta in flow_status_meta.items() %}
+      <li>
+        <span class="status-icon status-{{ key }}">{{ meta.icon }}</span>
+        <div>
+          <p class="status-label">{{ meta.label }}</p>
+          <p class="status-description">{{ meta.description }}</p>
+        </div>
+      </li>
+      {% endfor %}
+    </ul>
+  </aside>
+</section>
+
+<nav class="flow-nav glass-card" aria-label="Navigasi workflow">
+  <h2>Jelajahi Flow</h2>
+  <ol>
+    {% for flow in flows %}
+    <li><a href="#{{ flow.slug }}">{{ flow.title }}</a></li>
+    {% endfor %}
+  </ol>
+</nav>
+
+{% for flow in flows %}
+<section id="{{ flow.slug }}" class="flow-section glass-card">
+  <header class="flow-header">
+    <div>
+      <p class="flow-eyebrow">Blueprint</p>
+      <h2>{{ flow.title }}</h2>
+      <p class="flow-summary">{{ flow.summary }}</p>
+      <p class="flow-persona">Persona utama: <strong>{{ flow.persona }}</strong></p>
+    </div>
+    <div class="flow-meta">
+      <span class="status-chip status-{{ flow.status }}">
+        <span class="status-icon">{{ flow_status_meta[flow.status].icon }}</span>
+        {{ flow_status_meta[flow.status].label }}
+      </span>
+      <div class="metric-list">
+        <h3>Ukuran Keberhasilan</h3>
+        <ul>
+          {% for metric in flow.success_metrics %}
+          <li>{{ metric }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </header>
+
+  <ol class="flow-steps">
+    {% for step in flow.steps %}
+    <li class="flow-step" data-status="{{ step.status }}">
+      <div class="step-header">
+        <span class="step-index">{{ loop.index }}</span>
+        <div>
+          <p class="step-stage">{{ step.stage }}</p>
+          <h3>{{ step.goal }}</h3>
+        </div>
+        <span class="step-status status-{{ step.status }}">
+          <span class="status-icon">{{ flow_status_meta[step.status].icon }}</span>
+          {{ flow_status_meta[step.status].label }}
+        </span>
+      </div>
+      <div class="step-body">
+        <div class="touchpoints">
+          <h4>Touchpoint & Komponen</h4>
+          <ul>
+            {% for point in step.touchpoints %}
+            <li>{{ point }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+        <div class="notes">
+          <h4>Catatan Implementasi</h4>
+          <ul>
+            {% for note in step.notes %}
+            <li>{{ note }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </li>
+    {% endfor %}
+  </ol>
+</section>
+{% endfor %}
+
+<section class="foundation-notes glass-card">
+  <h2>Checklist Lanjutan</h2>
+  <p>
+    Pastikan integrasi teknis mengikuti <em>In Memory Session</em> dan struktur SSR FastAPI → Jinja seperti
+    yang sudah tersedia di repositori. Untuk setiap tahap, dokumentasikan endpoint atau partial template
+    yang diperlukan sehingga flow ini dapat dirangkai secara end-to-end.
+  </p>
+  <ul>
+    <li>Mapping modul backend ke setiap touchpoint agar kontrak data jelas.</li>
+    <li>Verifikasi aksesibilitas: fokus, pembaca layar, dan urutan tab saat checkout.</li>
+    <li>Rencanakan telemetry dasar (event HTMX/JS) guna mengukur metrik keberhasilan.</li>
+  </ul>
+</section>
+{% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -43,3 +43,45 @@ def test_homepage_returns_success():
         assert b"Sensasiwangi" in body
 
     asyncio.run(_run())
+
+
+def test_purchase_workflow_page_renders():
+    async def _run() -> None:
+        scope = {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/ui-ux/foundation/purchase",
+            "raw_path": b"/ui-ux/foundation/purchase",
+            "query_string": b"",
+            "headers": [],
+            "client": ("127.0.0.1", 0),
+            "server": ("testserver", 80),
+        }
+        messages: list[dict] = []
+
+        async def receive() -> dict:
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message: dict) -> None:
+            messages.append(message)
+
+        await app(scope, receive, send)
+
+        status = next(
+            (
+                message["status"]
+                for message in messages
+                if message["type"] == "http.response.start"
+            ),
+            None,
+        )
+        body = b"".join(
+            message["body"] for message in messages if message["type"] == "http.response.body"
+        )
+
+        assert status == 200
+        assert b"Blueprint workflow pembelian produk" in body
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add data structures and route to expose the purchase workflow blueprint derived from docs/ui-ux-foundation.md
- create glassmorphism template and styles to document regular and sambatan purchase flows
- surface the new page via navigation and ensure route coverage through tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d86ab207e48327a78bb116bcee9392