### PR TITLE
Add brand logo upload affordance

### DIFF
--- a/src/app/api/routes/brands.py
+++ b/src/app/api/routes/brands.py
@@ -1,0 +1,51 @@
+"""Routes for the brand storefront experience."""
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse
+
+from app.core.config import get_settings
+from app.services.brands import BrandNotFound, brand_service
+
+
+router = APIRouter()
+
+
+@router.get("/brands/{slug}", response_class=HTMLResponse)
+async def read_brand(request: Request, slug: str) -> HTMLResponse:
+    """Render the public brand page with collaboration summary."""
+
+    templates = request.app.state.templates
+    settings = get_settings()
+
+    try:
+        brand = brand_service.get_brand(slug)
+    except BrandNotFound as exc:  # pragma: no cover - handled via exception mapping
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    context = {
+        "request": request,
+        "app_name": settings.app_name,
+        "environment": settings.environment,
+        "title": brand.name,
+        "brand": brand,
+    }
+    return templates.TemplateResponse("pages/brand/detail.html", context)
+
+
+@router.get("/brands", response_class=HTMLResponse)
+async def list_brands(request: Request) -> HTMLResponse:
+    """Simple directory view to help merchant explore brand pages."""
+
+    templates = request.app.state.templates
+    settings = get_settings()
+    brands = list(brand_service.list_brands())
+
+    context = {
+        "request": request,
+        "app_name": settings.app_name,
+        "environment": settings.environment,
+        "title": "Brand Partner",
+        "brands": brands,
+    }
+    return templates.TemplateResponse("pages/brand/index.html", context)
+

--- a/src/app/api/routes/root.py
+++ b/src/app/api/routes/root.py
@@ -770,6 +770,7 @@ async def read_marketplace(request: Request) -> HTMLResponse:
                 {
                     "name": "Rimba Embun",
                     "origin": "Atar Nusantara",
+                    "brand_slug": "atar-nusantara",
                     "origin_type": "Brand Partner",
                     "category": "Parfum Artisan",
                     "notes": ["Jasmine sambac", "Vetiver Bali", "Cedar Atlas"],
@@ -781,6 +782,7 @@ async def read_marketplace(request: Request) -> HTMLResponse:
                 {
                     "name": "Pelangi Senja",
                     "origin": "Studio Senja",
+                    "brand_slug": "studio-senja",
                     "origin_type": "Brand Partner",
                     "category": "Signature Blend",
                     "notes": ["Ylang-ylang", "Patchouli Sulawesi", "Amber Praline"],
@@ -849,6 +851,7 @@ async def read_marketplace(request: Request) -> HTMLResponse:
                 {
                     "name": "Timbangan Digital 0.01g",
                     "origin": "Studio Senja",
+                    "brand_slug": "studio-senja",
                     "origin_type": "Brand Partner",
                     "category": "Peralatan Produksi",
                     "description": "Akurasi 0.01g dengan kalibrasi otomatis dan penutup kaca mini.",

--- a/src/app/core/application.py
+++ b/src/app/core/application.py
@@ -14,6 +14,7 @@ from app.api.routes import profile as profile_routes
 from app.api.routes import reports as reports_routes
 from app.api.routes import root as root_routes
 from app.api.routes import sambatan as sambatan_routes
+from app.api.routes import brands as brand_routes
 
 STATIC_DIR = Path(__file__).resolve().parent.parent / "web" / "static"
 
@@ -45,6 +46,7 @@ def create_app() -> FastAPI:
 
     # Register routers for server-rendered pages and API endpoints.
     app.include_router(root_routes.router)
+    app.include_router(brand_routes.router)
     app.include_router(reports_routes.router)
     app.include_router(onboarding_routes.router)
     app.include_router(sambatan_routes.router)

--- a/src/app/services/__init__.py
+++ b/src/app/services/__init__.py
@@ -1,6 +1,7 @@
 """Service exports for convenience."""
 
 from .auth import AuthService, auth_service
+from .brands import BrandService, brand_service
 from .onboarding import OnboardingService, onboarding_service
 from .products import ProductService, product_service
 from .sambatan import (
@@ -13,6 +14,8 @@ from .sambatan import (
 __all__ = [
     "AuthService",
     "auth_service",
+    "BrandService",
+    "brand_service",
     "OnboardingService",
     "onboarding_service",
     "ProductService",

--- a/src/app/services/brands.py
+++ b/src/app/services/brands.py
@@ -1,0 +1,444 @@
+"""In-memory brand catalog and collaboration workflow service."""
+
+from __future__ import annotations
+
+import secrets
+import unicodedata
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional
+
+
+class BrandError(Exception):
+    """Base error raised for invalid brand operations."""
+
+    status_code: int = 400
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class BrandNotFound(BrandError):
+    """Raised when attempting to access an unknown brand."""
+
+    status_code = 404
+
+
+class BrandAlreadyExists(BrandError):
+    """Raised when trying to create a duplicate brand."""
+
+
+class BrandMemberExists(BrandError):
+    """Raised when inviting a member that already has a role in the brand."""
+
+
+@dataclass
+class BrandMember:
+    """Represents a brand collaborator with a specific role."""
+
+    profile_id: str
+    full_name: str
+    username: str
+    role: str
+    status: str
+    avatar_url: Optional[str] = None
+    expertise: Optional[str] = None
+    invited_by: Optional[str] = None
+
+    @property
+    def is_pending(self) -> bool:
+        return self.status == "pending"
+
+
+@dataclass
+class BrandProduct:
+    """Represents a product highlighted on the brand page."""
+
+    id: str
+    name: str
+    slug: str
+    price_label: str
+    hero_note: str
+    availability: str
+    is_sambatan: bool = False
+
+
+@dataclass
+class BrandHighlight:
+    """Represents a recognition or milestone achieved by the brand."""
+
+    title: str
+    description: str
+    timestamp: str
+
+
+@dataclass
+class Brand:
+    """Rich brand record powering the public brand page."""
+
+    id: str
+    name: str
+    slug: str
+    tagline: str
+    summary: str
+    origin_city: str
+    established_year: int
+    hero_image_url: str
+    aroma_focus: List[str]
+    story_points: List[str]
+    logo_url: Optional[str] = None
+    is_verified: bool = False
+    members: List[BrandMember] = field(default_factory=list)
+    products: List[BrandProduct] = field(default_factory=list)
+    highlights: List[BrandHighlight] = field(default_factory=list)
+
+    def list_members_by_status(self, status: str) -> List[BrandMember]:
+        return [member for member in self.members if member.status == status]
+
+    def list_active_members(self) -> List[BrandMember]:
+        return self.list_members_by_status("active")
+
+    def list_pending_members(self) -> List[BrandMember]:
+        return self.list_members_by_status("pending")
+
+    def list_owners(self) -> List[BrandMember]:
+        return [member for member in self.list_active_members() if member.role == "owner"]
+
+    @property
+    def description(self) -> str:
+        """Alias to expose summary as a richer description in templates."""
+
+        return self.summary
+
+
+def _slugify(value: str) -> str:
+    """Generate a slug suitable for URLs from arbitrary input."""
+
+    normalized = unicodedata.normalize("NFKD", value)
+    ascii_value = normalized.encode("ascii", "ignore").decode("ascii")
+    slug = "-".join(part for part in ascii_value.lower().split() if part)
+    return slug or secrets.token_urlsafe(6)
+
+
+class BrandService:
+    """Minimal service to manage brand storefronts for the MVP."""
+
+    def __init__(self) -> None:
+        self._brands: Dict[str, Brand] = {}
+        self._brands_by_slug: Dict[str, Brand] = {}
+        self._seed_demo_brands()
+
+    # ------------------------------------------------------------------
+    # Read operations
+    # ------------------------------------------------------------------
+    def list_brands(self) -> Iterable[Brand]:
+        return sorted(self._brands.values(), key=lambda brand: brand.name.lower())
+
+    def search_brands(self, query: Optional[str] = None) -> List[Brand]:
+        if not query:
+            return list(self.list_brands())
+
+        keyword = query.strip().lower()
+        results = []
+        for brand in self._brands.values():
+            haystack = " ".join(
+                [
+                    brand.name.lower(),
+                    brand.tagline.lower(),
+                    brand.summary.lower(),
+                    " ".join(focus.lower() for focus in brand.aroma_focus),
+                ]
+            )
+            if keyword in haystack:
+                results.append(brand)
+        return sorted(results, key=lambda brand: brand.name.lower())
+
+    def get_brand(self, identifier: str) -> Brand:
+        if identifier in self._brands:
+            return self._brands[identifier]
+        if identifier in self._brands_by_slug:
+            return self._brands_by_slug[identifier]
+        raise BrandNotFound("Brand tidak ditemukan.")
+
+    # ------------------------------------------------------------------
+    # Mutating operations
+    # ------------------------------------------------------------------
+    def create_brand(
+        self,
+        *,
+        owner_profile_id: str,
+        owner_name: str,
+        owner_username: str,
+        owner_avatar: Optional[str],
+        name: str,
+        tagline: str,
+        summary: str,
+        origin_city: str,
+        established_year: int,
+        hero_image_url: str,
+        logo_url: Optional[str] = None,
+        aroma_focus: Optional[List[str]] = None,
+        story_points: Optional[List[str]] = None,
+        is_verified: bool = False,
+    ) -> Brand:
+        slug = _slugify(name)
+        if slug in self._brands_by_slug:
+            raise BrandAlreadyExists("Nama brand sudah digunakan pada etalase lain.")
+
+        brand_id = secrets.token_urlsafe(8)
+        brand = Brand(
+            id=brand_id,
+            name=name.strip(),
+            slug=slug,
+            tagline=tagline.strip(),
+            summary=summary.strip(),
+            origin_city=origin_city.strip(),
+            established_year=established_year,
+            hero_image_url=hero_image_url,
+            logo_url=logo_url,
+            aroma_focus=aroma_focus or [],
+            story_points=story_points or [],
+            is_verified=is_verified,
+        )
+        owner_member = BrandMember(
+            profile_id=owner_profile_id,
+            full_name=owner_name,
+            username=owner_username,
+            role="owner",
+            status="active",
+            avatar_url=owner_avatar,
+            expertise="Pendiri",
+        )
+        brand.members.append(owner_member)
+        self._register_brand(brand)
+        return brand
+
+    def update_logo(self, brand_slug: str, *, logo_url: Optional[str]) -> Brand:
+        """Assign or replace the public logo for a brand."""
+
+        brand = self.get_brand(brand_slug)
+        brand.logo_url = logo_url
+        return brand
+
+    def add_product(
+        self,
+        brand_slug: str,
+        *,
+        name: str,
+        slug: str,
+        price_label: str,
+        hero_note: str,
+        availability: str,
+        is_sambatan: bool = False,
+    ) -> BrandProduct:
+        brand = self.get_brand(brand_slug)
+        product = BrandProduct(
+            id=secrets.token_urlsafe(6),
+            name=name,
+            slug=slug,
+            price_label=price_label,
+            hero_note=hero_note,
+            availability=availability,
+            is_sambatan=is_sambatan,
+        )
+        brand.products.append(product)
+        return product
+
+    def add_highlight(
+        self,
+        brand_slug: str,
+        *,
+        title: str,
+        description: str,
+        timestamp: str,
+    ) -> BrandHighlight:
+        brand = self.get_brand(brand_slug)
+        highlight = BrandHighlight(title=title, description=description, timestamp=timestamp)
+        brand.highlights.append(highlight)
+        return highlight
+
+    def invite_co_owner(
+        self,
+        brand_slug: str,
+        *,
+        profile_id: str,
+        full_name: str,
+        username: str,
+        expertise: Optional[str] = None,
+        avatar_url: Optional[str] = None,
+        invited_by: Optional[str] = None,
+    ) -> BrandMember:
+        brand = self.get_brand(brand_slug)
+
+        if any(member.profile_id == profile_id for member in brand.members):
+            raise BrandMemberExists("Pengguna sudah terdaftar pada brand ini.")
+
+        member = BrandMember(
+            profile_id=profile_id,
+            full_name=full_name,
+            username=username,
+            role="co-owner",
+            status="pending",
+            expertise=expertise,
+            avatar_url=avatar_url,
+            invited_by=invited_by,
+        )
+        brand.members.append(member)
+        return member
+
+    def approve_co_owner(self, brand_slug: str, profile_id: str) -> BrandMember:
+        brand = self.get_brand(brand_slug)
+        for member in brand.members:
+            if member.profile_id == profile_id and member.role == "co-owner":
+                member.status = "active"
+                return member
+        raise BrandError("Undangan co-owner tidak ditemukan untuk brand ini.")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _register_brand(self, brand: Brand) -> None:
+        self._brands[brand.id] = brand
+        self._brands_by_slug[brand.slug] = brand
+
+    def _seed_demo_brands(self) -> None:
+        langit = self.create_brand(
+            owner_profile_id="user_amelia",
+            owner_name="Amelia Damayanti",
+            owner_username="amelia-damayanti",
+            owner_avatar="https://images.unsplash.com/photo-1542293787938-4d2226c3d9f1?auto=format&fit=crop&w=160&q=80",
+            name="Langit Senja",
+            tagline="Cerita aroma hangat untuk nostalgia senja.",
+            summary="Brand parfum craft yang merayakan perpaduan rempah hangat dan nuansa gourmand manis.",
+            origin_city="Bandung, Indonesia",
+            established_year=2019,
+            hero_image_url="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80",
+            logo_url="https://images.unsplash.com/photo-1612626253558-4fb0d8c2b993?auto=format&fit=crop&w=240&q=80",
+            aroma_focus=["Rempah hangat", "Gourmand lembut", "Aroma nostalgia"],
+            story_points=[
+                "Menyuplai batch terbatas dengan bahan utama dari petani lokal.",
+                "Rutin mengadakan sesi sambatan untuk transparansi proses produksi.",
+                "Mengkurasi komunitas pecinta aroma untuk eksplorasi kolaborasi.",
+            ],
+            is_verified=True,
+        )
+        self.add_product(
+            langit.slug,
+            name="Langit Sepia",
+            slug="langit-sepia",
+            price_label="Mulai Rp420K",
+            hero_note="Tonka bean dan patchouli yang menghangatkan momen senja",
+            availability="Batch Mei tersisa 18 botol",
+        )
+        self.add_product(
+            langit.slug,
+            name="Hujan Pagi",
+            slug="hujan-pagi",
+            price_label="Mulai Rp390K",
+            hero_note="Rain accord dengan vetiver basah khas Bandung",
+            availability="Pre-order sambatan batch Juni",
+            is_sambatan=True,
+        )
+        self.add_highlight(
+            langit.slug,
+            title="Kolaborasi Sambatan Batch #2",
+            description="Mengajak 25 anggota komunitas untuk uji coba aroma petrichor baru.",
+            timestamp="April 2024",
+        )
+        self.add_highlight(
+            langit.slug,
+            title="Featured di Nusantarum",
+            description="Menjadi salah satu brand pilihan editor pada edisi 'Hangat di Musim Hujan'.",
+            timestamp="Maret 2024",
+        )
+
+        studio = self.create_brand(
+            owner_profile_id="user_bintang",
+            owner_name="Bintang Waskita",
+            owner_username="bintang-waskita",
+            owner_avatar="https://images.unsplash.com/photo-1502323777036-f29e3972d82f?auto=format&fit=crop&w=160&q=80",
+            name="Studio Senja",
+            tagline="Peralatan dan aroma untuk studio parfum rumahan.",
+            summary="Studio butik yang menyediakan racikan wangi signature serta tools pendukung produksi rumahan.",
+            origin_city="Yogyakarta, Indonesia",
+            established_year=2020,
+            hero_image_url="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=1200&q=80",
+            logo_url="https://images.unsplash.com/photo-1616628182508-45138c88b4ce?auto=format&fit=crop&w=240&q=80",
+            aroma_focus=["Gourmand", "Aroma kopi", "Peralatan produksi"],
+            story_points=[
+                "Membantu UMKM parfum menyiapkan toolkit lengkap untuk batch perdana.",
+                "Menawarkan sesi konsultasi blending untuk pemula.",
+            ],
+        )
+        self.add_product(
+            studio.slug,
+            name="Pelangi Senja",
+            slug="pelangi-senja",
+            price_label="Rp380K",
+            hero_note="Ylang-ylang dan amber praline dengan sentuhan patchouli",
+            availability="Ready stock",
+        )
+        self.add_product(
+            studio.slug,
+            name="Timbangan Digital 0.01g",
+            slug="timbangan-digital-senja",
+            price_label="Rp420K",
+            hero_note="Akurasi tinggi untuk formula kecil",
+            availability="Garansi 1 tahun",
+        )
+        self.add_highlight(
+            studio.slug,
+            title="Penggerak Program Inkubasi Sensasiwangi",
+            description="Membimbing 12 brand baru menyiapkan SOP produksi rumahan.",
+            timestamp="Februari 2024",
+        )
+
+        self.invite_co_owner(
+            studio.slug,
+            profile_id="user_chandra",
+            full_name="Chandra Pratama",
+            username="chandra-pratama",
+            expertise="Kurator komunitas",
+            avatar_url="https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=160&q=80",
+            invited_by="Bintang Waskita",
+        )
+
+        self.add_highlight(
+            studio.slug,
+            title="Marketplace Favorite Tools",
+            description="Dinobatkan sebagai penyedia peralatan favorit oleh komunitas Nusantarum.",
+            timestamp="Desember 2023",
+        )
+
+        atar = self.create_brand(
+            owner_profile_id="brand_atar_owner",
+            owner_name="Atar Nusantara",
+            owner_username="atar-nusantara",
+            owner_avatar="https://images.unsplash.com/photo-1509042239860-f550ce710b93?auto=format&fit=crop&w=160&q=80",
+            name="Atar Nusantara",
+            tagline="Signature oud dan floral tropis dengan karakter modern.",
+            summary="Label parfum niche yang berfokus pada interpretasi aroma hutan hujan Indonesia.",
+            origin_city="Jakarta, Indonesia",
+            established_year=2016,
+            hero_image_url="https://images.unsplash.com/photo-1499695867787-121ffbfa0f5e?auto=format&fit=crop&w=1200&q=80",
+            logo_url="https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?auto=format&fit=crop&w=240&q=80",
+            aroma_focus=["Floral tropis", "Oud modern", "Resin eksotik"],
+            story_points=[
+                "Berkolaborasi dengan perfumer independen lintas kota.",
+                "Menjaga traceability bahan baku melalui petani binaan.",
+            ],
+            is_verified=True,
+        )
+        self.add_product(
+            atar.slug,
+            name="Rimba Embun",
+            slug="rimba-embun",
+            price_label="Rp420K",
+            hero_note="Jasmine sambac dan cedar atlas yang seimbang",
+            availability="Pre-order batch Juni",
+        )
+
+
+brand_service = BrandService()
+"""Singleton brand service instance shared across routers and tests."""
+

--- a/src/app/web/static/css/brand.css
+++ b/src/app/web/static/css/brand.css
@@ -1,0 +1,521 @@
+.brand-page {
+  display: grid;
+  gap: 3rem;
+  padding-bottom: 4rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.12);
+  color: inherit;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.button:hover {
+  background: rgba(255, 255, 255, 0.2);
+  transform: translateY(-1px);
+}
+
+.button-secondary {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0.05));
+}
+
+.button-ghost {
+  background: transparent;
+  border-style: dashed;
+}
+
+.button-small {
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+}
+
+.brand-hero {
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) 1.4fr;
+  gap: 2rem;
+  padding: 2.5rem;
+  align-items: center;
+}
+
+.brand-hero__branding {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}
+
+.brand-logo {
+  width: 104px;
+  height: 104px;
+  border-radius: 28px;
+  object-fit: cover;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 20px 35px rgba(15, 23, 42, 0.35);
+}
+
+.brand-logo--placeholder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 2.1rem;
+  letter-spacing: 0.08em;
+  width: 104px;
+  height: 104px;
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.32), rgba(14, 165, 233, 0.42));
+  color: #e0f2fe;
+  border: 1px solid rgba(14, 165, 233, 0.45);
+  text-transform: uppercase;
+}
+
+.brand-logo-upload {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.brand-logo-upload__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  border: 1px dashed rgba(148, 163, 184, 0.55);
+  background: rgba(15, 23, 42, 0.45);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.brand-logo-upload__trigger:hover {
+  background: rgba(30, 41, 59, 0.7);
+  border-color: rgba(148, 163, 184, 0.8);
+}
+
+.brand-logo-upload__trigger input {
+  display: none;
+}
+
+.brand-logo-upload__hint {
+  margin: 0;
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.brand-hero__media {
+  width: 100%;
+  padding-top: 75%;
+  background-size: cover;
+  background-position: center;
+  border-radius: 1.5rem;
+  position: relative;
+}
+
+.brand-hero__content h1 {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(2.4rem, 3vw, 3.6rem);
+  margin: 0;
+}
+
+.brand-title-group {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.brand-tagline {
+  font-size: 1.15rem;
+  font-weight: 500;
+  margin-bottom: 0.75rem;
+}
+
+.brand-description {
+  display: grid;
+  gap: 0.35rem;
+  margin-bottom: 1.5rem;
+}
+
+.brand-description h2 {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.65);
+  margin: 0;
+}
+
+.brand-description p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.brand-meta {
+  display: grid;
+  gap: 0.5rem;
+  margin: 1.5rem 0;
+}
+
+.brand-meta dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.brand-meta dd {
+  margin: 0.25rem 0 0;
+  font-weight: 500;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.badge.verified {
+  color: #4ade80;
+  background: rgba(74, 222, 128, 0.18);
+  border-color: rgba(34, 197, 94, 0.45);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.16);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.chip-owner {
+  background: rgba(59, 130, 246, 0.14);
+  border-color: rgba(59, 130, 246, 0.45);
+  color: #bfdbfe;
+}
+
+.chip-muted {
+  background: rgba(148, 163, 184, 0.1);
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.brand-cta {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.brand-section {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.section-header h2 {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.brand-story-list {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.brand-story-item {
+  position: relative;
+  padding: 1.75rem;
+}
+
+.story-index {
+  font-family: "Playfair Display", serif;
+  font-size: 1.5rem;
+  color: rgba(255, 255, 255, 0.4);
+  position: absolute;
+  top: 1.25rem;
+  right: 1.5rem;
+}
+
+.brand-product-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.brand-product-card {
+  padding: 1.75rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.brand-product-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.brand-product-card__note {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.brand-product-card__price {
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.brand-product-card__availability {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.brand-product-card__actions {
+  margin-top: 0.5rem;
+}
+
+.brand-collaboration .team-column {
+  display: grid;
+  gap: 1rem;
+}
+
+.brand-team-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.team-list {
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+  padding: 0;
+  margin: 0;
+}
+
+.team-card {
+  display: grid;
+  grid-template-columns: 64px 1fr;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem;
+}
+
+.team-card img {
+  width: 64px;
+  height: 64px;
+  object-fit: cover;
+  border-radius: 50%;
+}
+
+.team-card--pending {
+  border: 1px dashed rgba(255, 255, 255, 0.3);
+}
+
+.team-name {
+  font-weight: 600;
+}
+
+.team-role {
+  text-transform: capitalize;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.team-expertise {
+  font-size: 0.9rem;
+  margin-top: 0.25rem;
+}
+
+.team-invited {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.6);
+  margin-top: 0.25rem;
+}
+
+.team-actions {
+  display: flex;
+  gap: 0.5rem;
+  grid-column: 1 / -1;
+}
+
+.team-actions .button-small {
+  font-size: 0.85rem;
+  padding: 0.35rem 0.75rem;
+}
+
+.invite-form {
+  display: grid;
+  gap: 1rem;
+  padding: 1.5rem;
+}
+
+.invite-form label {
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.invite-form input,
+.invite-form textarea {
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(15, 18, 41, 0.35);
+  color: inherit;
+}
+
+.brand-highlight-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.highlight-card {
+  padding: 1.75rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.highlight-timestamp {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.brand-directory {
+  display: grid;
+  gap: 2.5rem;
+  padding-bottom: 4rem;
+}
+
+.brand-directory-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.brand-directory-card {
+  padding: 2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.brand-directory-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.brand-directory-logo {
+  width: 72px;
+  height: 72px;
+  border-radius: 1.25rem;
+  object-fit: cover;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.brand-directory-logo--placeholder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 1.5rem;
+  width: 72px;
+  height: 72px;
+  border-radius: 1.25rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.32), rgba(14, 165, 233, 0.42));
+  color: #e0f2fe;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.brand-directory-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.brand-directory-card__meta h2 {
+  font-family: "Playfair Display", serif;
+  font-size: 1.75rem;
+  margin: 0;
+}
+
+.brand-directory-meta-extra {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.brand-directory-meta-extra p {
+  margin: 0;
+}
+
+.brand-directory-tagline {
+  font-weight: 500;
+  margin-top: 0.5rem;
+}
+
+.brand-directory-card .badge.verified {
+  align-self: flex-start;
+}
+
+.brand-directory-location {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.brand-directory-summary {
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.brand-directory-focus {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 960px) {
+  .brand-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .brand-hero__media {
+    padding-top: 55%;
+  }
+}
+
+@media (max-width: 640px) {
+  .brand-page {
+    gap: 2rem;
+  }
+
+  .brand-hero {
+    padding: 1.75rem;
+  }
+
+  .brand-product-grid,
+  .brand-team-grid,
+  .brand-highlight-grid,
+  .brand-directory-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .team-card {
+    grid-template-columns: 48px 1fr;
+  }
+}
+

--- a/src/app/web/templates/marketplace.html
+++ b/src/app/web/templates/marketplace.html
@@ -75,7 +75,11 @@
         <div class="product-content">
           <div class="product-meta">
             <span class="product-category">{{ product.origin_type }}</span>
+            {% if product.brand_slug %}
+            <a class="product-owner" href="/brands/{{ product.brand_slug }}">{{ product.origin }}</a>
+            {% else %}
             <span class="product-owner">{{ product.origin }}</span>
+            {% endif %}
           </div>
           <h3>{{ product.name }}</h3>
           {% if product.perfumer %}

--- a/src/app/web/templates/pages/brand/detail.html
+++ b/src/app/web/templates/pages/brand/detail.html
@@ -1,0 +1,209 @@
+{% extends 'base.html' %}
+
+{% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/brand.css') }}" />
+{% endblock %}
+
+{% block content %}
+<article class="brand-page" aria-labelledby="brand-title">
+  <header class="brand-hero glass-card">
+    <div class="brand-hero__media" style="background-image: url('{{ brand.hero_image_url }}')" role="img" aria-label="Visual brand {{ brand.name }}"></div>
+    <div class="brand-hero__content">
+      <div class="brand-hero__branding">
+        {% if brand.logo_url %}
+        <img class="brand-logo" src="{{ brand.logo_url }}" alt="Logo {{ brand.name }}" loading="lazy" />
+        {% else %}
+        <div class="brand-logo brand-logo--placeholder" role="img" aria-label="Inisial brand {{ brand.name }}">
+          {{ brand.name[:2]|upper }}
+        </div>
+        {% endif %}
+        <form class="brand-logo-upload" aria-label="Form unggah logo brand" enctype="multipart/form-data">
+          <label class="brand-logo-upload__trigger">
+            <input type="file" name="logo" accept="image/*" />
+            <span>Unggah logo brand</span>
+          </label>
+          <p class="brand-logo-upload__hint">Format yang didukung: PNG, JPG, atau SVG maksimal 2MB.</p>
+        </form>
+      </div>
+      <span class="badge brand">Brand Partner</span>
+      <div class="brand-title-group">
+        <h1 id="brand-title">{{ brand.name }}</h1>
+        {% if brand.is_verified %}
+        <span class="badge verified" aria-label="Brand terverifikasi">&#10003; Verified Brand</span>
+        {% endif %}
+      </div>
+      <p class="brand-tagline">{{ brand.tagline }}</p>
+      <div class="brand-description">
+        <h2>Deskripsi Brand</h2>
+        <p>{{ brand.description }}</p>
+      </div>
+      <dl class="brand-meta">
+        <div>
+          <dt>Berbasis di</dt>
+          <dd>{{ brand.origin_city }}</dd>
+        </div>
+        <div>
+          <dt>Owner brand</dt>
+          <dd>
+            {% if brand.list_owners() %}
+            {% for owner in brand.list_owners() %}
+            <span class="chip chip-owner">{{ owner.full_name }}</span>
+            {% endfor %}
+            {% else %}
+            <span class="chip chip-muted">Belum ada owner aktif</span>
+            {% endif %}
+          </dd>
+        </div>
+        <div>
+          <dt>Tahun berdiri</dt>
+          <dd>Sejak {{ brand.established_year }}</dd>
+        </div>
+        {% if brand.aroma_focus %}
+        <div>
+          <dt>Fokus aroma</dt>
+          <dd>
+            {% for focus in brand.aroma_focus %}
+            <span class="chip">{{ focus }}</span>
+            {% endfor %}
+          </dd>
+        </div>
+        {% endif %}
+      </dl>
+      <div class="brand-cta">
+        <a class="button" href="/marketplace">Lihat katalog marketplace</a>
+        <a class="button button-secondary" href="/brands">Brand lainnya</a>
+      </div>
+    </div>
+  </header>
+
+  <section class="brand-section" aria-labelledby="brand-story">
+    <div class="section-header">
+      <h2 id="brand-story">Cerita Brand</h2>
+      <p>Bagikan narasi yang membuat calon pelanggan memahami keunikan brand-mu.</p>
+    </div>
+    <div class="brand-story-list">
+      {% for point in brand.story_points %}
+      <div class="brand-story-item glass-panel">
+        <span class="story-index" aria-hidden="true">0{{ loop.index }}</span>
+        <p>{{ point }}</p>
+      </div>
+      {% endfor %}
+    </div>
+  </section>
+
+  <section class="brand-section" aria-labelledby="brand-products">
+    <div class="section-header">
+      <h2 id="brand-products">Produk Unggulan</h2>
+      <p>Produk akan otomatis muncul di detail produk dan dapat dicari lewat katalog marketplace.</p>
+    </div>
+    <div class="brand-product-grid">
+      {% for product in brand.products %}
+      <article class="brand-product-card glass-panel">
+        <div class="brand-product-card__header">
+          <h3>{{ product.name }}</h3>
+          {% if product.is_sambatan %}
+          <span class="badge sambatan">Sambatan</span>
+          {% endif %}
+        </div>
+        <p class="brand-product-card__note">{{ product.hero_note }}</p>
+        <p class="brand-product-card__price">{{ product.price_label }}</p>
+        <p class="brand-product-card__availability">{{ product.availability }}</p>
+        <div class="brand-product-card__actions">
+          <a href="/marketplace" class="button button-ghost">Lihat di katalog</a>
+        </div>
+      </article>
+      {% else %}
+      <p>Belum ada produk terdaftar. Tambahkan produk untuk menampilkan etalase lengkap.</p>
+      {% endfor %}
+    </div>
+  </section>
+
+  <section class="brand-section brand-collaboration" aria-labelledby="brand-team">
+    <div class="section-header">
+      <h2 id="brand-team">Tim & Co-owner</h2>
+      <p>Brand owner bisa menandai kolaborator untuk membantu mengelola etalase.</p>
+    </div>
+    <div class="brand-team-grid">
+      <div class="team-column">
+        <h3>Aktif</h3>
+        <ul class="team-list">
+          {% for member in brand.list_active_members() %}
+          <li class="team-card glass-panel">
+            {% if member.avatar_url %}
+            <img src="{{ member.avatar_url }}" alt="{{ member.full_name }}" loading="lazy" />
+            {% endif %}
+            <div>
+              <p class="team-name">{{ member.full_name }}</p>
+              <p class="team-role">{{ member.role|replace('-', ' ')|title }}</p>
+              {% if member.expertise %}
+              <p class="team-expertise">{{ member.expertise }}</p>
+              {% endif %}
+            </div>
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+      <div class="team-column">
+        <h3>Menunggu Persetujuan</h3>
+        {% if brand.list_pending_members() %}
+        <ul class="team-list">
+          {% for member in brand.list_pending_members() %}
+          <li class="team-card glass-panel team-card--pending">
+            {% if member.avatar_url %}
+            <img src="{{ member.avatar_url }}" alt="{{ member.full_name }}" loading="lazy" />
+            {% endif %}
+            <div>
+              <p class="team-name">{{ member.full_name }}</p>
+              <p class="team-role">{{ member.role|replace('-', ' ')|title }}</p>
+              <p class="team-expertise">{{ member.expertise or 'Menunggu konfirmasi peran' }}</p>
+              {% if member.invited_by %}
+              <p class="team-invited">Diundang oleh {{ member.invited_by }}</p>
+              {% endif %}
+            </div>
+            <div class="team-actions">
+              <button type="button" class="button button-small">Setujui</button>
+              <button type="button" class="button button-ghost button-small">Batalkan</button>
+            </div>
+          </li>
+          {% endfor %}
+        </ul>
+        {% else %}
+        <p class="empty-state">Belum ada undangan co-owner yang menunggu persetujuan.</p>
+        {% endif %}
+        <form class="invite-form glass-panel" aria-label="Form undang co-owner">
+          <h4>Undang Co-owner</h4>
+          <p>Masukkan username komunitas untuk meminta persetujuan mereka sebagai co-owner.</p>
+          <label>
+            <span>Username</span>
+            <input type="text" placeholder="contoh: chandra-pratama" />
+          </label>
+          <label>
+            <span>Catatan</span>
+            <textarea rows="3" placeholder="Jelaskan peran atau kontribusi yang diharapkan"></textarea>
+          </label>
+          <button type="button" class="button button-secondary">Kirim Undangan</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <section class="brand-section" aria-labelledby="brand-recognition">
+    <div class="section-header">
+      <h2 id="brand-recognition">Sorotan & Pengakuan</h2>
+      <p>Gunakan highlight untuk membangun kepercayaan dan bukti sosial.</p>
+    </div>
+    <div class="brand-highlight-grid">
+      {% for highlight in brand.highlights %}
+      <article class="highlight-card glass-panel">
+        <span class="highlight-timestamp">{{ highlight.timestamp }}</span>
+        <h3>{{ highlight.title }}</h3>
+        <p>{{ highlight.description }}</p>
+      </article>
+      {% else %}
+      <p>Tambahkan pencapaian brand untuk meningkatkan kredibilitas di mata pembeli.</p>
+      {% endfor %}
+    </div>
+  </section>
+</article>
+{% endblock %}
+

--- a/src/app/web/templates/pages/brand/index.html
+++ b/src/app/web/templates/pages/brand/index.html
@@ -1,0 +1,53 @@
+{% extends 'base.html' %}
+
+{% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/brand.css') }}" />
+{% endblock %}
+
+{% block content %}
+<section class="brand-directory" aria-labelledby="brand-directory-title">
+  <div class="section-header">
+    <span class="badge brand">Brand</span>
+    <h1 id="brand-directory-title">Direktori Brand Sensasiwangi</h1>
+    <p>
+      Jelajahi brand komunitas dan partner Sensasiwangi. Setiap brand memiliki halaman khusus untuk
+      menampilkan cerita, tim, serta produk unggulan mereka.
+    </p>
+  </div>
+
+  <div class="brand-directory-grid">
+    {% for brand in brands %}
+    <article class="brand-directory-card glass-panel">
+      <div class="brand-directory-card__header">
+        {% if brand.logo_url %}
+        <img class="brand-directory-logo" src="{{ brand.logo_url }}" alt="Logo {{ brand.name }}" loading="lazy" />
+        {% else %}
+        <div class="brand-directory-logo brand-directory-logo--placeholder" aria-hidden="true">
+          {{ brand.name[:2]|upper }}
+        </div>
+        {% endif %}
+      </div>
+      <div class="brand-directory-card__meta">
+        <h2>{{ brand.name }}</h2>
+        <div class="brand-directory-meta-extra">
+          <p class="brand-directory-location">{{ brand.origin_city }}</p>
+          <p class="brand-directory-year">Sejak {{ brand.established_year }}</p>
+        </div>
+        <p class="brand-directory-tagline">{{ brand.tagline }}</p>
+        {% if brand.is_verified %}
+        <span class="badge verified">&#10003; Verified Brand</span>
+        {% endif %}
+      </div>
+      <p class="brand-directory-summary">{{ brand.description }}</p>
+      <div class="brand-directory-focus">
+        {% for focus in brand.aroma_focus[:3] %}
+        <span class="chip">{{ focus }}</span>
+        {% endfor %}
+      </div>
+      <a class="button button-secondary" href="/brands/{{ brand.slug }}">Kunjungi brand</a>
+    </article>
+    {% endfor %}
+  </div>
+</section>
+{% endblock %}
+

--- a/src/app/web/templates/partials/navbar.html
+++ b/src/app/web/templates/partials/navbar.html
@@ -17,6 +17,11 @@
       </a>
     </li>
     <li>
+      <a href="{{ url_for('list_brands') }}" class="{% if request.url.path.startswith('/brands') %}active{% endif %}">
+        Brand
+      </a>
+    </li>
+    <li>
       <a href="{{ url_for('read_onboarding') }}" class="{% if request.url.path.startswith('/onboarding') %}active{% endif %}">
         Onboarding
       </a>

--- a/tests/test_brand_service.py
+++ b/tests/test_brand_service.py
@@ -1,0 +1,115 @@
+"""Unit tests for the in-memory brand service."""
+
+import pytest
+
+from app.services.brands import (
+    BrandAlreadyExists,
+    BrandError,
+    BrandMemberExists,
+    BrandService,
+)
+
+
+def create_service() -> BrandService:
+    """Helper to create a fresh service with seeded data for each test."""
+
+    return BrandService()
+
+
+def test_search_brands_matches_by_tagline() -> None:
+    service = create_service()
+
+    results = service.search_brands("nostalgia")
+
+    assert results, "Expected at least one search result"
+    assert results[0].slug == "langit-senja"
+
+
+def test_create_brand_registers_owner_and_unique_slug() -> None:
+    service = create_service()
+
+    brand = service.create_brand(
+        owner_profile_id="user_diah",
+        owner_name="Diah Lestari",
+        owner_username="diah-lestari",
+        owner_avatar=None,
+        name="Aroma Harmoni",
+        tagline="Eksplorasi aroma herbal dan teh fermentasi",
+        summary="Brand eksperimen aroma yang fokus pada bahan botani hasil fermentasi.",
+        origin_city="Semarang, Indonesia",
+        established_year=2022,
+        hero_image_url="https://example.com/hero.jpg",
+        aroma_focus=["Herbal", "Fermentasi"],
+        logo_url=None,
+    )
+
+    assert brand.slug == "aroma-harmoni"
+    assert brand.list_active_members()[0].role == "owner"
+    assert brand.list_owners()[0].full_name == "Diah Lestari"
+    assert brand.established_year == 2022
+    assert not brand.is_verified
+
+    with pytest.raises(BrandAlreadyExists):
+        service.create_brand(
+            owner_profile_id="user_other",
+            owner_name="Orang Lain",
+            owner_username="orang-lain",
+            owner_avatar=None,
+            name="Aroma Harmoni",
+            tagline="",
+            summary="",
+            origin_city="",
+            established_year=2022,
+            hero_image_url="https://example.com/hero.jpg",
+            logo_url=None,
+        )
+
+
+def test_invite_and_approve_co_owner() -> None:
+    service = create_service()
+    brand = service.get_brand("studio-senja")
+
+    pending_before = len(brand.list_pending_members())
+
+    invitation = service.invite_co_owner(
+        brand.slug,
+        profile_id="user_farhan",
+        full_name="Farhan Nugraha",
+        username="farhan-nugraha",
+        expertise="Operasional",
+    )
+
+    assert invitation.is_pending
+    assert len(brand.list_pending_members()) == pending_before + 1
+
+    with pytest.raises(BrandMemberExists):
+        service.invite_co_owner(
+            brand.slug,
+            profile_id="user_farhan",
+            full_name="Farhan Nugraha",
+            username="farhan-nugraha",
+        )
+
+    approved = service.approve_co_owner(brand.slug, "user_farhan")
+
+    assert approved.status == "active"
+    assert not approved.is_pending
+
+    with pytest.raises(BrandError):
+        service.approve_co_owner(brand.slug, "user_tidak_ada")
+
+
+def test_update_logo_assigns_and_replaces_brand_logo() -> None:
+    service = create_service()
+    brand = service.get_brand("langit-senja")
+
+    assert brand.logo_url is not None
+
+    updated = service.update_logo(brand.slug, logo_url="https://example.com/new-logo.png")
+
+    assert updated.logo_url == "https://example.com/new-logo.png"
+
+    cleared = service.update_logo(brand.slug, logo_url=None)
+
+    assert cleared.logo_url is None
+


### PR DESCRIPTION
## Summary
- add logo metadata support to the in-memory brand service including seeding helpers and an update API
- render brand logos with a visible upload control on the storefront and previews inside the brand directory
- extend brand styling and tests to cover the new logo workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8982e6e608327bd47b1d1ce4ed341