### PR TITLE
feat: add Nusantarum directory integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "python-multipart>=0.0.6",
     "pydantic-settings>=2.2",
     "aiofiles>=23.2",
+    "httpx>=0.27",
 ]
 
 [project.optional-dependencies]

--- a/src/app/api/routes/nusantarum.py
+++ b/src/app/api/routes/nusantarum.py
@@ -1,0 +1,224 @@
+"""Routing module for the Nusantarum directory experience."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Tuple
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+
+from app.services.nusantarum_service import (
+    NusantarumConfigurationError,
+    NusantarumError,
+    NusantarumService,
+    nusantarum_service,
+)
+
+
+router = APIRouter(prefix="/nusantarum", tags=["nusantarum"])
+
+
+def get_service() -> NusantarumService:
+    return nusantarum_service
+
+
+async def _load_perfume_tab(
+    service: NusantarumService,
+    *,
+    page: int,
+    page_size: int,
+    families: List[str],
+    city: str | None,
+    price_min: float | None,
+    price_max: float | None,
+    verified: bool,
+):
+    return await service.list_perfumes(
+        page=page,
+        page_size=page_size,
+        families=families,
+        city=city,
+        price_min=price_min,
+        price_max=price_max,
+        verified_only=verified,
+    )
+
+
+async def _load_brand_tab(
+    service: NusantarumService,
+    *,
+    page: int,
+    page_size: int,
+    families: List[str],
+    city: str | None,
+    price_min: float | None,
+    price_max: float | None,
+    verified: bool,
+):
+    del families, price_min, price_max
+    return await service.list_brands(page=page, page_size=page_size, city=city, verified_only=verified)
+
+
+async def _load_perfumer_tab(
+    service: NusantarumService,
+    *,
+    page: int,
+    page_size: int,
+    families: List[str],
+    city: str | None,
+    price_min: float | None,
+    price_max: float | None,
+    verified: bool,
+):
+    del families, city, price_min, price_max
+    return await service.list_perfumers(page=page, page_size=page_size, verified_only=verified)
+
+
+TAB_LOADERS: Dict[str, Tuple[str, Callable[..., Any]]] = {
+    "parfum": ("components/nusantarum/perfume-list.html", _load_perfume_tab),
+    "brand": ("components/nusantarum/brand-list.html", _load_brand_tab),
+    "perfumer": ("components/nusantarum/perfumer-list.html", _load_perfumer_tab),
+}
+
+
+@router.get("", response_class=HTMLResponse, name="nusantarum:index")
+async def nusantarum_index(
+    request: Request,
+    service: NusantarumService = Depends(get_service),
+    families: List[str] = Query(default_factory=list),
+    city: str | None = Query(default=None),
+    price_min: float | None = Query(default=None, ge=0),
+    price_max: float | None = Query(default=None, ge=0),
+    verified: bool = Query(default=True),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=12, ge=1, le=50),
+) -> HTMLResponse:
+    templates = request.app.state.templates
+    filters = {
+        "families": families,
+        "city": city,
+        "price_min": price_min,
+        "price_max": price_max,
+        "verified": verified,
+    }
+
+    try:
+        perfume_page = await _load_perfume_tab(
+            service,
+            page=page,
+            page_size=page_size,
+            families=families,
+            city=city,
+            price_min=price_min,
+            price_max=price_max,
+            verified=verified,
+        )
+        sync_status = await service.get_sync_status()
+        error_message = None
+    except NusantarumConfigurationError as exc:
+        perfume_page = None
+        sync_status = []
+        error_message = str(exc)
+
+    context = {
+        "request": request,
+        "title": "Nusantarum Directory",
+        "filters": filters,
+        "perfume_page": perfume_page,
+        "sync_status": sync_status,
+        "error_message": error_message,
+        "active_tab": "parfum",
+    }
+    return templates.TemplateResponse("pages/nusantarum/index.html", context)
+
+
+@router.get("/tab/{slug}", response_class=HTMLResponse, name="nusantarum:tab")
+async def nusantarum_tab(
+    slug: str,
+    request: Request,
+    service: NusantarumService = Depends(get_service),
+    families: List[str] = Query(default_factory=list),
+    city: str | None = Query(default=None),
+    price_min: float | None = Query(default=None, ge=0),
+    price_max: float | None = Query(default=None, ge=0),
+    verified: bool = Query(default=True),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=12, ge=1, le=50),
+) -> HTMLResponse:
+    slug = slug.lower()
+    if slug not in TAB_LOADERS:
+        raise HTTPException(status_code=404, detail="Tab tidak ditemukan")
+
+    template_name, loader = TAB_LOADERS[slug]
+    templates = request.app.state.templates
+
+    try:
+        page_data = await loader(
+            service,
+            page=page,
+            page_size=page_size,
+            families=families,
+            city=city,
+            price_min=price_min,
+            price_max=price_max,
+            verified=verified,
+        )
+        error_message = None
+    except NusantarumConfigurationError as exc:
+        page_data = None
+        error_message = str(exc)
+
+    context = {
+        "request": request,
+        "page": page_data,
+        "error_message": error_message,
+        "filters": {
+            "families": families,
+            "city": city,
+            "price_min": price_min,
+            "price_max": price_max,
+            "verified": verified,
+        },
+        "active_tab": slug,
+    }
+    return templates.TemplateResponse(template_name, context)
+
+
+@router.get("/search", response_class=HTMLResponse, name="nusantarum:search")
+async def nusantarum_search(
+    request: Request,
+    query: str = Query(alias="q"),
+    service: NusantarumService = Depends(get_service),
+) -> HTMLResponse:
+    templates = request.app.state.templates
+    try:
+        results = await service.search(query)
+    except NusantarumConfigurationError as exc:
+        context = {
+            "request": request,
+            "results": {"perfumes": [], "brands": [], "perfumers": []},
+            "error_message": str(exc),
+        }
+        return templates.TemplateResponse("components/nusantarum/search-results.html", context)
+
+    context = {"request": request, "results": results, "error_message": None}
+    return templates.TemplateResponse("components/nusantarum/search-results.html", context)
+
+
+@router.post("/sync/{source}", response_class=JSONResponse, name="nusantarum:trigger-sync")
+async def trigger_sync(
+    source: str,
+    service: NusantarumService = Depends(get_service),
+) -> JSONResponse:
+    source = source.lower()
+    if source not in {"marketplace", "profiles"}:
+        raise HTTPException(status_code=400, detail="Sumber sinkronisasi tidak dikenal")
+
+    try:
+        await service.trigger_sync(source)
+    except NusantarumConfigurationError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except NusantarumError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return JSONResponse({"status": "queued", "source": source})

--- a/src/app/core/application.py
+++ b/src/app/core/application.py
@@ -15,6 +15,7 @@ from app.api.routes import reports as reports_routes
 from app.api.routes import root as root_routes
 from app.api.routes import sambatan as sambatan_routes
 from app.api.routes import brands as brand_routes
+from app.api.routes import nusantarum as nusantarum_routes
 
 STATIC_DIR = Path(__file__).resolve().parent.parent / "web" / "static"
 
@@ -51,6 +52,7 @@ def create_app() -> FastAPI:
     app.include_router(onboarding_routes.router)
     app.include_router(sambatan_routes.router)
     app.include_router(profile_routes.router)
+    app.include_router(nusantarum_routes.router)
     from app.api.routes import auth as auth_routes
 
     app.include_router(auth_routes.router)

--- a/src/app/services/__init__.py
+++ b/src/app/services/__init__.py
@@ -4,6 +4,10 @@ from .auth import AuthService, auth_service
 from .brands import BrandService, brand_service
 from .onboarding import OnboardingService, onboarding_service
 from .products import ProductService, product_service
+from .nusantarum_service import (
+    NusantarumService,
+    nusantarum_service,
+)
 from .sambatan import (
     SambatanLifecycleService,
     SambatanService,
@@ -20,6 +24,8 @@ __all__ = [
     "onboarding_service",
     "ProductService",
     "product_service",
+    "NusantarumService",
+    "nusantarum_service",
     "SambatanService",
     "sambatan_service",
     "SambatanLifecycleService",

--- a/src/app/services/nusantarum_service.py
+++ b/src/app/services/nusantarum_service.py
@@ -1,0 +1,557 @@
+"""Service layer for Nusantarum directory integration with Supabase."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional, Protocol, Sequence, Tuple, TypedDict
+
+try:  # pragma: no cover - gracefully handle missing optional dependency
+    import httpx
+except ModuleNotFoundError:  # pragma: no cover - environment without httpx
+    class _HttpxStub:  # type: ignore[override]
+        class HTTPStatusError(RuntimeError):
+            pass
+
+        class AsyncClient:  # noqa: D401 - simple stub
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                raise RuntimeError(
+                    "httpx package is required for Supabase integration. "
+                    "Install httpx or provide a custom gateway."
+                )
+
+    httpx = _HttpxStub()  # type: ignore[assignment]
+
+from app.core.config import get_settings
+
+
+class NusantarumError(Exception):
+    """Base error for Nusantarum operations."""
+
+
+class NusantarumConfigurationError(NusantarumError):
+    """Raised when Supabase credentials are not configured."""
+
+
+class NusantarumGatewayError(NusantarumError):
+    """Raised when Supabase responds with an unexpected error."""
+
+
+class GatewayResult(TypedDict, total=False):
+    data: List[Dict[str, Any]]
+    total: Optional[int]
+
+
+class NusantarumGateway(Protocol):
+    """Protocol describing the Supabase gateway used by the service."""
+
+    async def fetch_directory(
+        self,
+        resource: str,
+        *,
+        page: int,
+        page_size: int,
+        filters: Iterable[Tuple[str, Any]] | None = None,
+        order: str | None = None,
+    ) -> GatewayResult:
+        ...
+
+    async def fetch_sync_logs(self, *, limit: int = 5) -> List[Dict[str, Any]]:
+        ...
+
+    async def rpc(self, name: str, payload: Dict[str, Any] | None = None) -> Any:
+        ...
+
+
+@dataclass(slots=True)
+class PerfumeListItem:
+    """Representation of a parfum item rendered on the Nusantarum page."""
+
+    id: str
+    name: str
+    slug: str
+    brand_name: str
+    brand_slug: str
+    brand_city: Optional[str]
+    brand_profile_username: Optional[str]
+    perfumer_name: Optional[str]
+    perfumer_slug: Optional[str]
+    perfumer_profile_username: Optional[str]
+    hero_note: Optional[str]
+    description: Optional[str]
+    aroma_families: List[str]
+    price_reference: Optional[float]
+    price_currency: str
+    marketplace_price: Optional[float]
+    marketplace_status: Optional[str]
+    marketplace_product_id: Optional[str]
+    base_image_url: Optional[str]
+    sync_source: str
+    sync_status: Optional[str]
+    synced_at: Optional[datetime]
+    updated_at: Optional[datetime]
+    marketplace_rating: Optional[float]
+
+    @property
+    def marketplace_url(self) -> Optional[str]:
+        if self.marketplace_product_id:
+            return f"/marketplace/products/{self.marketplace_product_id}"
+        return None
+
+    @property
+    def brand_profile_url(self) -> Optional[str]:
+        if self.brand_profile_username:
+            return f"/profile/{self.brand_profile_username}"
+        return None
+
+    @property
+    def perfumer_profile_url(self) -> Optional[str]:
+        if self.perfumer_profile_username:
+            return f"/profile/{self.perfumer_profile_username}"
+        return None
+
+
+@dataclass(slots=True)
+class BrandListItem:
+    id: str
+    name: str
+    slug: str
+    origin_city: Optional[str]
+    active_perfume_count: int
+    nusantarum_status: Optional[str]
+    brand_profile_username: Optional[str]
+    last_perfume_synced_at: Optional[datetime]
+
+    @property
+    def profile_url(self) -> Optional[str]:
+        if self.brand_profile_username:
+            return f"/profile/{self.brand_profile_username}"
+        return None
+
+
+@dataclass(slots=True)
+class PerfumerListItem:
+    id: str
+    display_name: str
+    slug: str
+    signature_scent: Optional[str]
+    active_perfume_count: int
+    perfumer_profile_username: Optional[str]
+    highlight_perfume: Optional[str]
+    highlight_brand: Optional[str]
+    last_synced_at: Optional[datetime]
+
+    @property
+    def profile_url(self) -> Optional[str]:
+        if self.perfumer_profile_username:
+            return f"/profile/{self.perfumer_profile_username}"
+        return None
+
+
+@dataclass(slots=True)
+class SyncLog:
+    source: str
+    status: str
+    summary: Optional[str]
+    run_at: datetime
+
+
+@dataclass(slots=True)
+class PagedResult:
+    items: List[Any]
+    total: Optional[int]
+    page: int
+    page_size: int
+
+    @property
+    def pages(self) -> int:
+        if not self.total:
+            return 1
+        return max(1, math.ceil(self.total / self.page_size))
+
+
+class HttpSupabaseGateway:
+    """HTTP implementation of the Supabase gateway using PostgREST endpoints."""
+
+    def __init__(self, *, base_url: str, api_key: str, schema: str = "public", timeout: float = 10.0) -> None:
+        self._base_url = base_url.rstrip("/") + "/rest/v1"
+        self._schema = schema
+        self._timeout = timeout
+        self._headers = {
+            "apikey": api_key,
+            "Authorization": f"Bearer {api_key}",
+            "Accept-Profile": schema,
+        }
+
+    async def fetch_directory(
+        self,
+        resource: str,
+        *,
+        page: int,
+        page_size: int,
+        filters: Iterable[Tuple[str, Any]] | None = None,
+        order: str | None = None,
+    ) -> GatewayResult:
+        params: List[Tuple[str, Any]] = [("select", "*")]
+        if filters:
+            params.extend(list(filters))
+        if order:
+            params.append(("order", order))
+
+        offset = (page - 1) * page_size
+        headers = {**self._headers, "Prefer": "count=exact"}
+
+        async with httpx.AsyncClient(base_url=self._base_url, timeout=self._timeout) as client:
+            response = await client.get(
+                f"/{resource}",
+                headers=headers,
+                params=[("limit", page_size), ("offset", offset), *params],
+            )
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - network failure
+            raise NusantarumGatewayError(str(exc)) from exc
+
+        data = response.json()
+        total = self._parse_total(response.headers.get("content-range"))
+        return {"data": data, "total": total}
+
+    async def fetch_sync_logs(self, *, limit: int = 5) -> List[Dict[str, Any]]:
+        params = {
+            "order": "run_at.desc",
+            "limit": limit,
+            "select": "*",
+        }
+        async with httpx.AsyncClient(base_url=self._base_url, timeout=self._timeout) as client:
+            response = await client.get("/nusantarum_sync_logs", headers=self._headers, params=params)
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - network failure
+            raise NusantarumGatewayError(str(exc)) from exc
+        return response.json()
+
+    async def rpc(self, name: str, payload: Dict[str, Any] | None = None) -> Any:
+        async with httpx.AsyncClient(base_url=self._base_url, timeout=self._timeout) as client:
+            response = await client.post(
+                f"/rpc/{name}",
+                headers=self._headers,
+                json=payload or {},
+            )
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - network failure
+            raise NusantarumGatewayError(str(exc)) from exc
+        if response.content:
+            return response.json()
+        return None
+
+    @staticmethod
+    def _parse_total(content_range: Optional[str]) -> Optional[int]:
+        if not content_range:
+            return None
+        try:
+            _, total = content_range.split("/")
+            if total == "*":
+                return None
+            return int(total)
+        except ValueError:
+            return None
+
+
+class _CacheEntry(TypedDict):
+    expires_at: float
+    value: PagedResult
+
+
+class NusantarumService:
+    """Facade providing cached access to Nusantarum directory data."""
+
+    def __init__(
+        self,
+        gateway: NusantarumGateway | None = None,
+        *,
+        cache_ttl: float = 30.0,
+    ) -> None:
+        self._gateway = gateway
+        self._cache_ttl = cache_ttl
+        self._cache: Dict[Tuple[str, Tuple[Any, ...]], _CacheEntry] = {}
+        self._lock = asyncio.Lock()
+
+    def _ensure_gateway(self) -> NusantarumGateway:
+        if self._gateway is not None:
+            return self._gateway
+        settings = get_settings()
+        if not settings.supabase_url or not settings.supabase_anon_key:
+            raise NusantarumConfigurationError(
+                "Supabase credentials belum dikonfigurasi untuk Nusantarum."
+            )
+        self._gateway = HttpSupabaseGateway(
+            base_url=settings.supabase_url,
+            api_key=settings.supabase_service_role_key or settings.supabase_anon_key,
+        )
+        return self._gateway
+
+    async def list_perfumes(
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 20,
+        families: Iterable[str] | None = None,
+        city: str | None = None,
+        price_min: float | None = None,
+        price_max: float | None = None,
+        verified_only: bool = True,
+    ) -> PagedResult:
+        filters: List[Tuple[str, Any]] = []
+        if verified_only:
+            filters.append(("brand_is_verified", "eq.true"))
+        if families:
+            filters.append(("aroma_families", "ov.{" + ",".join(families) + "}"))
+        if city:
+            filters.append(("brand_city", f"ilike.*{city}*"))
+        if price_min is not None:
+            filters.append(("marketplace_price", f"gte.{price_min}"))
+        if price_max is not None:
+            filters.append(("marketplace_price", f"lte.{price_max}"))
+
+        payload = await self._fetch_with_cache(
+            "perfumes",
+            filters,
+            page,
+            page_size,
+            order="synced_at.desc,nullslast",
+        )
+        items = [self._build_perfume(item) for item in payload.items]
+        return PagedResult(items=items, total=payload.total, page=page, page_size=page_size)
+
+    async def list_brands(
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 20,
+        city: str | None = None,
+        verified_only: bool = True,
+    ) -> PagedResult:
+        filters: List[Tuple[str, Any]] = []
+        if verified_only:
+            filters.append(("is_verified", "eq.true"))
+        if city:
+            filters.append(("origin_city", f"ilike.*{city}*"))
+
+        payload = await self._fetch_with_cache(
+            "brands",
+            filters,
+            page,
+            page_size,
+            resource="nusantarum_brand_directory",
+            order="name.asc",
+        )
+        items = [self._build_brand(item) for item in payload.items]
+        return PagedResult(items=items, total=payload.total, page=page, page_size=page_size)
+
+    async def list_perfumers(
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 20,
+        verified_only: bool = True,
+    ) -> PagedResult:
+        filters: List[Tuple[str, Any]] = []
+        if verified_only:
+            filters.append(("is_verified", "eq.true"))
+
+        payload = await self._fetch_with_cache(
+            "perfumers",
+            filters,
+            page,
+            page_size,
+            resource="nusantarum_perfumer_directory",
+            order="display_name.asc",
+        )
+        items = [self._build_perfumer(item) for item in payload.items]
+        return PagedResult(items=items, total=payload.total, page=page, page_size=page_size)
+
+    async def search(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+    ) -> Dict[str, List[str]]:
+        q = query.strip()
+        if not q:
+            return {"perfumes": [], "brands": [], "perfumers": []}
+
+        filters = [("name", f"ilike.*{q}*")]
+        perfume_results = await self._fetch_with_cache(
+            "perfumes-search",
+            filters,
+            1,
+            limit,
+            resource="nusantarum_perfume_directory",
+            order="name.asc",
+        )
+        brand_results = await self._fetch_with_cache(
+            "brands-search",
+            [("name", f"ilike.*{q}*")],
+            1,
+            limit,
+            resource="nusantarum_brand_directory",
+            order="name.asc",
+        )
+        perfumer_results = await self._fetch_with_cache(
+            "perfumers-search",
+            [("display_name", f"ilike.*{q}*")],
+            1,
+            limit,
+            resource="nusantarum_perfumer_directory",
+            order="display_name.asc",
+        )
+        return {
+            "perfumes": [item["name"] for item in perfume_results.items],
+            "brands": [item["name"] for item in brand_results.items],
+            "perfumers": [item["display_name"] for item in perfumer_results.items],
+        }
+
+    async def get_sync_status(self) -> List[SyncLog]:
+        gateway = self._ensure_gateway()
+        rows = await gateway.fetch_sync_logs(limit=5)
+        status: List[SyncLog] = []
+        for row in rows:
+            try:
+                run_at = datetime.fromisoformat(row["run_at"].replace("Z", "+00:00"))
+            except (KeyError, ValueError):
+                continue
+            status.append(
+                SyncLog(
+                    source=row.get("source", "unknown"),
+                    status=row.get("status", "unknown"),
+                    summary=row.get("summary"),
+                    run_at=run_at,
+                )
+            )
+        return status
+
+    async def trigger_sync(self, source: str) -> None:
+        gateway = self._ensure_gateway()
+        if source == "marketplace":
+            await gateway.rpc("sync_marketplace_products")
+        elif source == "profiles":
+            await gateway.rpc("sync_nusantarum_profiles")
+        else:  # pragma: no cover - defensive programming
+            raise NusantarumError(f"Unknown sync source: {source}")
+
+    async def _fetch_with_cache(
+        self,
+        cache_key: str,
+        filters: Sequence[Tuple[str, Any]],
+        page: int,
+        page_size: int,
+        *,
+        resource: str = "nusantarum_perfume_directory",
+        order: str | None = None,
+    ) -> PagedResult:
+        gateway = self._ensure_gateway()
+        normalized_filters = tuple(sorted(filters))
+        key = (cache_key, normalized_filters, page, page_size, resource, order)
+        now = time.monotonic()
+
+        entry = self._cache.get(key)
+        if entry and entry["expires_at"] > now:
+            return entry["value"]
+
+        async with self._lock:
+            entry = self._cache.get(key)
+            if entry and entry["expires_at"] > now:
+                return entry["value"]
+
+            result = await gateway.fetch_directory(
+                resource,
+                page=page,
+                page_size=page_size,
+                filters=filters,
+                order=order,
+            )
+            paged = PagedResult(
+                items=result.get("data", []),
+                total=result.get("total"),
+                page=page,
+                page_size=page_size,
+            )
+            self._cache[key] = {"expires_at": now + self._cache_ttl, "value": paged}
+            return paged
+
+    @staticmethod
+    def _build_perfume(row: Dict[str, Any]) -> PerfumeListItem:
+        return PerfumeListItem(
+            id=str(row.get("id")),
+            name=row.get("name", ""),
+            slug=row.get("slug", ""),
+            brand_name=row.get("brand_name", ""),
+            brand_slug=row.get("brand_slug", ""),
+            brand_city=row.get("brand_city"),
+            brand_profile_username=row.get("brand_profile_username"),
+            perfumer_name=row.get("perfumer_name"),
+            perfumer_slug=row.get("perfumer_slug"),
+            perfumer_profile_username=row.get("perfumer_profile_username"),
+            hero_note=row.get("hero_note"),
+            description=row.get("description"),
+            aroma_families=list(row.get("aroma_families") or []),
+            price_reference=row.get("price_reference"),
+            price_currency=row.get("price_currency", "IDR"),
+            marketplace_price=row.get("marketplace_price"),
+            marketplace_status=row.get("marketplace_status"),
+            marketplace_product_id=row.get("marketplace_product_id"),
+            base_image_url=row.get("base_image_url"),
+            sync_source=row.get("sync_source", "manual"),
+            sync_status=row.get("sync_status"),
+            synced_at=_parse_datetime(row.get("synced_at")),
+            updated_at=_parse_datetime(row.get("updated_at")),
+            marketplace_rating=row.get("marketplace_rating"),
+        )
+
+    @staticmethod
+    def _build_brand(row: Dict[str, Any]) -> BrandListItem:
+        return BrandListItem(
+            id=str(row.get("id")),
+            name=row.get("name", ""),
+            slug=row.get("slug", ""),
+            origin_city=row.get("origin_city"),
+            active_perfume_count=int(row.get("active_perfume_count") or 0),
+            nusantarum_status=row.get("nusantarum_status"),
+            brand_profile_username=row.get("brand_profile_username"),
+            last_perfume_synced_at=_parse_datetime(row.get("last_perfume_synced_at")),
+        )
+
+    @staticmethod
+    def _build_perfumer(row: Dict[str, Any]) -> PerfumerListItem:
+        return PerfumerListItem(
+            id=str(row.get("id")),
+            display_name=row.get("display_name", ""),
+            slug=row.get("slug", ""),
+            signature_scent=row.get("signature_scent"),
+            active_perfume_count=int(row.get("active_perfume_count") or 0),
+            perfumer_profile_username=row.get("perfumer_profile_username"),
+            highlight_perfume=row.get("highlight_perfume"),
+            highlight_brand=row.get("highlight_brand"),
+            last_synced_at=_parse_datetime(row.get("last_synced_at")),
+        )
+
+
+def _parse_datetime(value: Any) -> Optional[datetime]:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+nusantarum_service = NusantarumService()
+"""Default singleton service instance used by routers and tests."""

--- a/src/app/web/static/css/nusantarum.css
+++ b/src/app/web/static/css/nusantarum.css
@@ -1,0 +1,300 @@
+.nusantarum-page {
+  display: grid;
+  gap: 2rem;
+}
+
+.nusantarum-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(18px);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: var(--text-primary);
+}
+
+.text-muted {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.95rem;
+}
+
+.nusantarum-header h1 {
+  font-size: clamp(1.8rem, 2vw + 1rem, 2.6rem);
+  font-weight: 600;
+}
+
+.nusantarum-search {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.nusantarum-search-results {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  width: 100%;
+  padding: 1rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: inherit;
+}
+
+.nusantarum-search-results ul {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0;
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.nusantarum-search input[type="search"] {
+  flex: 1;
+  min-width: 240px;
+  padding: 0.75rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.15);
+  color: inherit;
+}
+
+.nusantarum-search input[type="search"]::placeholder {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.nusantarum-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+}
+
+.nusantarum-tabs {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.nusantarum-tab {
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.15);
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, border 0.2s ease;
+}
+
+.nusantarum-tab[aria-selected="true"],
+.nusantarum-tab:hover,
+.nusantarum-tab:focus-visible {
+  background: rgba(255, 255, 255, 0.35);
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+.nusantarum-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1.5rem;
+}
+
+@media (min-width: 992px) {
+  .nusantarum-body {
+    grid-template-columns: 260px 1fr;
+  }
+}
+
+.nusantarum-filter-panel {
+  position: sticky;
+  top: 1.5rem;
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+  padding: 1.5rem;
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: var(--text-primary);
+}
+
+.filter-chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.filter-chip {
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.filter-chip input[type="checkbox"] {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.filter-chip span {
+  pointer-events: none;
+}
+
+.filter-chip input[type="checkbox"]:checked + span {
+  background: rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+}
+
+.toggle {
+  display: inline-flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.toggle input[type="checkbox"] {
+  width: 1.15rem;
+  height: 1.15rem;
+  accent-color: #f59e0b;
+}
+
+.nusantarum-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.nusantarum-list-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.8rem;
+  padding: 1.25rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: var(--text-primary);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.nusantarum-list-card:hover,
+.nusantarum-list-card:focus-within {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.35);
+}
+
+.nusantarum-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  align-items: center;
+}
+
+.nusantarum-meta strong {
+  font-weight: 600;
+}
+
+.sync-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.25);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.nusantarum-empty {
+  padding: 2rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.08);
+  text-align: center;
+}
+
+.nusantarum-pagination {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.nusantarum-pagination button {
+  padding: 0.6rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.18);
+  color: inherit;
+  cursor: pointer;
+}
+
+.nusantarum-pagination button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.hover-preview {
+  display: none;
+  position: absolute;
+  top: 50%;
+  right: 1.5rem;
+  transform: translateY(-50%);
+  width: 120px;
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.4);
+}
+
+.nusantarum-list-card:hover .hover-preview,
+.nusantarum-list-card:focus-within .hover-preview {
+  display: block;
+}
+
+.hover-preview img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.sync-status-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.sync-status-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.85rem;
+}
+
+.sync-status-item span:first-child {
+  font-weight: 500;
+}
+
+@media (max-width: 991px) {
+  .nusantarum-body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .hover-preview {
+    display: none !important;
+  }
+}

--- a/src/app/web/templates/components/nusantarum/brand-list-item.html
+++ b/src/app/web/templates/components/nusantarum/brand-list-item.html
@@ -1,0 +1,17 @@
+<article class="nusantarum-list-card" tabindex="0">
+  <header class="nusantarum-meta">
+    <strong>{{ brand.name }}</strong>
+    <span>{{ brand.origin_city or 'Lokasi belum tersedia' }}</span>
+    <span>Parfum Aktif: {{ brand.active_perfume_count }}</span>
+    {% if brand.profile_url %}
+    <a href="{{ brand.profile_url }}">Profil Brand</a>
+    {% endif %}
+  </header>
+
+  <footer class="nusantarum-meta">
+    <span class="sync-status">{{ brand.nusantarum_status or 'aktif' }}</span>
+    {% if brand.last_perfume_synced_at %}
+    <span>Sinkron {{ brand.last_perfume_synced_at.strftime('%d %b %Y') }}</span>
+    {% endif %}
+  </footer>
+</article>

--- a/src/app/web/templates/components/nusantarum/brand-list.html
+++ b/src/app/web/templates/components/nusantarum/brand-list.html
@@ -1,0 +1,42 @@
+{% if error_message %}
+<div class="nusantarum-empty">
+  <p>{{ error_message }}</p>
+</div>
+{% elif page %}
+<div class="nusantarum-list" role="list">
+  {% if page.items %}
+  {% for brand in page.items %}
+  {% with brand=brand %}
+  {% include 'components/nusantarum/brand-list-item.html' %}
+  {% endwith %}
+  {% endfor %}
+  {% else %}
+  <div class="nusantarum-empty">
+    <p>Belum ada brand yang memenuhi filter. Periksa ulang kota atau status verifikasi.</p>
+  </div>
+  {% endif %}
+</div>
+<div class="nusantarum-pagination">
+  <button
+    type="button"
+    hx-get="/nusantarum/tab/{{ active_tab }}"
+    hx-target="#nusantarum-tab-content"
+    hx-include="#nusantarum-filter-form"
+    hx-vals='{"page": {{ page.page - 1 }}, "page_size": {{ page.page_size }}}'
+    {% if page.page <= 1 %}disabled{% endif %}
+  >Sebelumnya</button>
+  <span>Halaman {{ page.page }} dari {{ page.pages }}</span>
+  <button
+    type="button"
+    hx-get="/nusantarum/tab/{{ active_tab }}"
+    hx-target="#nusantarum-tab-content"
+    hx-include="#nusantarum-filter-form"
+    hx-vals='{"page": {{ page.page + 1 }}, "page_size": {{ page.page_size }}}'
+    {% if page.page >= page.pages %}disabled{% endif %}
+  >Berikutnya</button>
+</div>
+{% else %}
+<div class="nusantarum-empty">
+  <p>Direktori brand belum dapat dimuat.</p>
+</div>
+{% endif %}

--- a/src/app/web/templates/components/nusantarum/filter-panel.html
+++ b/src/app/web/templates/components/nusantarum/filter-panel.html
@@ -1,0 +1,79 @@
+<form
+  id="nusantarum-filter-form"
+  class="nusantarum-filter-panel"
+  hx-get="/nusantarum/tab/{{ active_tab }}"
+  hx-target="#nusantarum-tab-content"
+  hx-trigger="change delay:250ms"
+  hx-include="#nusantarum-filter-form"
+>
+  <h2>Filter Nusantarum</h2>
+  <p class="text-muted">Sesuaikan direktori berdasarkan aroma, lokasi brand, dan status verifikasi.</p>
+
+  <section>
+    <h3>Aroma Families</h3>
+    <div class="filter-chip-group">
+      {% set aroma_options = [
+        "Floral",
+        "Citrus",
+        "Woody",
+        "Oriental",
+        "Fruity",
+        "Gourmand",
+        "Fresh"
+      ] %}
+      {% for option in aroma_options %}
+      <label class="filter-chip">
+        <input type="checkbox" name="families" value="{{ option }}" {% if option in filters.families %}checked{% endif %} />
+        <span>{{ option }}</span>
+      </label>
+      {% endfor %}
+    </div>
+  </section>
+
+  <section>
+    <h3>Kota Brand</h3>
+    <input
+      type="search"
+      name="city"
+      value="{{ filters.city or '' }}"
+      placeholder="Cari kota atau provinsi"
+    />
+  </section>
+
+  <section>
+    <h3>Rentang Harga</h3>
+    <div class="filter-chip-group">
+      <label>
+        <span class="sr-only">Harga minimum</span>
+        <input type="number" name="price_min" min="0" step="50000" value="{{ filters.price_min or '' }}" placeholder="Mulai dari" />
+      </label>
+      <label>
+        <span class="sr-only">Harga maksimum</span>
+        <input type="number" name="price_max" min="0" step="50000" value="{{ filters.price_max or '' }}" placeholder="Sampai" />
+      </label>
+    </div>
+  </section>
+
+  <section>
+    <h3>Status Verifikasi</h3>
+    <label class="toggle">
+      <input type="checkbox" name="verified" value="true" {% if filters.verified %}checked{% endif %} />
+      <span>Hanya tampilkan brand terverifikasi</span>
+    </label>
+  </section>
+
+  {% if sync_status %}
+  <section>
+    <h3>Status Sinkronisasi</h3>
+    <div class="sync-status-list">
+      {% for status in sync_status %}
+      <div class="sync-status-item">
+        <span>{{ status.source|title }}</span>
+        <span>{{ status.run_at.strftime('%d %b %Y %H:%M') }}</span>
+        <span>{{ status.status }}</span>
+      </div>
+      {% endfor %}
+    </div>
+  </section>
+  {% endif %}
+</form>

--- a/src/app/web/templates/components/nusantarum/perfume-list-item.html
+++ b/src/app/web/templates/components/nusantarum/perfume-list-item.html
@@ -1,0 +1,55 @@
+<article class="nusantarum-list-card" tabindex="0">
+  <header class="nusantarum-meta">
+    <strong>{{ perfume.name }}</strong>
+    <span>oleh <a href="/brands/{{ perfume.brand_slug }}">{{ perfume.brand_name }}</a></span>
+    {% if perfume.perfumer_name %}
+    <span>
+      Perfumer:
+      {% if perfume.perfumer_profile_url %}
+      <a href="{{ perfume.perfumer_profile_url }}">{{ perfume.perfumer_name }}</a>
+      {% else %}
+      {{ perfume.perfumer_name }}
+      {% endif %}
+    </span>
+    {% endif %}
+  </header>
+
+  {% if perfume.hero_note %}
+  <p>{{ perfume.hero_note }}</p>
+  {% elif perfume.description %}
+  <p>{{ perfume.description[:180] }}{% if perfume.description|length > 180 %}…{% endif %}</p>
+  {% endif %}
+
+  <div class="nusantarum-meta">
+    {% if perfume.aroma_families %}
+    <span>Aroma: {{ perfume.aroma_families | join(', ') }}</span>
+    {% endif %}
+    {% if perfume.marketplace_price %}
+    <span>Harga Marketplace: Rp{{ '%.0f'|format(perfume.marketplace_price) }}</span>
+    {% elif perfume.price_reference %}
+    <span>Harga Referensi: Rp{{ '%.0f'|format(perfume.price_reference) }}</span>
+    {% endif %}
+    {% if perfume.marketplace_rating %}
+    <span>Rating: {{ '%.1f'|format(perfume.marketplace_rating) }}</span>
+    {% endif %}
+    {% if perfume.brand_profile_url %}
+    <span><a href="{{ perfume.brand_profile_url }}">Profil Brand</a></span>
+    {% endif %}
+    {% if perfume.perfumer_profile_url %}
+    <span><a href="{{ perfume.perfumer_profile_url }}">Profil Perfumer</a></span>
+    {% endif %}
+  </div>
+
+  <footer class="nusantarum-meta">
+    <span class="sync-status">{{ perfume.sync_source|title }} · {{ perfume.sync_status or 'Terjadwal' }}</span>
+    {% if perfume.marketplace_url %}
+    <a href="{{ perfume.marketplace_url }}">Lihat di Marketplace</a>
+    {% endif %}
+  </footer>
+
+  {% if perfume.base_image_url %}
+  <div class="hover-preview">
+    <img src="{{ perfume.base_image_url }}" alt="{{ perfume.name }}" loading="lazy" />
+  </div>
+  {% endif %}
+</article>

--- a/src/app/web/templates/components/nusantarum/perfume-list.html
+++ b/src/app/web/templates/components/nusantarum/perfume-list.html
@@ -1,0 +1,42 @@
+{% if error_message %}
+<div class="nusantarum-empty">
+  <p>{{ error_message }}</p>
+</div>
+{% elif page %}
+<div class="nusantarum-list" role="list">
+  {% if page.items %}
+  {% for perfume in page.items %}
+  {% with perfume=perfume %}
+  {% include 'components/nusantarum/perfume-list-item.html' %}
+  {% endwith %}
+  {% endfor %}
+  {% else %}
+  <div class="nusantarum-empty">
+    <p>Belum ada parfum yang memenuhi filter ini. Coba pilihan aroma atau kota lainnya.</p>
+  </div>
+  {% endif %}
+</div>
+<div class="nusantarum-pagination">
+  <button
+    type="button"
+    hx-get="/nusantarum/tab/{{ active_tab }}"
+    hx-target="#nusantarum-tab-content"
+    hx-include="#nusantarum-filter-form"
+    hx-vals='{"page": {{ page.page - 1 }}, "page_size": {{ page.page_size }}}'
+    {% if page.page <= 1 %}disabled{% endif %}
+  >Sebelumnya</button>
+  <span>Halaman {{ page.page }} dari {{ page.pages }}</span>
+  <button
+    type="button"
+    hx-get="/nusantarum/tab/{{ active_tab }}"
+    hx-target="#nusantarum-tab-content"
+    hx-include="#nusantarum-filter-form"
+    hx-vals='{"page": {{ page.page + 1 }}, "page_size": {{ page.page_size }}}'
+    {% if page.page >= page.pages %}disabled{% endif %}
+  >Berikutnya</button>
+</div>
+{% else %}
+<div class="nusantarum-empty">
+  <p>Direktori belum dapat dimuat.</p>
+</div>
+{% endif %}

--- a/src/app/web/templates/components/nusantarum/perfumer-list-item.html
+++ b/src/app/web/templates/components/nusantarum/perfumer-list-item.html
@@ -1,0 +1,24 @@
+<article class="nusantarum-list-card" tabindex="0">
+  <header class="nusantarum-meta">
+    <strong>{{ perfumer.display_name }}</strong>
+    <span>Karya aktif: {{ perfumer.active_perfume_count }}</span>
+    {% if perfumer.signature_scent %}
+    <span>Signature: {{ perfumer.signature_scent }}</span>
+    {% endif %}
+  </header>
+
+  <div class="nusantarum-meta">
+    {% if perfumer.highlight_perfume %}
+    <span>Sorotan parfum: {{ perfumer.highlight_perfume }}{% if perfumer.highlight_brand %} ({{ perfumer.highlight_brand }}){% endif %}</span>
+    {% endif %}
+    {% if perfumer.profile_url %}
+    <a href="{{ perfumer.profile_url }}">Profil Perfumer</a>
+    {% endif %}
+  </div>
+
+  {% if perfumer.last_synced_at %}
+  <footer class="nusantarum-meta">
+    <span class="sync-status">Sinkron {{ perfumer.last_synced_at.strftime('%d %b %Y') }}</span>
+  </footer>
+  {% endif %}
+</article>

--- a/src/app/web/templates/components/nusantarum/perfumer-list.html
+++ b/src/app/web/templates/components/nusantarum/perfumer-list.html
@@ -1,0 +1,42 @@
+{% if error_message %}
+<div class="nusantarum-empty">
+  <p>{{ error_message }}</p>
+</div>
+{% elif page %}
+<div class="nusantarum-list" role="list">
+  {% if page.items %}
+  {% for perfumer in page.items %}
+  {% with perfumer=perfumer %}
+  {% include 'components/nusantarum/perfumer-list-item.html' %}
+  {% endwith %}
+  {% endfor %}
+  {% else %}
+  <div class="nusantarum-empty">
+    <p>Perfumer aktif belum tersedia untuk filter saat ini.</p>
+  </div>
+  {% endif %}
+</div>
+<div class="nusantarum-pagination">
+  <button
+    type="button"
+    hx-get="/nusantarum/tab/{{ active_tab }}"
+    hx-target="#nusantarum-tab-content"
+    hx-include="#nusantarum-filter-form"
+    hx-vals='{"page": {{ page.page - 1 }}, "page_size": {{ page.page_size }}}'
+    {% if page.page <= 1 %}disabled{% endif %}
+  >Sebelumnya</button>
+  <span>Halaman {{ page.page }} dari {{ page.pages }}</span>
+  <button
+    type="button"
+    hx-get="/nusantarum/tab/{{ active_tab }}"
+    hx-target="#nusantarum-tab-content"
+    hx-include="#nusantarum-filter-form"
+    hx-vals='{"page": {{ page.page + 1 }}, "page_size": {{ page.page_size }}}'
+    {% if page.page >= page.pages %}disabled{% endif %}
+  >Berikutnya</button>
+</div>
+{% else %}
+<div class="nusantarum-empty">
+  <p>Direktori perfumer belum dapat dimuat.</p>
+</div>
+{% endif %}

--- a/src/app/web/templates/components/nusantarum/search-results.html
+++ b/src/app/web/templates/components/nusantarum/search-results.html
@@ -1,0 +1,41 @@
+<div class="nusantarum-search-results" role="status" aria-live="polite">
+  {% if error_message %}
+  <p>{{ error_message }}</p>
+  {% elif results.perfumes or results.brands or results.perfumers %}
+  <div>
+    <strong>Parfum</strong>
+    <ul>
+      {% for item in results.perfumes %}
+      <li>{{ item }}</li>
+      {% endfor %}
+      {% if not results.perfumes %}
+      <li>Tidak ada hasil.</li>
+      {% endif %}
+    </ul>
+  </div>
+  <div>
+    <strong>Brand</strong>
+    <ul>
+      {% for item in results.brands %}
+      <li>{{ item }}</li>
+      {% endfor %}
+      {% if not results.brands %}
+      <li>Tidak ada hasil.</li>
+      {% endif %}
+    </ul>
+  </div>
+  <div>
+    <strong>Perfumer</strong>
+    <ul>
+      {% for item in results.perfumers %}
+      <li>{{ item }}</li>
+      {% endfor %}
+      {% if not results.perfumers %}
+      <li>Tidak ada hasil.</li>
+      {% endif %}
+    </ul>
+  </div>
+  {% else %}
+  <p>Masukkan kata kunci untuk menelusuri katalog.</p>
+  {% endif %}
+</div>

--- a/src/app/web/templates/pages/nusantarum/index.html
+++ b/src/app/web/templates/pages/nusantarum/index.html
@@ -1,0 +1,87 @@
+{% extends 'base.html' %}
+
+{% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/nusantarum.css') }}" />
+{% endblock %}
+
+{% block content %}
+<section class="nusantarum-page">
+  <header class="nusantarum-header">
+    <div>
+      <span class="nusantarum-badge">Direktori Nusantara</span>
+      <h1>Pusat Kurasi Parfum Lokal Indonesia</h1>
+      <p>
+        Jelajahi parfum dari brand terverifikasi, temukan profil perfumer komunitas, dan pantau ketersediaan produk di marketplace Sensasiwangi.
+      </p>
+    </div>
+
+    <form
+      id="nusantarum-search-form"
+      class="nusantarum-search"
+      hx-get="/nusantarum/search"
+      hx-target="#nusantarum-search-results"
+      hx-trigger="keyup changed delay:400ms"
+      hx-indicator="#nusantarum-search-results"
+    >
+      <label class="sr-only" for="nusantarum-search-input">Cari parfum, brand, atau perfumer</label>
+      <input
+        id="nusantarum-search-input"
+        type="search"
+        name="q"
+        placeholder="Cari parfum, brand, atau perfumer"
+        autocomplete="off"
+      />
+    </form>
+    <div id="nusantarum-search-results">
+      {% with results={'perfumes': [], 'brands': [], 'perfumers': []}, error_message=None %}
+      {% include 'components/nusantarum/search-results.html' %}
+      {% endwith %}
+    </div>
+
+    <nav class="nusantarum-tabs" role="tablist">
+      <button
+        type="button"
+        class="nusantarum-tab"
+        role="tab"
+        aria-selected="{{ 'true' if active_tab == 'parfum' else 'false' }}"
+        hx-get="/nusantarum/tab/parfum"
+        hx-target="#nusantarum-tab-content"
+        hx-include="#nusantarum-filter-form"
+        hx-on::after-request="document.getElementById('nusantarum-filter-form')?.setAttribute('hx-get', '/nusantarum/tab/parfum')"
+      >Parfum</button>
+      <button
+        type="button"
+        class="nusantarum-tab"
+        role="tab"
+        aria-selected="{{ 'true' if active_tab == 'brand' else 'false' }}"
+        hx-get="/nusantarum/tab/brand"
+        hx-target="#nusantarum-tab-content"
+        hx-include="#nusantarum-filter-form"
+        hx-on::after-request="document.getElementById('nusantarum-filter-form')?.setAttribute('hx-get', '/nusantarum/tab/brand')"
+      >Brand</button>
+      <button
+        type="button"
+        class="nusantarum-tab"
+        role="tab"
+        aria-selected="{{ 'true' if active_tab == 'perfumer' else 'false' }}"
+        hx-get="/nusantarum/tab/perfumer"
+        hx-target="#nusantarum-tab-content"
+        hx-include="#nusantarum-filter-form"
+        hx-on::after-request="document.getElementById('nusantarum-filter-form')?.setAttribute('hx-get', '/nusantarum/tab/perfumer')"
+      >Perfumer</button>
+    </nav>
+  </header>
+
+  <div class="nusantarum-body">
+    {% with filters=filters, sync_status=sync_status, active_tab=active_tab %}
+    {% include 'components/nusantarum/filter-panel.html' %}
+    {% endwith %}
+
+    <section id="nusantarum-tab-content" aria-live="polite" aria-busy="false">
+      {% with page=perfume_page, error_message=error_message, active_tab=active_tab %}
+      {% include 'components/nusantarum/perfume-list.html' %}
+      {% endwith %}
+    </section>
+  </div>
+</section>
+{% endblock %}

--- a/supabase/migrations/0003_nusantarum_schema.sql
+++ b/supabase/migrations/0003_nusantarum_schema.sql
@@ -1,0 +1,430 @@
+-- Nusantarum data model, marketplace integration, and profile linkage
+-- Implements docs/nusantarum-implementation-plan.md foundation
+
+set check_function_bodies = off;
+set search_path = public;
+
+-- ---------------------------------------------------------------------------
+-- Brand enrichment for Nusantarum directory
+-- ---------------------------------------------------------------------------
+
+alter table brands
+    add column if not exists nusantarum_status text not null default 'draft',
+    add column if not exists is_verified boolean not null default false,
+    add column if not exists brand_profile_id uuid references user_profiles(id);
+
+alter table user_profiles
+    add column if not exists username citext unique;
+
+-- ---------------------------------------------------------------------------
+-- Core Nusantarum entities
+-- ---------------------------------------------------------------------------
+
+create table if not exists perfumers (
+    id uuid primary key default gen_random_uuid(),
+    slug text not null,
+    display_name text not null,
+    biography text,
+    signature_scent text,
+    website_url text,
+    instagram_handle text,
+    perfumer_profile_id uuid references user_profiles(id),
+    is_featured boolean not null default false,
+    is_verified boolean not null default false,
+    is_linked_to_active_perfume boolean not null default false,
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now()),
+    constraint perfumers_slug_key unique (slug)
+);
+
+create trigger set_updated_at_perfumers
+    before update on perfumers
+    for each row execute function set_updated_at();
+
+create table if not exists parfums (
+    id uuid primary key default gen_random_uuid(),
+    slug text not null,
+    name text not null,
+    description text,
+    hero_note text,
+    aroma_families text[] not null default '{}'::text[],
+    accords jsonb not null default '[]'::jsonb,
+    release_year integer,
+    price_reference numeric(12,2),
+    price_currency text not null default 'IDR',
+    marketplace_rating numeric(4,2),
+    base_image_url text,
+    brand_id uuid not null references brands(id) on delete cascade,
+    perfumer_id uuid references perfumers(id) on delete set null,
+    marketplace_product_id uuid references products(id) on delete set null,
+    is_active boolean not null default true,
+    is_displayable boolean not null default false,
+    sync_source text not null default 'manual',
+    sync_status text default 'pending',
+    synced_at timestamptz,
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now()),
+    constraint parfums_slug_key unique (slug)
+);
+
+create trigger set_updated_at_parfums
+    before update on parfums
+    for each row execute function set_updated_at();
+
+create table if not exists perfume_notes (
+    id bigserial primary key,
+    parfum_id uuid not null references parfums(id) on delete cascade,
+    note_type text not null check (note_type in ('top', 'middle', 'base')),
+    note text not null,
+    position integer not null default 0
+);
+
+create table if not exists perfume_assets (
+    id uuid primary key default gen_random_uuid(),
+    parfum_id uuid not null references parfums(id) on delete cascade,
+    asset_type text not null default 'image',
+    file_path text not null,
+    alt_text text,
+    metadata jsonb not null default '{}'::jsonb,
+    position integer not null default 0,
+    created_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists parfum_audits (
+    id bigserial primary key,
+    parfum_id uuid,
+    action text not null,
+    payload jsonb not null,
+    actor_id uuid references user_profiles(id),
+    created_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists nusantarum_sync_logs (
+    id bigserial primary key,
+    source text not null,
+    status text not null,
+    summary text,
+    payload jsonb not null default '{}'::jsonb,
+    run_by uuid references user_profiles(id),
+    run_at timestamptz not null default timezone('utc', now())
+);
+
+-- ---------------------------------------------------------------------------
+-- Helper functions and triggers
+-- ---------------------------------------------------------------------------
+
+create or replace function set_parfum_displayable()
+returns trigger
+language plpgsql
+as $$
+declare
+    brand_verified boolean := false;
+begin
+    select coalesce(is_verified, false)
+      into brand_verified
+      from brands
+     where id = new.brand_id;
+
+    new.is_displayable := coalesce(new.is_active, false) and brand_verified;
+    return new;
+end;
+$$;
+
+create trigger parfums_displayable_guard
+    before insert or update on parfums
+    for each row execute function set_parfum_displayable();
+
+create or replace function maintain_parfum_displayable_from_brand()
+returns trigger
+language plpgsql
+as $$
+begin
+    update parfums
+       set is_displayable = (new.is_verified and parfums.is_active)
+     where brand_id = new.id;
+    return new;
+end;
+$$;
+
+create trigger parfums_brand_displayable
+    after update of is_verified on brands
+    for each row execute function maintain_parfum_displayable_from_brand();
+
+create or replace function update_perfumer_link_flag(perfumer uuid)
+returns void
+language plpgsql
+as $$
+begin
+    update perfumers p
+       set is_linked_to_active_perfume = exists (
+            select 1
+              from parfums pf
+              join brands b on b.id = pf.brand_id
+             where pf.perfumer_id = p.id
+               and pf.is_active
+               and b.is_verified
+        )
+     where p.id = perfumer;
+end;
+$$;
+
+create or replace function refresh_perfumer_link()
+returns trigger
+language plpgsql
+as $$
+begin
+    if tg_op = 'DELETE' then
+        if old.perfumer_id is not null then
+            perform update_perfumer_link_flag(old.perfumer_id);
+        end if;
+        return old;
+    end if;
+
+    if new.perfumer_id is not null then
+        perform update_perfumer_link_flag(new.perfumer_id);
+    end if;
+
+    if tg_op = 'UPDATE' and old.perfumer_id is distinct from new.perfumer_id and old.perfumer_id is not null then
+        perform update_perfumer_link_flag(old.perfumer_id);
+    end if;
+
+    return new;
+end;
+$$;
+
+create trigger parfums_perfumer_link_refresh
+    after insert or update or delete on parfums
+    for each row execute function refresh_perfumer_link();
+
+create or replace function log_parfum_audit()
+returns trigger
+language plpgsql
+as $$
+declare
+    actor uuid;
+begin
+    begin
+        actor := nullif(current_setting('app.current_actor', true), '')::uuid;
+    exception when others then
+        actor := null;
+    end;
+
+    if tg_op = 'DELETE' then
+        insert into parfum_audits(parfum_id, action, payload, actor_id)
+        values (old.id, tg_op, to_jsonb(old), actor);
+        return old;
+    else
+        insert into parfum_audits(parfum_id, action, payload, actor_id)
+        values (new.id, tg_op, to_jsonb(new), actor);
+        return new;
+    end if;
+end;
+$$;
+
+create trigger parfums_audit_log
+    after insert or update or delete on parfums
+    for each row execute function log_parfum_audit();
+
+-- ---------------------------------------------------------------------------
+-- Marketplace and profile driven views
+-- ---------------------------------------------------------------------------
+
+create or replace view marketplace_product_snapshot as
+select
+    p.id as product_id,
+    p.brand_id,
+    p.name,
+    p.slug,
+    p.highlight_aroma,
+    p.price_currency,
+    coalesce(ml.list_price, p.price_low) as list_price,
+    ml.compare_at_price,
+    ml.stock_on_hand,
+    ml.stock_reserved,
+    ml.status as marketplace_status,
+    ml.updated_at as marketplace_updated_at,
+    p.updated_at as product_updated_at
+from products p
+left join marketplace_listings ml on ml.product_id = p.id
+where p.marketplace_enabled;
+
+create or replace view perfumer_showcase as
+select
+    pr.id as perfumer_id,
+    pr.slug as perfumer_slug,
+    pr.display_name,
+    pr.signature_scent,
+    pr.is_linked_to_active_perfume,
+    pf.id as parfum_id,
+    pf.slug as parfum_slug,
+    pf.name as parfum_name,
+    b.slug as brand_slug,
+    b.name as brand_name
+from perfumers pr
+left join parfums pf on pf.perfumer_id = pr.id and pf.is_active
+left join brands b on b.id = pf.brand_id
+where b.is_verified;
+
+create or replace view nusantarum_perfume_directory as
+select
+    pf.id,
+    pf.slug,
+    pf.name,
+    pf.hero_note,
+    pf.aroma_families,
+    pf.release_year,
+    pf.price_reference,
+    pf.price_currency,
+    pf.marketplace_rating,
+    pf.description,
+    pf.base_image_url,
+    pf.sync_source,
+    pf.sync_status,
+    pf.synced_at,
+    pf.is_displayable,
+    pf.is_active,
+    pf.updated_at,
+    b.id as brand_id,
+    b.slug as brand_slug,
+    b.name as brand_name,
+    b.origin_city as brand_city,
+    b.is_verified as brand_is_verified,
+    b.nusantarum_status,
+    mp.list_price as marketplace_price,
+    mp.marketplace_status,
+    mp.stock_on_hand,
+    mp.marketplace_updated_at,
+    pf.marketplace_product_id,
+    pr.slug as perfumer_slug,
+    pr.display_name as perfumer_name,
+    pr.signature_scent,
+    pr.is_verified as perfumer_verified,
+    pr.is_linked_to_active_perfume,
+    up.username as perfumer_profile_username,
+    ub.username as brand_profile_username
+from parfums pf
+join brands b on b.id = pf.brand_id
+left join marketplace_product_snapshot mp on mp.product_id = pf.marketplace_product_id
+left join perfumers pr on pr.id = pf.perfumer_id
+left join user_profiles up on up.id = pr.perfumer_profile_id
+left join user_profiles ub on ub.id = b.brand_profile_id
+where b.is_verified and pf.is_active;
+
+create or replace view nusantarum_brand_directory as
+select
+    b.id,
+    b.slug,
+    b.name,
+    b.origin_city,
+    b.nusantarum_status,
+    b.is_verified,
+    b.brand_profile_id,
+    ub.username as brand_profile_username,
+    coalesce(stats.active_count, 0) as active_perfume_count,
+    stats.last_perfume_synced_at
+from brands b
+left join (
+    select
+        brand_id,
+        count(*) filter (where is_active) as active_count,
+        max(synced_at) as last_perfume_synced_at
+    from parfums
+    where is_displayable
+    group by brand_id
+) stats on stats.brand_id = b.id
+left join user_profiles ub on ub.id = b.brand_profile_id
+where b.is_verified;
+
+create or replace view nusantarum_perfumer_directory as
+select
+    pr.id,
+    pr.slug,
+    pr.display_name,
+    pr.signature_scent,
+    pr.is_verified,
+    pr.is_linked_to_active_perfume,
+    pr.perfumer_profile_id,
+    up.username as perfumer_profile_username,
+    coalesce(stats.active_perfume_count, 0) as active_perfume_count,
+    stats.highlight_perfume,
+    stats.highlight_brand,
+    stats.last_synced_at
+from perfumers pr
+left join (
+    select
+        pf.perfumer_id,
+        count(*) filter (where pf.is_active) as active_perfume_count,
+        max(pf.synced_at) as last_synced_at,
+        max(pf.name) filter (where pf.is_displayable) as highlight_perfume,
+        max(b.name) filter (where pf.is_displayable) as highlight_brand
+    from parfums pf
+    join brands b on b.id = pf.brand_id
+    where b.is_verified
+    group by pf.perfumer_id
+) stats on stats.perfumer_id = pr.id
+left join user_profiles up on up.id = pr.perfumer_profile_id
+where pr.is_linked_to_active_perfume;
+
+-- ---------------------------------------------------------------------------
+-- Row level security for public consumption
+-- ---------------------------------------------------------------------------
+
+alter table perfumers enable row level security;
+alter table parfums enable row level security;
+alter table perfume_notes enable row level security;
+alter table perfume_assets enable row level security;
+alter table parfum_audits enable row level security;
+alter table nusantarum_sync_logs enable row level security;
+
+create policy perfumers_public_read on perfumers for select using (true);
+create policy parfums_public_read on parfums for select using (true);
+create policy perfume_notes_public_read on perfume_notes for select using (true);
+create policy perfume_assets_public_read on perfume_assets for select using (true);
+
+create policy perfumers_curator_write on perfumers for all
+    using ((auth.jwt() ->> 'role') in ('admin', 'brand_owner'))
+    with check ((auth.jwt() ->> 'role') in ('admin', 'brand_owner'));
+
+create policy parfums_curator_write on parfums for all
+    using ((auth.jwt() ->> 'role') in ('admin', 'brand_owner'))
+    with check ((auth.jwt() ->> 'role') in ('admin', 'brand_owner'));
+
+create policy perfume_notes_curator_write on perfume_notes for all
+    using ((auth.jwt() ->> 'role') in ('admin', 'brand_owner'))
+    with check ((auth.jwt() ->> 'role') in ('admin', 'brand_owner'));
+
+create policy perfume_assets_curator_write on perfume_assets for all
+    using ((auth.jwt() ->> 'role') in ('admin', 'brand_owner'))
+    with check ((auth.jwt() ->> 'role') in ('admin', 'brand_owner'));
+
+create policy parfum_audits_admin_read on parfum_audits for select
+    using ((auth.jwt() ->> 'role') in ('admin', 'brand_owner'));
+
+create policy sync_logs_admin_all on nusantarum_sync_logs for all
+    using ((auth.jwt() ->> 'role') in ('admin'))
+    with check ((auth.jwt() ->> 'role') in ('admin'));
+
+-- ---------------------------------------------------------------------------
+-- Supabase helper functions for background workers
+-- ---------------------------------------------------------------------------
+
+create or replace function sync_marketplace_products()
+returns void
+language plpgsql
+as $$
+begin
+    insert into nusantarum_sync_logs(source, status, summary)
+    values ('marketplace', 'queued', 'Marketplace product sync triggered');
+end;
+$$;
+
+create or replace function sync_nusantarum_profiles()
+returns void
+language plpgsql
+as $$
+begin
+    insert into nusantarum_sync_logs(source, status, summary)
+    values ('profiles', 'queued', 'Profile sync triggered');
+end;
+$$;
+

--- a/tests/test_nusantarum_api.py
+++ b/tests/test_nusantarum_api.py
@@ -1,0 +1,195 @@
+"""API tests for Nusantarum router without relying on external HTTP clients."""
+import json
+from datetime import datetime
+from typing import Any, Dict, List, Tuple
+
+import asyncio
+
+import pytest
+
+from app.api.routes.nusantarum import get_service
+from app.main import app
+from app.services.nusantarum_service import (
+    BrandListItem,
+    NusantarumConfigurationError,
+    PagedResult,
+    PerfumeListItem,
+    PerfumerListItem,
+    SyncLog,
+)
+
+
+class FakeNusantarumService:
+    def __init__(self) -> None:
+        self.triggered: List[str] = []
+
+    async def list_perfumes(self, **_: Any) -> PagedResult:
+        perfume = PerfumeListItem(
+            id="pf-1",
+            name="Hutan Senja",
+            slug="hutan-senja",
+            brand_name="Langit Senja",
+            brand_slug="langit-senja",
+            brand_city="Bandung",
+            brand_profile_username="langit-senja",
+            perfumer_name="Ayu Pratiwi",
+            perfumer_slug="ayu-pratiwi",
+            perfumer_profile_username="ayu-pratiwi",
+            hero_note="Jasmine dan kayu cendana",
+            description="Aroma nostalgia senja di hutan pinus.",
+            aroma_families=["Floral", "Woody"],
+            price_reference=450000,
+            price_currency="IDR",
+            marketplace_price=470000,
+            marketplace_status="published",
+            marketplace_product_id="prod-1",
+            base_image_url="https://cdn.example.com/hutan-senja.jpg",
+            sync_source="marketplace",
+            sync_status="success",
+            synced_at=None,
+            updated_at=None,
+            marketplace_rating=4.7,
+        )
+        return PagedResult(items=[perfume], total=1, page=1, page_size=12)
+
+    async def list_brands(self, **_: Any) -> PagedResult:
+        brand = BrandListItem(
+            id="brand-1",
+            name="Langit Senja",
+            slug="langit-senja",
+            origin_city="Bandung",
+            active_perfume_count=3,
+            nusantarum_status="aktif",
+            brand_profile_username="langit-senja",
+            last_perfume_synced_at=None,
+        )
+        return PagedResult(items=[brand], total=1, page=1, page_size=12)
+
+    async def list_perfumers(self, **_: Any) -> PagedResult:
+        perfumer = PerfumerListItem(
+            id="pfmr-1",
+            display_name="Ayu Pratiwi",
+            slug="ayu-pratiwi",
+            signature_scent="Tropical jasmine",
+            active_perfume_count=2,
+            perfumer_profile_username="ayu-pratiwi",
+            highlight_perfume="Hutan Senja",
+            highlight_brand="Langit Senja",
+            last_synced_at=None,
+        )
+        return PagedResult(items=[perfumer], total=1, page=1, page_size=12)
+
+    async def search(self, query: str, limit: int = 5) -> Dict[str, List[str]]:
+        return {
+            "perfumes": [f"{query.title()} Parfum"],
+            "brands": [f"{query.title()} Brand"],
+            "perfumers": [f"{query.title()} Perfumer"],
+        }
+
+    async def get_sync_status(self) -> List[SyncLog]:
+        return [
+            SyncLog(
+                source="marketplace",
+                status="success",
+                summary="Synced",
+                run_at=datetime(2024, 4, 2, 10, 0, 0),
+            )
+        ]
+
+    async def trigger_sync(self, source: str) -> None:
+        self.triggered.append(source)
+
+
+class ErrorService(FakeNusantarumService):
+    async def list_perfumes(self, **_: Any) -> PagedResult:
+        raise NusantarumConfigurationError("Supabase credentials belum dikonfigurasi")
+
+
+@pytest.fixture
+def fake_service() -> FakeNusantarumService:
+    service = FakeNusantarumService()
+    app.dependency_overrides[get_service] = lambda: service
+    yield service
+    app.dependency_overrides.clear()
+
+
+async def _send_request(
+    method: str,
+    path: str,
+    *,
+    query_string: str = "",
+    body: bytes = b"",
+    headers: List[Tuple[bytes, bytes]] | None = None,
+) -> Tuple[int, Dict[str, str], bytes]:
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("ascii"),
+        "query_string": query_string.encode("ascii"),
+        "headers": headers or [],
+        "client": ("127.0.0.1", 0),
+        "server": ("testserver", 80),
+    }
+    messages: List[Dict[str, Any]] = []
+
+    async def receive() -> Dict[str, Any]:
+        nonlocal body
+        chunk = body
+        body = b""
+        return {"type": "http.request", "body": chunk, "more_body": False}
+
+    async def send(message: Dict[str, Any]) -> None:
+        messages.append(message)
+
+    await app(scope, receive, send)
+
+    status = next(m["status"] for m in messages if m["type"] == "http.response.start")
+    raw_headers = next(m["headers"] for m in messages if m["type"] == "http.response.start")
+    response_headers = {key.decode().lower(): value.decode() for key, value in raw_headers}
+    body_bytes = b"".join(m["body"] for m in messages if m["type"] == "http.response.body")
+    return status, response_headers, body_bytes
+
+
+def test_index_page_renders_with_perfume_list(fake_service: FakeNusantarumService) -> None:
+    status, headers, body = asyncio.run(_send_request("GET", "/nusantarum"))
+    assert status == 200
+    assert headers["content-type"].startswith("text/html")
+    text = body.decode()
+    assert "Hutan Senja" in text
+    assert "Pusat Kurasi Parfum Lokal Indonesia" in text
+
+
+def test_tab_endpoint_returns_partial(fake_service: FakeNusantarumService) -> None:
+    status, headers, body = asyncio.run(_send_request("GET", "/nusantarum/tab/brand"))
+    assert status == 200
+    assert headers["content-type"].startswith("text/html")
+    assert "Langit Senja" in body.decode()
+
+
+def test_search_endpoint_returns_html(fake_service: FakeNusantarumService) -> None:
+    status, headers, body = asyncio.run(
+        _send_request("GET", "/nusantarum/search", query_string="q=senja")
+    )
+    assert status == 200
+    assert headers["content-type"].startswith("text/html")
+    assert "Senja Parfum" in body.decode()
+
+
+def test_trigger_sync_records_source(fake_service: FakeNusantarumService) -> None:
+    status, headers, body = asyncio.run(
+        _send_request("POST", "/nusantarum/sync/marketplace")
+    )
+    assert status == 200
+    assert json.loads(body)["status"] == "queued"
+    assert fake_service.triggered == ["marketplace"]
+
+
+def test_index_handles_configuration_error() -> None:
+    app.dependency_overrides[get_service] = lambda: ErrorService()
+    status, headers, body = asyncio.run(_send_request("GET", "/nusantarum"))
+    assert status == 200
+    assert "Supabase credentials" in body.decode()
+    app.dependency_overrides.clear()

--- a/tests/test_nusantarum_service.py
+++ b/tests/test_nusantarum_service.py
@@ -1,0 +1,161 @@
+"""Unit tests for the Nusantarum service layer."""
+
+import asyncio
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Sequence, Tuple
+
+import pytest
+
+from app.services.nusantarum_service import (
+    NusantarumService,
+    PerfumeListItem,
+)
+
+
+class DummyGateway:
+    """In-memory gateway faking Supabase responses for the service tests."""
+
+    def __init__(self) -> None:
+        self.calls: List[Tuple[str, Sequence[Tuple[str, Any]]]] = []
+        self.perfume_rows = [
+            {
+                "id": "pf-1",
+                "name": "Hutan Senja",
+                "slug": "hutan-senja",
+                "brand_name": "Langit Senja",
+                "brand_slug": "langit-senja",
+                "brand_city": "Bandung",
+                "brand_profile_username": "langit-senja",
+                "perfumer_name": "Ayu Pratiwi",
+                "perfumer_slug": "ayu-pratiwi",
+                "perfumer_profile_username": "ayu-pratiwi",
+                "hero_note": "Jasmine dan kayu cendana",
+                "description": "Aroma nostalgia senja di hutan pinus.",
+                "aroma_families": ["Floral", "Woody"],
+                "price_reference": 450000,
+                "price_currency": "IDR",
+                "marketplace_price": 470000,
+                "marketplace_status": "published",
+                "marketplace_product_id": "prod-1",
+                "base_image_url": "https://cdn.example.com/hutan-senja.jpg",
+                "sync_source": "marketplace",
+                "sync_status": "success",
+                "synced_at": "2024-04-01T08:30:00+00:00",
+                "updated_at": "2024-04-02T10:00:00+00:00",
+                "marketplace_rating": 4.7,
+            }
+        ]
+        self.brand_rows = [
+            {
+                "id": "brand-1",
+                "name": "Langit Senja",
+                "slug": "langit-senja",
+                "origin_city": "Bandung",
+                "active_perfume_count": 3,
+                "nusantarum_status": "aktif",
+                "brand_profile_username": "langit-senja",
+                "last_perfume_synced_at": "2024-04-01T08:30:00+00:00",
+            }
+        ]
+        self.perfumer_rows = [
+            {
+                "id": "pfmr-1",
+                "slug": "ayu-pratiwi",
+                "display_name": "Ayu Pratiwi",
+                "signature_scent": "Tropical jasmine",
+                "active_perfume_count": 2,
+                "perfumer_profile_username": "ayu-pratiwi",
+                "highlight_perfume": "Hutan Senja",
+                "highlight_brand": "Langit Senja",
+                "last_synced_at": "2024-04-02T10:00:00+00:00",
+            }
+        ]
+        self.sync_logs = [
+            {
+                "source": "marketplace",
+                "status": "success",
+                "summary": "Synced",
+                "run_at": "2024-04-02T11:00:00+00:00",
+            }
+        ]
+        self.rpc_calls: List[str] = []
+
+    async def fetch_directory(
+        self,
+        resource: str,
+        *,
+        page: int,
+        page_size: int,
+        filters: Iterable[Tuple[str, Any]] | None = None,
+        order: str | None = None,
+    ) -> Dict[str, Any]:
+        self.calls.append((resource, tuple(filters or [])))
+        data_map = {
+            "nusantarum_perfume_directory": self.perfume_rows,
+            "nusantarum_brand_directory": self.brand_rows,
+            "nusantarum_perfumer_directory": self.perfumer_rows,
+        }
+        data = data_map.get(resource, [])
+        return {"data": data, "total": len(data)}
+
+    async def fetch_sync_logs(self, *, limit: int = 5) -> List[Dict[str, Any]]:
+        return self.sync_logs[:limit]
+
+    async def rpc(self, name: str, payload: Dict[str, Any] | None = None) -> Any:
+        self.rpc_calls.append(name)
+        return None
+
+
+def test_list_perfumes_transforms_rows_and_caches() -> None:
+    gateway = DummyGateway()
+    service = NusantarumService(gateway=gateway, cache_ttl=60)
+
+    result = asyncio.run(
+        service.list_perfumes(families=["Floral"], city="Bandung", price_min=400000)
+    )
+
+    assert isinstance(result.items[0], PerfumeListItem)
+    assert result.items[0].brand_profile_url == "/profile/langit-senja"
+    assert result.items[0].marketplace_url == "/marketplace/products/prod-1"
+    assert gateway.calls, "Gateway should have been called"
+
+    # Second call with identical filters should hit the cache
+    asyncio.run(service.list_perfumes(families=["Floral"], city="Bandung", price_min=400000))
+    assert len(gateway.calls) == 1
+
+
+def test_list_brands_and_perfumers_use_directory_views() -> None:
+    gateway = DummyGateway()
+    service = NusantarumService(gateway=gateway, cache_ttl=0)
+
+    brand_page = asyncio.run(service.list_brands(city="Bandung"))
+    perfumer_page = asyncio.run(service.list_perfumers())
+
+    assert brand_page.items[0].name == "Langit Senja"
+    assert perfumer_page.items[0].display_name == "Ayu Pratiwi"
+    resources = {call[0] for call in gateway.calls}
+    assert "nusantarum_brand_directory" in resources
+    assert "nusantarum_perfumer_directory" in resources
+
+
+def test_get_sync_status_and_trigger_sync_call_gateway() -> None:
+    gateway = DummyGateway()
+    service = NusantarumService(gateway=gateway)
+
+    status = asyncio.run(service.get_sync_status())
+    assert status[0].source == "marketplace"
+    assert isinstance(status[0].run_at, datetime)
+
+    asyncio.run(service.trigger_sync("marketplace"))
+    assert gateway.rpc_calls == ["sync_marketplace_products"]
+
+
+def test_search_combines_categories() -> None:
+    gateway = DummyGateway()
+    service = NusantarumService(gateway=gateway, cache_ttl=0)
+
+    results = asyncio.run(service.search("senja"))
+
+    assert "Hutan Senja" in results["perfumes"]
+    assert "Langit Senja" in results["brands"]
+    assert "Ayu Pratiwi" in results["perfumers"]


### PR DESCRIPTION
## Summary
- add Supabase migration for Nusantarum parfums, perfumers, sync logs, and curated directory views
- implement a cached service layer with graceful httpx fallback plus FastAPI router for tabs, search, and sync triggers
- build HTMX-powered templates and styling for the Nusantarum directory along with unit and API tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8b57aa6608327a21ae09c51e65848