### PR TITLE
Implement social profile page with follow interactions

### DIFF
--- a/src/app/api/routes/profile.py
+++ b/src/app/api/routes/profile.py
@@ -1,0 +1,170 @@
+"""Profile detail and follow interaction endpoints."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import HTMLResponse
+
+from app.services.profile import (
+    ProfileError,
+    ProfileService,
+    ProfileView,
+    profile_service,
+)
+
+
+router = APIRouter(prefix="/profile", tags=["profile"])
+
+
+def get_profile_service() -> ProfileService:
+    return profile_service
+
+
+def _viewer_query_param(viewer_id: str | None) -> str:
+    return f"viewer={viewer_id}" if viewer_id else ""
+
+
+@router.get("/{username}", response_class=HTMLResponse, name="profile_detail")
+def profile_detail(
+    username: str,
+    request: Request,
+    viewer: str | None = Query(default=None),
+    service: ProfileService = Depends(get_profile_service),
+) -> HTMLResponse:
+    profile_view = service.get_profile(username, viewer_id=viewer)
+    templates = request.app.state.templates
+    context = {
+        "request": request,
+        "profile_view": profile_view,
+        "profile": profile_view.profile,
+        "stats": profile_view.stats,
+        "viewer_query": _viewer_query_param(profile_view.viewer.id),
+    }
+    return templates.TemplateResponse("pages/profile/detail.html", context)
+
+
+def _render_follow_button(
+    request: Request,
+    profile_view: ProfileView,
+) -> HTMLResponse:
+    templates = request.app.state.templates
+    context = {
+        "request": request,
+        "profile_view": profile_view,
+        "profile": profile_view.profile,
+        "stats": profile_view.stats,
+        "viewer_query": _viewer_query_param(profile_view.viewer.id),
+    }
+    return templates.TemplateResponse("components/profile/follow_button.html", context)
+
+
+@router.post("/{username}/follow", response_class=HTMLResponse, name="profile_follow")
+def follow_profile(
+    username: str,
+    request: Request,
+    viewer: str | None = Query(default=None),
+    service: ProfileService = Depends(get_profile_service),
+) -> HTMLResponse:
+    if not viewer:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Viewer wajib diisi")
+
+    try:
+        profile_view = service.follow_profile(username, follower_id=viewer)
+    except ProfileError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+
+    return _render_follow_button(request, profile_view)
+
+
+@router.delete("/{username}/follow", response_class=HTMLResponse, name="profile_unfollow")
+def unfollow_profile(
+    username: str,
+    request: Request,
+    viewer: str | None = Query(default=None),
+    service: ProfileService = Depends(get_profile_service),
+) -> HTMLResponse:
+    if not viewer:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Viewer wajib diisi")
+
+    try:
+        profile_view = service.unfollow_profile(username, follower_id=viewer)
+    except ProfileError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+
+    return _render_follow_button(request, profile_view)
+
+
+@router.get("/{username}/followers", response_class=HTMLResponse, name="profile_followers")
+def followers_modal(
+    username: str,
+    request: Request,
+    service: ProfileService = Depends(get_profile_service),
+) -> HTMLResponse:
+    followers = service.list_followers(username)
+    profile_view = service.get_profile(username)
+    templates = request.app.state.templates
+    context = {
+        "request": request,
+        "title": "Pengikut",
+        "profiles": followers,
+        "profile": profile_view.profile,
+    }
+    return templates.TemplateResponse("components/profile/user_list.html", context)
+
+
+@router.get("/{username}/following", response_class=HTMLResponse, name="profile_following")
+def following_modal(
+    username: str,
+    request: Request,
+    service: ProfileService = Depends(get_profile_service),
+) -> HTMLResponse:
+    following = service.list_following(username)
+    profile_view = service.get_profile(username)
+    templates = request.app.state.templates
+    context = {
+        "request": request,
+        "title": "Mengikuti",
+        "profiles": following,
+        "profile": profile_view.profile,
+    }
+    return templates.TemplateResponse("components/profile/user_list.html", context)
+
+
+TAB_TEMPLATES: Dict[str, str] = {
+    "aktivitas": "components/profile/tab_activity.html",
+    "favorit": "components/profile/tab_favorites.html",
+    "sambatan": "components/profile/tab_sambatan.html",
+    "karya": "components/profile/perfumer_products.html",
+    "brand": "components/profile/brand_cards.html",
+}
+
+
+@router.get("/{username}/tab/{tab}", response_class=HTMLResponse, name="profile_tab")
+def profile_tab(
+    username: str,
+    tab: str,
+    request: Request,
+    service: ProfileService = Depends(get_profile_service),
+) -> HTMLResponse:
+    tab = tab.lower()
+    if tab not in TAB_TEMPLATES:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tab tidak ditemukan")
+
+    profile_view = service.get_profile(username)
+    templates = request.app.state.templates
+
+    context = {
+        "request": request,
+        "profile_view": profile_view,
+        "profile": profile_view.profile,
+    }
+
+    if tab == "karya":
+        context["products"] = service.list_perfumer_products(username)
+    elif tab == "brand":
+        context["brands"] = service.list_owned_brands(username)
+
+    template_name = TAB_TEMPLATES[tab]
+    return templates.TemplateResponse(template_name, context)

--- a/src/app/core/application.py
+++ b/src/app/core/application.py
@@ -10,6 +10,7 @@ from app.core.config import get_settings
 from app.core.session import InMemorySessionMiddleware
 from app.web.templates import template_engine
 from app.api.routes import onboarding as onboarding_routes
+from app.api.routes import profile as profile_routes
 from app.api.routes import reports as reports_routes
 from app.api.routes import root as root_routes
 from app.api.routes import sambatan as sambatan_routes
@@ -47,6 +48,7 @@ def create_app() -> FastAPI:
     app.include_router(reports_routes.router)
     app.include_router(onboarding_routes.router)
     app.include_router(sambatan_routes.router)
+    app.include_router(profile_routes.router)
     from app.api.routes import auth as auth_routes
 
     app.include_router(auth_routes.router)

--- a/src/app/services/profile.py
+++ b/src/app/services/profile.py
@@ -1,0 +1,401 @@
+"""Profile service powering the community-centric profile page."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+class ProfileError(Exception):
+    """Base error class for profile operations."""
+
+    status_code: int = 400
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class ProfileNotFound(ProfileError):
+    """Raised when attempting to access an unknown profile."""
+
+    status_code = 404
+
+
+@dataclass
+class ProfileBadge:
+    """Represents a badge rendered on the profile header."""
+
+    slug: str
+    label: str
+    description: str
+    icon: str
+    count: Optional[int] = None
+
+
+@dataclass
+class ProfileStats:
+    """Aggregated counters displayed on the profile."""
+
+    follower_count: int
+    following_count: int
+    perfumer_product_count: int
+    owned_brand_count: int
+
+
+@dataclass
+class PerfumerProduct:
+    """Represents a product credited to a perfumer."""
+
+    id: str
+    name: str
+    brand_name: str
+    brand_slug: str
+    aroma_notes: str
+    highlight: str
+
+
+@dataclass
+class OwnedBrand:
+    """Represents a brand owned or administered by the profile."""
+
+    id: str
+    name: str
+    slug: str
+    logo_url: str
+    status: str
+    tagline: str
+
+
+@dataclass
+class TimelineEntry:
+    """Represents an activity entry shown on the profile."""
+
+    title: str
+    timestamp: str
+    description: str
+
+
+@dataclass
+class ProfileRecord:
+    """Internal representation of a user profile."""
+
+    id: str
+    username: str
+    full_name: str
+    bio: str
+    preferred_aroma: Optional[str]
+    avatar_url: Optional[str]
+    location: Optional[str]
+    tagline: Optional[str]
+    followers: set[str] = field(default_factory=set)
+    following: set[str] = field(default_factory=set)
+    perfumer_products: List[PerfumerProduct] = field(default_factory=list)
+    owned_brands: List[OwnedBrand] = field(default_factory=list)
+    activities: List[TimelineEntry] = field(default_factory=list)
+    favorites: List[str] = field(default_factory=list)
+    sambatan_updates: List[str] = field(default_factory=list)
+
+    def clone_relationships(self) -> tuple[set[str], set[str]]:
+        return set(self.followers), set(self.following)
+
+
+@dataclass
+class ProfileViewerState:
+    """Viewer metadata that determines CTA state."""
+
+    id: Optional[str]
+    is_owner: bool
+    is_following: bool
+
+    @property
+    def can_follow(self) -> bool:
+        return bool(self.id) and not self.is_owner
+
+
+@dataclass
+class ProfileView:
+    """Bundle of data required to render a profile page."""
+
+    profile: ProfileRecord
+    stats: ProfileStats
+    badges: List[ProfileBadge]
+    viewer: ProfileViewerState
+
+
+class ProfileService:
+    """Simple in-memory profile store used for SSR demos."""
+
+    def __init__(self) -> None:
+        self._profiles: Dict[str, ProfileRecord] = {}
+        self._profiles_by_username: Dict[str, ProfileRecord] = {}
+        self._initial_relationships: Dict[str, tuple[set[str], set[str]]] = {}
+        self._seed_demo_profiles()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def get_profile(self, profile_identifier: str, *, viewer_id: Optional[str] = None) -> ProfileView:
+        profile = self._resolve_profile(profile_identifier)
+
+        stats = ProfileStats(
+            follower_count=len(profile.followers),
+            following_count=len(profile.following),
+            perfumer_product_count=len(profile.perfumer_products),
+            owned_brand_count=len(profile.owned_brands),
+        )
+
+        badges: List[ProfileBadge] = []
+        if profile.perfumer_products:
+            badges.append(
+                ProfileBadge(
+                    slug="perfumer",
+                    label="Perfumer",
+                    description="Diracik pada produk marketplace Sensasiwangi.",
+                    icon="🧪",
+                    count=len(profile.perfumer_products),
+                )
+            )
+        if any(brand for brand in profile.owned_brands if brand.status == "active"):
+            badges.append(
+                ProfileBadge(
+                    slug="brand-owner",
+                    label="Brand Owner",
+                    description="Mengelola brand parfum independen di platform.",
+                    icon="🏷️",
+                    count=len(profile.owned_brands),
+                )
+            )
+
+        viewer = ProfileViewerState(
+            id=viewer_id,
+            is_owner=viewer_id == profile.id if viewer_id else False,
+            is_following=viewer_id in profile.followers if viewer_id else False,
+        )
+
+        return ProfileView(profile=profile, stats=stats, badges=badges, viewer=viewer)
+
+    def follow_profile(self, target_identifier: str, *, follower_id: str) -> ProfileView:
+        follower = self._resolve_profile(follower_id)
+        target = self._resolve_profile(target_identifier)
+
+        if follower.id == target.id:
+            raise ProfileError("Tidak dapat mengikuti profil sendiri.")
+
+        if follower.id in target.followers:
+            # Idempotent response to simplify HTMX interactions.
+            return self.get_profile(target.id, viewer_id=follower.id)
+
+        target.followers.add(follower.id)
+        follower.following.add(target.id)
+        return self.get_profile(target.id, viewer_id=follower.id)
+
+    def unfollow_profile(self, target_identifier: str, *, follower_id: str) -> ProfileView:
+        follower = self._resolve_profile(follower_id)
+        target = self._resolve_profile(target_identifier)
+
+        if follower.id == target.id:
+            raise ProfileError("Tidak dapat berhenti mengikuti profil sendiri.")
+
+        if follower.id in target.followers:
+            target.followers.remove(follower.id)
+            follower.following.remove(target.id)
+
+        return self.get_profile(target.id, viewer_id=follower.id)
+
+    def list_followers(self, profile_identifier: str) -> List[ProfileRecord]:
+        profile = self._resolve_profile(profile_identifier)
+        return sorted((self._profiles[follower_id] for follower_id in profile.followers), key=lambda p: p.full_name)
+
+    def list_following(self, profile_identifier: str) -> List[ProfileRecord]:
+        profile = self._resolve_profile(profile_identifier)
+        return sorted((self._profiles[following_id] for following_id in profile.following), key=lambda p: p.full_name)
+
+    def list_perfumer_products(self, profile_identifier: str) -> List[PerfumerProduct]:
+        profile = self._resolve_profile(profile_identifier)
+        return profile.perfumer_products
+
+    def list_owned_brands(self, profile_identifier: str) -> List[OwnedBrand]:
+        profile = self._resolve_profile(profile_identifier)
+        return profile.owned_brands
+
+    def reset_relationships(self) -> None:
+        """Reset follow relationships to the initial demo state (used in tests)."""
+
+        for profile_id, snapshot in self._initial_relationships.items():
+            followers, following = snapshot
+            profile = self._profiles[profile_id]
+            profile.followers.clear()
+            profile.followers.update(followers)
+            profile.following.clear()
+            profile.following.update(following)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _resolve_profile(self, profile_identifier: str) -> ProfileRecord:
+        if profile_identifier in self._profiles:
+            return self._profiles[profile_identifier]
+        if profile_identifier in self._profiles_by_username:
+            return self._profiles_by_username[profile_identifier]
+        raise ProfileNotFound("Profil tidak ditemukan.")
+
+    def _register_profile(self, profile: ProfileRecord) -> None:
+        self._profiles[profile.id] = profile
+        self._profiles_by_username[profile.username] = profile
+
+    def _seed_demo_profiles(self) -> None:
+        """Create demo data to satisfy the profile UX mocks."""
+
+        amelia = ProfileRecord(
+            id="user_amelia",
+            username="amelia-damayanti",
+            full_name="Amelia Damayanti",
+            bio=(
+                "Perfumer independen yang gemar mengeksplorasi aroma rempah Nusantara. "
+                "Percaya bahwa setiap wewangian punya cerita manis untuk dibagikan."
+            ),
+            preferred_aroma="Rempah hangat & floral gourmand",
+            avatar_url="https://images.unsplash.com/photo-1542293787938-4d2226c3d9f1?auto=format&fit=crop&w=300&q=80",
+            location="Bandung, Indonesia",
+            tagline="Meracik cerita wangi untuk komunitas.",
+            perfumer_products=[
+                PerfumerProduct(
+                    id="prod_langitsepia",
+                    name="Langit Sepia",
+                    brand_name="Langit Senja",
+                    brand_slug="langit-senja",
+                    aroma_notes="Bergamot • Tonka Bean • Patchouli",
+                    highlight="Racikan signature bertema golden hour dengan nuansa cozy.",
+                ),
+                PerfumerProduct(
+                    id="prod_hujanpagi",
+                    name="Hujan Pagi",
+                    brand_name="Langit Senja",
+                    brand_slug="langit-senja",
+                    aroma_notes="Rain Accord • Vetiver • White Musk",
+                    highlight="Aroma petrichor lembut yang menenangkan suasana pagi.",
+                ),
+            ],
+            owned_brands=[
+                OwnedBrand(
+                    id="brand_langitsenja",
+                    name="Langit Senja",
+                    slug="langit-senja",
+                    logo_url="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=120&q=80",
+                    status="active",
+                    tagline="Cerita aroma hangat untuk nostalgia senja.",
+                ),
+            ],
+            activities=[
+                TimelineEntry(
+                    title="Merilis batch perdana Langit Sepia",
+                    timestamp="2 hari lalu",
+                    description="Batch pertama ludes dalam 36 jam setelah teaser di komunitas PerfumeLoka.",
+                ),
+                TimelineEntry(
+                    title="Sesi live blending dengan komunitas",
+                    timestamp="1 minggu lalu",
+                    description="Berbagi proses layering rempah manis dan musk yang bisa dicoba di rumah.",
+                ),
+            ],
+            favorites=[
+                "Aroma Senopati – Rumah Wangi",
+                "Kopi Sore – SukaSuara",
+                "Damar Biru – Cahaya Laut",
+            ],
+            sambatan_updates=[
+                "Mengkurasi 12 peserta untuk Sambatan Hujan Pagi batch 2.",
+                "Membantu brand Arunika memilih packaging eco friendly.",
+            ],
+        )
+
+        bintang = ProfileRecord(
+            id="user_bintang",
+            username="bintang-waskita",
+            full_name="Bintang Waskita",
+            bio="Founder Arunika Fragrance. Fokus mengangkat aroma kopi dan cokelat Indonesia.",
+            preferred_aroma="Gourmand & woody",
+            avatar_url="https://images.unsplash.com/photo-1502323777036-f29e3972d82f?auto=format&fit=crop&w=300&q=80",
+            location="Yogyakarta, Indonesia",
+            tagline="Menguatkan rasa lokal lewat aroma.",
+            owned_brands=[
+                OwnedBrand(
+                    id="brand_arunika",
+                    name="Arunika",
+                    slug="arunika",
+                    logo_url="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=120&q=80",
+                    status="active",
+                    tagline="Eksperimen rasa kopi dan cokelat premium.",
+                ),
+            ],
+            activities=[
+                TimelineEntry(
+                    title="Memenangkan penghargaan UKM Aroma 2024",
+                    timestamp="5 hari lalu",
+                    description="Arunika terpilih sebagai brand parfum terinovatif kategori bahan lokal.",
+                ),
+            ],
+            favorites=[
+                "Langit Sepia – Langit Senja",
+                "Rimba Malam – Cahaya Laut",
+            ],
+            sambatan_updates=[
+                "Mengajak 20 anggota komunitas mencoba eksperimen Macchiato Accord.",
+            ],
+        )
+
+        chandra = ProfileRecord(
+            id="user_chandra",
+            username="chandra-pratama",
+            full_name="Chandra Pratama",
+            bio="Collector fragrance niche dan reviewer tetap di Nusantarum.",
+            preferred_aroma="Citrus aromatic",
+            avatar_url="https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=300&q=80",
+            location="Jakarta, Indonesia",
+            tagline="Berbagi insight wewangian buat pemula.",
+            activities=[
+                TimelineEntry(
+                    title="Mengulas Langit Sepia",
+                    timestamp="3 hari lalu",
+                    description="Memberi rating 4.5/5 dan highlight pada dry-down manisnya yang tahan lama.",
+                ),
+                TimelineEntry(
+                    title="Membuka diskusi komunitas tentang teknik layering",
+                    timestamp="2 minggu lalu",
+                    description="Mengulas cara memadukan citrus segar dengan gourmand berat.",
+                ),
+            ],
+            favorites=[
+                "Hujan Pagi – Langit Senja",
+                "Macchiato Drift – Arunika",
+                "Teh Senja – Rumah Wangi",
+            ],
+            sambatan_updates=[
+                "Mengikuti Sambatan Macchiato Drift batch 1.",
+            ],
+        )
+
+        # Register demo profiles.
+        for profile in (amelia, bintang, chandra):
+            self._register_profile(profile)
+
+        # Establish initial follow graph.
+        amelia.followers.update({"user_bintang", "user_chandra"})
+        amelia.following.update({"user_bintang"})
+
+        bintang.followers.update({"user_chandra"})
+        bintang.following.update({"user_amelia"})
+
+        chandra.followers.update(set())
+        chandra.following.update({"user_amelia", "user_bintang"})
+
+        # Snapshot initial relationships for test resets.
+        self._initial_relationships = {
+            profile.id: profile.clone_relationships() for profile in (amelia, bintang, chandra)
+        }
+
+
+profile_service = ProfileService()
+"""Singleton profile service instance shared across routers and tests."""
+

--- a/src/app/web/static/css/profile.css
+++ b/src/app/web/static/css/profile.css
@@ -1,0 +1,487 @@
+.profile-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.glass-panel {
+  backdrop-filter: blur(24px) saturate(160%);
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.75), rgba(30, 41, 59, 0.55));
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 25px 45px rgba(8, 15, 29, 0.45);
+}
+
+.profile-hero {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 2rem;
+  padding: 2.5rem;
+  align-items: center;
+}
+
+.profile-hero__avatar {
+  width: 160px;
+  height: 160px;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 3px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 14px 28px rgba(8, 15, 29, 0.4);
+}
+
+.profile-hero__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-hero__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.profile-hero__headline {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: start;
+}
+
+.profile-hero__headline h1 {
+  margin: 0;
+  font-size: clamp(2.1rem, 2vw + 1.2rem, 2.6rem);
+}
+
+.profile-hero__username {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.profile-hero__bio {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--text-secondary);
+}
+
+.profile-hero__meta {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+  padding: 0;
+  margin: 0;
+  color: var(--muted);
+}
+
+.profile-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.profile-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.profile-badge__label {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.profile-badge__meta {
+  font-size: 0.9rem;
+  color: var(--accent-secondary);
+}
+
+.profile-badge--perfumer {
+  background: linear-gradient(135deg, rgba(192, 38, 211, 0.25), rgba(14, 116, 144, 0.15));
+  border-color: rgba(192, 38, 211, 0.35);
+}
+
+.profile-badge--brand-owner {
+  background: linear-gradient(135deg, rgba(249, 115, 22, 0.25), rgba(244, 114, 182, 0.18));
+  border-color: rgba(249, 115, 22, 0.35);
+}
+
+.profile-follow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.profile-follow__button,
+.profile-follow__edit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.65rem 1.8rem;
+  font-weight: 600;
+  background: var(--accent-primary);
+  color: #0f172a;
+  border: none;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+  box-shadow: 0 16px 30px rgba(192, 38, 211, 0.35);
+}
+
+.profile-follow__button:hover,
+.profile-follow__edit:hover {
+  transform: translateY(-2px);
+}
+
+.profile-follow__button--muted {
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--text-primary);
+  box-shadow: none;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.profile-follow__button--ghost {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: var(--text-secondary);
+  box-shadow: none;
+}
+
+.profile-follow__button--ghost:hover {
+  color: var(--text-primary);
+}
+
+.profile-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  padding: 1.5rem 2rem;
+}
+
+.profile-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  text-align: center;
+}
+
+.profile-stat__label {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.profile-stat__value {
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+  transition: color var(--transition-base), transform var(--transition-base);
+}
+
+.profile-stat__value:hover {
+  color: var(--accent-secondary);
+  transform: translateY(-2px);
+}
+
+.profile-tabs {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.profile-tabs__nav {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+.profile-tabs__button {
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+  background: rgba(148, 163, 184, 0.14);
+  border: 1px solid transparent;
+  color: var(--text-secondary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-base), border var(--transition-base);
+}
+
+.profile-tabs__button--active,
+.profile-tabs__button:hover {
+  background: rgba(56, 189, 248, 0.18);
+  border-color: rgba(56, 189, 248, 0.35);
+  color: var(--text-primary);
+}
+
+.profile-tabs__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.profile-timeline {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0;
+  margin: 0;
+}
+
+.profile-timeline__item {
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.profile-timeline__title {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.profile-timeline__time {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.profile-list {
+  list-style: none;
+  padding: 1.25rem 1.5rem;
+  margin: 0;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.profile-list__item {
+  color: var(--text-secondary);
+}
+
+.profile-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+}
+
+.profile-card {
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.profile-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 40px rgba(8, 15, 29, 0.45);
+}
+
+.profile-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.profile-card__title {
+  margin: 0;
+}
+
+.profile-card__brand {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.profile-card__notes {
+  margin: 0;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.profile-card__highlight {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.profile-card__cta {
+  align-self: flex-start;
+  padding: 0.55rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid rgba(56, 189, 248, 0.45);
+  color: var(--accent-secondary);
+  text-decoration: none;
+  font-weight: 600;
+  transition: background var(--transition-base), color var(--transition-base);
+}
+
+.profile-card__cta:hover {
+  background: rgba(56, 189, 248, 0.15);
+  color: var(--text-primary);
+}
+
+.profile-card__badge {
+  padding: 0.3rem 0.8rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  background: rgba(148, 163, 184, 0.18);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  text-transform: capitalize;
+}
+
+.profile-card__badge--active {
+  background: rgba(56, 189, 248, 0.2);
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.profile-empty {
+  padding: 2rem;
+  text-align: center;
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  color: var(--text-secondary);
+}
+
+.profile-empty--subtle {
+  padding: 1rem 1.25rem;
+  border-style: solid;
+}
+
+.profile-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.profile-modal__overlay {
+  position: fixed;
+  inset: 0;
+  backdrop-filter: blur(6px);
+  background: rgba(8, 15, 29, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+  padding: 2rem;
+}
+
+.profile-modal__content {
+  width: min(420px, 100%);
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.profile-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.profile-modal__header h2 {
+  margin: 0;
+}
+
+.profile-modal__close {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+
+.profile-modal__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.profile-modal__item {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.profile-modal__avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(148, 163, 184, 0.2);
+  font-weight: 600;
+}
+
+.profile-modal__name {
+  font-weight: 600;
+}
+
+.profile-modal__username {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.profile-modal__empty {
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 768px) {
+  .profile-hero {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .profile-hero__headline {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .profile-follow {
+    justify-content: center;
+  }
+
+  .profile-stats {
+    grid-template-columns: repeat(2, minmax(120px, 1fr));
+    padding: 1.25rem;
+  }
+
+  .profile-tabs {
+    padding: 1.5rem;
+  }
+}

--- a/src/app/web/templates/components/profile/badge.html
+++ b/src/app/web/templates/components/profile/badge.html
@@ -1,0 +1,8 @@
+<div class="profile-badge profile-badge--{{ badge.slug }}" role="presentation">
+  <span class="profile-badge__icon" aria-hidden="true">{{ badge.icon }}</span>
+  <span class="profile-badge__label">{{ badge.label }}</span>
+  {% if badge.count is not none %}
+    <span class="profile-badge__meta">{{ badge.count }}</span>
+  {% endif %}
+  <span class="sr-only">{{ badge.description }}</span>
+</div>

--- a/src/app/web/templates/components/profile/brand_cards.html
+++ b/src/app/web/templates/components/profile/brand_cards.html
@@ -1,0 +1,19 @@
+{% if brands %}
+  <div class="profile-grid">
+    {% for brand in brands %}
+      <article class="profile-card glass-panel" aria-label="Brand {{ brand.name }}">
+        <div class="profile-card__header">
+          <h3 class="profile-card__title">{{ brand.name }}</h3>
+          <span class="profile-card__badge profile-card__badge--{{ brand.status }}">{{ brand.status|capitalize }}</span>
+        </div>
+        <p class="profile-card__notes">{{ brand.tagline }}</p>
+        <a class="profile-card__cta" href="/brands/{{ brand.slug }}">Kunjungi brand</a>
+      </article>
+    {% endfor %}
+  </div>
+{% else %}
+  <div class="profile-empty glass-panel">
+    <h3>Belum memiliki brand</h3>
+    <p>Ciptakan brand pertamamu dan tampilkan identitas unikmu di komunitas.</p>
+  </div>
+{% endif %}

--- a/src/app/web/templates/components/profile/follow_button.html
+++ b/src/app/web/templates/components/profile/follow_button.html
@@ -1,0 +1,32 @@
+<div id="profile-follow-button" class="profile-follow">
+  {% if profile_view.viewer.is_owner %}
+    <a href="#" class="profile-follow__edit" aria-label="Edit profil">Edit Profil</a>
+  {% elif profile_view.viewer.is_following %}
+    {% set unfollow_url = request.url_for('profile_unfollow', username=profile.username) %}
+    <form
+      hx-delete="{{ unfollow_url }}{% if viewer_query %}?{{ viewer_query }}{% endif %}"
+      hx-target="#profile-follow-button"
+      hx-swap="outerHTML"
+      class="profile-follow__form"
+    >
+      <button type="submit" class="profile-follow__button profile-follow__button--muted">Mengikuti</button>
+    </form>
+  {% elif profile_view.viewer.can_follow %}
+    {% set follow_url = request.url_for('profile_follow', username=profile.username) %}
+    <form
+      hx-post="{{ follow_url }}{% if viewer_query %}?{{ viewer_query }}{% endif %}"
+      hx-target="#profile-follow-button"
+      hx-swap="outerHTML"
+      class="profile-follow__form"
+    >
+      <button type="submit" class="profile-follow__button">Ikuti</button>
+    </form>
+  {% else %}
+    <a href="/auth" class="profile-follow__button profile-follow__button--ghost">Masuk untuk mengikuti</a>
+  {% endif %}
+</div>
+{% if request.headers.get('hx-request') %}
+  <div hx-swap-oob="true" id="profile-community-stats">
+    {% include 'components/profile/stats.html' %}
+  </div>
+{% endif %}

--- a/src/app/web/templates/components/profile/perfumer_products.html
+++ b/src/app/web/templates/components/profile/perfumer_products.html
@@ -1,0 +1,20 @@
+{% if products %}
+  <div class="profile-grid">
+    {% for product in products %}
+      <article class="profile-card glass-panel" aria-label="Produk racikan {{ product.name }}">
+        <div class="profile-card__header">
+          <h3 class="profile-card__title">{{ product.name }}</h3>
+          <span class="profile-card__brand">{{ product.brand_name }}</span>
+        </div>
+        <p class="profile-card__notes">{{ product.aroma_notes }}</p>
+        <p class="profile-card__highlight">{{ product.highlight }}</p>
+        <a class="profile-card__cta" href="/marketplace/{{ product.brand_slug }}">Lihat detail</a>
+      </article>
+    {% endfor %}
+  </div>
+{% else %}
+  <div class="profile-empty glass-panel">
+    <h3>Belum ada karya perfumer</h3>
+    <p>Ajak brand favoritmu menandai profil ini sebagai perfumer kolaborator.</p>
+  </div>
+{% endif %}

--- a/src/app/web/templates/components/profile/stats.html
+++ b/src/app/web/templates/components/profile/stats.html
@@ -1,0 +1,32 @@
+{% set follower_url = request.url_for('profile_followers', username=profile.username) %}
+{% set following_url = request.url_for('profile_following', username=profile.username) %}
+<section id="profile-community-stats" class="profile-stats glass-panel" aria-label="Statistik komunitas">
+  <div class="profile-stat">
+    <span class="profile-stat__label">Pengikut</span>
+    <button
+      class="profile-stat__value"
+      type="button"
+      hx-get="{{ follower_url }}"
+      hx-target="#profile-modal"
+      hx-trigger="click"
+    >{{ stats.follower_count }}</button>
+  </div>
+  <div class="profile-stat">
+    <span class="profile-stat__label">Mengikuti</span>
+    <button
+      class="profile-stat__value"
+      type="button"
+      hx-get="{{ following_url }}"
+      hx-target="#profile-modal"
+      hx-trigger="click"
+    >{{ stats.following_count }}</button>
+  </div>
+  <div class="profile-stat">
+    <span class="profile-stat__label">Karya Perfumer</span>
+    <span class="profile-stat__value" aria-live="polite">{{ stats.perfumer_product_count }}</span>
+  </div>
+  <div class="profile-stat">
+    <span class="profile-stat__label">Brand Dimiliki</span>
+    <span class="profile-stat__value" aria-live="polite">{{ stats.owned_brand_count }}</span>
+  </div>
+</section>

--- a/src/app/web/templates/components/profile/tab_activity.html
+++ b/src/app/web/templates/components/profile/tab_activity.html
@@ -1,0 +1,16 @@
+{% if profile.activities %}
+  <ul class="profile-timeline">
+    {% for activity in profile.activities %}
+      <li class="profile-timeline__item glass-panel">
+        <h3 class="profile-timeline__title">{{ activity.title }}</h3>
+        <span class="profile-timeline__time">{{ activity.timestamp }}</span>
+        <p class="profile-timeline__description">{{ activity.description }}</p>
+      </li>
+    {% endfor %}
+  </ul>
+{% else %}
+  <div class="profile-empty glass-panel">
+    <h3>Belum ada aktivitas publik</h3>
+    <p>Aktivitas terbaru profil akan tampil di sini setelah kolaborasi pertama.</p>
+  </div>
+{% endif %}

--- a/src/app/web/templates/components/profile/tab_favorites.html
+++ b/src/app/web/templates/components/profile/tab_favorites.html
@@ -1,0 +1,12 @@
+{% if profile.favorites %}
+  <ul class="profile-list glass-panel">
+    {% for favorite in profile.favorites %}
+      <li class="profile-list__item">{{ favorite }}</li>
+    {% endfor %}
+  </ul>
+{% else %}
+  <div class="profile-empty glass-panel">
+    <h3>Belum ada produk favorit</h3>
+    <p>Tambahkan produk favorit untuk menunjukkan selera aromamu ke komunitas.</p>
+  </div>
+{% endif %}

--- a/src/app/web/templates/components/profile/tab_sambatan.html
+++ b/src/app/web/templates/components/profile/tab_sambatan.html
@@ -1,0 +1,12 @@
+{% if profile.sambatan_updates %}
+  <ul class="profile-list glass-panel">
+    {% for update in profile.sambatan_updates %}
+      <li class="profile-list__item">{{ update }}</li>
+    {% endfor %}
+  </ul>
+{% else %}
+  <div class="profile-empty glass-panel">
+    <h3>Belum ada aktivitas Sambatan</h3>
+    <p>Kolaborasi Sambatan akan tampil di sini untuk menunjukkan dampak komunitasmu.</p>
+  </div>
+{% endif %}

--- a/src/app/web/templates/components/profile/user_list.html
+++ b/src/app/web/templates/components/profile/user_list.html
@@ -1,0 +1,27 @@
+<div class="profile-modal__overlay" role="dialog" aria-modal="true" aria-label="{{ title }}">
+  <div class="profile-modal__content glass-panel">
+    <header class="profile-modal__header">
+      <h2>{{ title }}</h2>
+      <button
+        class="profile-modal__close"
+        type="button"
+        hx-on="click: document.getElementById('profile-modal').innerHTML = ''"
+      >✕</button>
+    </header>
+    {% if profiles %}
+      <ul class="profile-modal__list">
+        {% for item in profiles %}
+          <li class="profile-modal__item">
+            <span class="profile-modal__avatar" aria-hidden="true">{{ item.full_name[:1] }}</span>
+            <div class="profile-modal__meta">
+              <span class="profile-modal__name">{{ item.full_name }}</span>
+              <span class="profile-modal__username">@{{ item.username }}</span>
+            </div>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="profile-modal__empty">Belum ada data untuk ditampilkan.</p>
+    {% endif %}
+  </div>
+</div>

--- a/src/app/web/templates/pages/profile/detail.html
+++ b/src/app/web/templates/pages/profile/detail.html
@@ -1,0 +1,119 @@
+{% extends "base.html" %}
+
+{% block head_extra %}
+  {{ super() }}
+  <link rel="stylesheet" href="{{ url_for('static', path='css/profile.css') }}" />
+{% endblock %}
+
+{% block body_scripts %}
+  {{ super() }}
+  <script>
+    document.addEventListener("click", function (event) {
+      const button = event.target.closest(".profile-tabs__button");
+      if (!button) {
+        return;
+      }
+      const nav = button.parentElement;
+      if (!nav) {
+        return;
+      }
+      nav.querySelectorAll(".profile-tabs__button").forEach((item) => {
+        item.classList.remove("profile-tabs__button--active");
+      });
+      button.classList.add("profile-tabs__button--active");
+    });
+  </script>
+{% endblock %}
+
+{% block content %}
+  <section class="profile-page">
+    <header class="profile-hero glass-panel">
+      <div class="profile-hero__avatar">
+        <img src="{{ profile.avatar_url }}" alt="{{ profile.full_name }}" />
+      </div>
+      <div class="profile-hero__content">
+        <div class="profile-hero__headline">
+          <div>
+            <h1>{{ profile.full_name }}</h1>
+            <p class="profile-hero__username">@{{ profile.username }}</p>
+          </div>
+          {% include 'components/profile/follow_button.html' %}
+        </div>
+        <p class="profile-hero__bio">{{ profile.bio }}</p>
+        <ul class="profile-hero__meta">
+          {% if profile.tagline %}
+            <li>{{ profile.tagline }}</li>
+          {% endif %}
+          {% if profile.preferred_aroma %}
+            <li>Preferensi aroma: <strong>{{ profile.preferred_aroma }}</strong></li>
+          {% endif %}
+          {% if profile.location %}
+            <li>Domisili: {{ profile.location }}</li>
+          {% endif %}
+        </ul>
+        {% if profile_view.badges %}
+          <div class="profile-badges" role="list">
+            {% for badge in profile_view.badges %}
+              {% include 'components/profile/badge.html' with context %}
+            {% endfor %}
+          </div>
+        {% else %}
+          <div class="profile-empty profile-empty--subtle">
+            <p>Belum ada badge aktif. Kolaborasi dengan brand untuk menampilkan pencapaianmu.</p>
+          </div>
+        {% endif %}
+      </div>
+    </header>
+
+    {% include 'components/profile/stats.html' %}
+
+    <section class="profile-tabs glass-panel" aria-label="Konten profil">
+      <div class="profile-tabs__nav" role="tablist">
+        <button
+          class="profile-tabs__button profile-tabs__button--active"
+          type="button"
+          data-tab="aktivitas"
+          hx-get="{{ request.url_for('profile_tab', username=profile.username, tab='aktivitas') }}"
+          hx-target="#profile-tab-content"
+          hx-swap="innerHTML"
+        >Aktivitas</button>
+        <button
+          class="profile-tabs__button"
+          type="button"
+          data-tab="favorit"
+          hx-get="{{ request.url_for('profile_tab', username=profile.username, tab='favorit') }}"
+          hx-target="#profile-tab-content"
+          hx-swap="innerHTML"
+        >Favorit</button>
+        <button
+          class="profile-tabs__button"
+          type="button"
+          data-tab="sambatan"
+          hx-get="{{ request.url_for('profile_tab', username=profile.username, tab='sambatan') }}"
+          hx-target="#profile-tab-content"
+          hx-swap="innerHTML"
+        >Sambatan</button>
+        <button
+          class="profile-tabs__button"
+          type="button"
+          data-tab="karya"
+          hx-get="{{ request.url_for('profile_tab', username=profile.username, tab='karya') }}"
+          hx-target="#profile-tab-content"
+          hx-swap="innerHTML"
+        >Karya Perfumer</button>
+        <button
+          class="profile-tabs__button"
+          type="button"
+          data-tab="brand"
+          hx-get="{{ request.url_for('profile_tab', username=profile.username, tab='brand') }}"
+          hx-target="#profile-tab-content"
+          hx-swap="innerHTML"
+        >Brand Dimiliki</button>
+      </div>
+      <div id="profile-tab-content" class="profile-tabs__content">
+        {% include 'components/profile/tab_activity.html' %}
+      </div>
+    </section>
+  </section>
+  <div id="profile-modal" class="profile-modal" aria-live="polite"></div>
+{% endblock %}

--- a/supabase/migrations/0002_profile_social_graph.sql
+++ b/supabase/migrations/0002_profile_social_graph.sql
@@ -1,0 +1,71 @@
+-- Profile social graph, perfumer tagging, and brand summary expansion
+-- Implements the schema additions required by docs/user-profile-feature-plan.md
+
+set check_function_bodies = off;
+set search_path = public;
+
+-- ---------------------------------------------------------------------------
+-- User follow relationships
+-- ---------------------------------------------------------------------------
+
+create table if not exists user_follows (
+    follower_id uuid references user_profiles(id) on delete cascade,
+    following_id uuid references user_profiles(id) on delete cascade,
+    created_at timestamptz default timezone('utc', now()),
+    constraint user_follows_pkey primary key (follower_id, following_id),
+    constraint user_follows_no_self_follow check (follower_id <> following_id)
+);
+
+create index if not exists idx_user_follows_following on user_follows (following_id);
+create index if not exists idx_user_follows_follower on user_follows (follower_id);
+
+-- ---------------------------------------------------------------------------
+-- Perfumer tagging for marketplace products
+-- ---------------------------------------------------------------------------
+
+create table if not exists product_perfumers (
+    product_id uuid not null references products(id) on delete cascade,
+    perfumer_profile_id uuid not null references user_profiles(id) on delete cascade,
+    role text default 'lead',
+    assigned_by uuid references user_profiles(id),
+    assigned_at timestamptz default timezone('utc', now()),
+    notes text,
+    constraint product_perfumers_pkey primary key (product_id, perfumer_profile_id)
+);
+
+-- ---------------------------------------------------------------------------
+-- Brand ownership summary view for quick profile lookups
+-- ---------------------------------------------------------------------------
+
+create or replace view profile_brand_summary as
+select
+    bm.profile_id,
+    b.id as brand_id,
+    b.name,
+    b.slug,
+    b.logo_path,
+    bm.role,
+    b.status,
+    b.tagline
+from brand_members bm
+join brands b on b.id = bm.brand_id
+where bm.role in ('owner', 'admin');
+
+-- ---------------------------------------------------------------------------
+-- Profile aggregated statistics to speed up SSR rendering
+-- ---------------------------------------------------------------------------
+
+create or replace view user_profile_stats as
+select
+    p.id as profile_id,
+    count(distinct f.following_id) filter (where f.follower_id = p.id) as following_count,
+    count(distinct f.follower_id) filter (where f.following_id = p.id) as follower_count,
+    count(distinct pp.product_id) as perfumer_product_count,
+    count(distinct case when bm.role = 'owner' then bm.brand_id end) as owned_brand_count
+from user_profiles p
+left join user_follows f on f.follower_id = p.id or f.following_id = p.id
+left join product_perfumers pp on pp.perfumer_profile_id = p.id
+left join brand_members bm on bm.profile_id = p.id
+group by p.id;
+
+-- End of migration ----------------------------------------------------------

--- a/tests/test_profile_api.py
+++ b/tests/test_profile_api.py
@@ -1,0 +1,105 @@
+import asyncio
+from urllib.parse import urlsplit
+
+import pytest
+
+from app.main import app
+from app.services.profile import profile_service
+
+
+async def _request(method: str, raw_path: str, headers: dict[str, str] | None = None) -> tuple[int, str]:
+    parsed = urlsplit(raw_path)
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": parsed.path,
+        "raw_path": raw_path.encode(),
+        "query_string": parsed.query.encode(),
+        "headers": [],
+        "client": ("127.0.0.1", 0),
+        "server": ("testserver", 80),
+    }
+
+    if headers:
+        scope["headers"] = [
+            (key.lower().encode(), value.encode()) for key, value in headers.items()
+        ]
+
+    messages: list[dict] = []
+
+    async def receive() -> dict:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: dict) -> None:
+        messages.append(message)
+
+    await app(scope, receive, send)
+
+    status = next(
+        message["status"]
+        for message in messages
+        if message["type"] == "http.response.start"
+    )
+    body = b"".join(
+        message["body"] for message in messages if message["type"] == "http.response.body"
+    )
+    return status, body.decode()
+
+
+def request(method: str, raw_path: str, headers: dict[str, str] | None = None) -> tuple[int, str]:
+    return asyncio.run(_request(method, raw_path, headers))
+
+
+@pytest.fixture(autouse=True)
+def reset_profile_state() -> None:
+    profile_service.reset_relationships()
+    yield
+    profile_service.reset_relationships()
+
+
+def test_profile_detail_page_renders() -> None:
+    status, body = request("GET", "/profile/amelia-damayanti?viewer=user_chandra")
+
+    assert status == 200
+    assert "Amelia Damayanti" in body
+    assert "Perfumer" in body
+
+
+def test_profile_tab_endpoint_returns_perfumer_products() -> None:
+    status, body = request("GET", "/profile/amelia-damayanti/tab/karya")
+
+    assert status == 200
+    assert "Langit Sepia" in body
+
+
+def test_follow_and_unfollow_flow_via_htmx() -> None:
+    status_follow, follow_body = request(
+        "POST",
+        "/profile/chandra-pratama/follow?viewer=user_bintang",
+        headers={"hx-request": "true"},
+    )
+    assert status_follow == 200
+    assert "Mengikuti" in follow_body
+
+    view = profile_service.get_profile("chandra-pratama", viewer_id="user_bintang")
+    assert view.viewer.is_following is True
+
+    status_unfollow, unfollow_body = request(
+        "DELETE",
+        "/profile/chandra-pratama/follow?viewer=user_bintang",
+        headers={"hx-request": "true"},
+    )
+    assert status_unfollow == 200
+    assert "Ikuti" in unfollow_body
+
+    view_after = profile_service.get_profile("chandra-pratama", viewer_id="user_bintang")
+    assert view_after.viewer.is_following is False
+
+
+def test_followers_modal_lists_profiles() -> None:
+    status, body = request("GET", "/profile/amelia-damayanti/followers")
+
+    assert status == 200
+    assert "Bintang Waskita" in body

--- a/tests/test_profile_service.py
+++ b/tests/test_profile_service.py
@@ -1,0 +1,42 @@
+import pytest
+
+from app.services.profile import ProfileError, profile_service
+
+
+@pytest.fixture(autouse=True)
+def reset_profile_service() -> None:
+    profile_service.reset_relationships()
+    yield
+    profile_service.reset_relationships()
+
+
+def test_get_profile_returns_badges_and_stats() -> None:
+    view = profile_service.get_profile("amelia-damayanti")
+
+    assert view.profile.full_name == "Amelia Damayanti"
+    assert view.stats.follower_count == 2
+    badge_slugs = {badge.slug for badge in view.badges}
+    assert "perfumer" in badge_slugs
+    assert "brand-owner" in badge_slugs
+
+
+def test_follow_profile_updates_relationship() -> None:
+    view = profile_service.follow_profile("chandra-pratama", follower_id="user_bintang")
+
+    assert view.stats.follower_count >= 1
+    viewer_state = profile_service.get_profile("chandra-pratama", viewer_id="user_bintang").viewer
+    assert viewer_state.is_following is True
+
+
+def test_unfollow_profile_resets_relationship() -> None:
+    profile_service.follow_profile("chandra-pratama", follower_id="user_bintang")
+    view = profile_service.unfollow_profile("chandra-pratama", follower_id="user_bintang")
+
+    assert view.stats.follower_count >= 0
+    viewer_state = profile_service.get_profile("chandra-pratama", viewer_id="user_bintang").viewer
+    assert viewer_state.is_following is False
+
+
+def test_cannot_follow_self() -> None:
+    with pytest.raises(ProfileError):
+        profile_service.follow_profile("user_bintang", follower_id="user_bintang")


### PR DESCRIPTION
## Summary
- add Supabase migration covering user follows, perfumer tags, and stats view
- implement in-memory profile service plus FastAPI endpoints and HTMX partials for profile, follow, and tabs
- build glassmorphism profile templates, CSS, and tests exercising service and ASGI flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d894072e888327bbff7331ccb08a4b