### PR TITLE
Add brand owner dashboard experience

### DIFF
--- a/src/app/api/routes/root.py
+++ b/src/app/api/routes/root.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 
 from app.core.config import get_settings
+from app.services.brand_dashboard import brand_dashboard_service
 from app.services.products import product_service
 from app.services.sambatan import SambatanCampaign, sambatan_service
 
@@ -1010,3 +1011,21 @@ async def read_purchase_foundation(request: Request) -> HTMLResponse:
         "flows": PURCHASE_FLOW_BLUEPRINT,
     }
     return templates.TemplateResponse("purchase_workflow.html", context)
+
+
+@router.get("/dashboard/brand-owner", response_class=HTMLResponse)
+async def read_brand_owner_dashboard(request: Request) -> HTMLResponse:
+    """Render the operational dashboard playground for brand owners."""
+
+    settings = get_settings()
+    templates = request.app.state.templates
+    snapshot = brand_dashboard_service.get_snapshot()
+
+    context = {
+        "request": request,
+        "app_name": settings.app_name,
+        "environment": settings.environment,
+        "title": "Dashboard Brand Owner",
+        "snapshot": snapshot,
+    }
+    return templates.TemplateResponse("pages/dashboard/brand_owner.html", context)

--- a/src/app/services/__init__.py
+++ b/src/app/services/__init__.py
@@ -2,6 +2,7 @@
 
 from .auth import AuthService, auth_service
 from .brands import BrandService, brand_service
+from .brand_dashboard import BrandOwnerDashboardService, brand_dashboard_service
 from .onboarding import OnboardingService, onboarding_service
 from .products import ProductService, product_service
 from .nusantarum_service import (
@@ -20,6 +21,8 @@ __all__ = [
     "auth_service",
     "BrandService",
     "brand_service",
+    "BrandOwnerDashboardService",
+    "brand_dashboard_service",
     "OnboardingService",
     "onboarding_service",
     "ProductService",

--- a/src/app/services/brand_dashboard.py
+++ b/src/app/services/brand_dashboard.py
@@ -1,0 +1,542 @@
+"""Service layer providing demo data for the brand owner dashboard."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Iterable, List
+
+
+@dataclass(frozen=True)
+class DashboardKPI:
+    """Represents a key metric surfaced on the dashboard hero area."""
+
+    label: str
+    value: str
+    delta_label: str
+    is_positive: bool
+
+
+@dataclass(frozen=True)
+class OrderStatusSummary:
+    """Aggregated counts for the order status overview chips."""
+
+    label: str
+    count: int
+    tone: str
+
+
+@dataclass(frozen=True)
+class DashboardNotification:
+    """Important alert surfaced to the operator."""
+
+    category: str
+    message: str
+    urgency: str
+
+
+@dataclass(frozen=True)
+class ManagedProduct:
+    """Simplified representation of a product row."""
+
+    name: str
+    status: str
+    stock_level: str
+    price: str
+    updated: str
+    sku: str
+
+
+@dataclass(frozen=True)
+class ManagedOrder:
+    """Recent order entries shown in the order table."""
+
+    invoice: str
+    customer: str
+    items: int
+    total: str
+    status: str
+    updated: str
+
+
+@dataclass(frozen=True)
+class PromotionSnapshot:
+    """Short summary of an active promotion or campaign."""
+
+    name: str
+    status: str
+    goal: str
+    progress_percent: int
+    period: str
+
+
+@dataclass(frozen=True)
+class VerificationStep:
+    """Individual step of the brand verification workflow."""
+
+    title: str
+    status: str
+    description: str
+
+
+@dataclass(frozen=True)
+class VerificationDocument:
+    """Document checklist item for verification."""
+
+    name: str
+    status: str
+    note: str | None = None
+
+
+@dataclass(frozen=True)
+class TeamMember:
+    """Represents a collaborator within the brand team."""
+
+    name: str
+    role: str
+    email: str
+    last_active: str
+    permissions: List[str]
+
+
+@dataclass(frozen=True)
+class TeamInvitation:
+    """Pending invitation state for collaborators."""
+
+    email: str
+    role: str
+    sent_at: str
+    expires_at: str
+
+
+@dataclass(frozen=True)
+class ActivityLog:
+    """Audit log entries for transparency."""
+
+    timestamp: str
+    actor: str
+    action: str
+
+
+class BrandOwnerDashboardService:
+    """Encapsulates dashboard specific demo data for the brand owner persona."""
+
+    def __init__(self) -> None:
+        self._brand_profile = {
+            "brand_name": "Studio Senja",
+            "tagline": "Kelola katalog, pesanan, dan tim dalam satu layar.",
+            "owner_name": "Ayu Prameswari",
+            "sync_status": "Sinkronisasi stok terakhir 2 menit lalu",
+        }
+
+        self._kpis: List[DashboardKPI] = [
+            DashboardKPI(
+                label="Penjualan Bulan Ini",
+                value="Rp182,4 Jt",
+                delta_label="+12,4% dibanding bulan lalu",
+                is_positive=True,
+            ),
+            DashboardKPI(
+                label="Pesanan Aktif",
+                value="128",
+                delta_label="18 perlu tindak lanjut hari ini",
+                is_positive=False,
+            ),
+            DashboardKPI(
+                label="Rata-rata Nilai Order",
+                value="Rp1,42 Jt",
+                delta_label="+6,1% dalam 30 hari",
+                is_positive=True,
+            ),
+            DashboardKPI(
+                label="SKU Stok Kritis",
+                value="6",
+                delta_label="Segera jadwalkan restock",
+                is_positive=False,
+            ),
+        ]
+
+        self._order_statuses: List[OrderStatusSummary] = [
+            OrderStatusSummary(label="Baru", count=24, tone="info"),
+            OrderStatusSummary(label="Diproses", count=42, tone="primary"),
+            OrderStatusSummary(label="Dikirim", count=51, tone="success"),
+            OrderStatusSummary(label="Perlu Perhatian", count=11, tone="warning"),
+        ]
+
+        self._notifications: List[DashboardNotification] = [
+            DashboardNotification(
+                category="Stok",
+                message="Euforia Pagi tinggal 14 botol di gudang utama.",
+                urgency="Tinggi",
+            ),
+            DashboardNotification(
+                category="Pesanan",
+                message="3 pesanan pre-order melewati SLA konfirmasi 24 jam.",
+                urgency="Sedang",
+            ),
+            DashboardNotification(
+                category="Verifikasi",
+                message="Kurator meminta revisi portofolio foto untuk tahap verifikasi brand.",
+                urgency="Perlu Tindakan",
+            ),
+        ]
+
+        self._products: List[ManagedProduct] = [
+            ManagedProduct(
+                name="Euforia Pagi Eau de Parfum",
+                status="aktif",
+                stock_level="128 unit",
+                price="Rp475.000",
+                updated="3 jam lalu",
+                sku="STJ-EFP-50",
+            ),
+            ManagedProduct(
+                name="Galaksi Senja Discovery Set",
+                status="aktif",
+                stock_level="64 set",
+                price="Rp320.000",
+                updated="1 hari lalu",
+                sku="STJ-GS-DSC",
+            ),
+            ManagedProduct(
+                name="Sampler Atelier Eksklusif",
+                status="draft",
+                stock_level="--",
+                price="Rp180.000",
+                updated="Menunggu foto",
+                sku="STJ-SMPLR",
+            ),
+            ManagedProduct(
+                name="Seri Kolaborasi Nusantarum x Studio Senja",
+                status="pending",
+                stock_level="Batch 1: 80",
+                price="Rp520.000",
+                updated="Butuh approval",
+                sku="STJ-NUSA-01",
+            ),
+            ManagedProduct(
+                name="Refill Base Oil 1L",
+                status="arsip",
+                stock_level="0",
+                price="Rp850.000",
+                updated="Diarsipkan 12 Mei",
+                sku="STJ-RFL-1L",
+            ),
+        ]
+
+        self._orders: List[ManagedOrder] = [
+            ManagedOrder(
+                invoice="INV-240512-9812",
+                customer="Rina Maheswari",
+                items=3,
+                total="Rp1.420.000",
+                status="Diproses",
+                updated="10 menit lalu",
+            ),
+            ManagedOrder(
+                invoice="INV-240512-9804",
+                customer="Bayu Wicaksana",
+                items=1,
+                total="Rp475.000",
+                status="Baru",
+                updated="Baru masuk",
+            ),
+            ManagedOrder(
+                invoice="INV-240511-9720",
+                customer="Nadia Permata",
+                items=2,
+                total="Rp945.000",
+                status="Dikirim",
+                updated="Resi JNE 12 Mei",
+            ),
+            ManagedOrder(
+                invoice="INV-240511-9714",
+                customer="Andra Kusumah",
+                items=4,
+                total="Rp2.040.000",
+                status="Perlu perhatian",
+                updated="Komplain aroma",
+            ),
+        ]
+
+        self._promotions: List[PromotionSnapshot] = [
+            PromotionSnapshot(
+                name="Voucher Loyalis Ramadan",
+                status="Aktif",
+                goal="Target Rp60 Jt",
+                progress_percent=72,
+                period="1-15 Ramadan",
+            ),
+            PromotionSnapshot(
+                name="Sambatan Kolaborasi Nusantarum",
+                status="Pra-launch",
+                goal="150 slot kontributor",
+                progress_percent=48,
+                period="Draft jadwal",
+            ),
+            PromotionSnapshot(
+                name="Bundling Discovery Set",
+                status="Selesai",
+                goal="Terjual 320 set",
+                progress_percent=100,
+                period="April 2024",
+            ),
+        ]
+
+        self._verification_steps: List[VerificationStep] = [
+            VerificationStep(
+                title="Lengkapi Data Legal",
+                status="selesai",
+                description="Nomor NIB dan NPWP brand sudah diverifikasi sistem.",
+            ),
+            VerificationStep(
+                title="Unggah Portofolio Brand",
+                status="revisi",
+                description="Kurator meminta tambahan dokumentasi foto workshop.",
+            ),
+            VerificationStep(
+                title="Konfirmasi Penanggung Jawab",
+                status="menunggu",
+                description="Undangan tanda tangan digital dikirim ke co-founder.",
+            ),
+            VerificationStep(
+                title="Review Kurator",
+                status="menunggu",
+                description="Estimasi SLA 2 hari kerja setelah dokumen lengkap.",
+            ),
+        ]
+
+        self._verification_documents: List[VerificationDocument] = [
+            VerificationDocument(
+                name="Surat Izin Usaha",
+                status="Lengkap",
+            ),
+            VerificationDocument(
+                name="Identitas Penanggung Jawab",
+                status="Lengkap",
+            ),
+            VerificationDocument(
+                name="Portofolio Produk",
+                status="Perlu revisi",
+                note="Tambahkan dokumentasi proses produksi dan sertifikasi batch.",
+            ),
+            VerificationDocument(
+                name="Sertifikat Halal / BPOM",
+                status="Opsional",
+                note="Upload jika tersedia untuk percepat review retail partner.",
+            ),
+        ]
+
+        self._team_members: List[TeamMember] = [
+            TeamMember(
+                name="Ayu Prameswari",
+                role="Brand Owner",
+                email="ayu@studiosenja.id",
+                last_active="Online",
+                permissions=["Semua modul", "Kelola tim", "Akses finansial"],
+            ),
+            TeamMember(
+                name="Rifky Hartanto",
+                role="Co-founder",
+                email="rifky@studiosenja.id",
+                last_active="1 jam lalu",
+                permissions=["Manajemen produk", "Sambatan", "Analitik"],
+            ),
+            TeamMember(
+                name="Sari Utami",
+                role="Admin Operasional",
+                email="sari@studiosenja.id",
+                last_active="43 menit lalu",
+                permissions=["Pesanan", "Stok", "Respon pelanggan"],
+            ),
+            TeamMember(
+                name="Galih Wibisono",
+                role="Staff Warehouse",
+                email="warehouse@studiosenja.id",
+                last_active="2 jam lalu",
+                permissions=["Update stok", "Cetak label", "Logistik"],
+            ),
+        ]
+
+        self._invitations: List[TeamInvitation] = [
+            TeamInvitation(
+                email="keuangan@studiosenja.id",
+                role="Finance Viewer",
+                sent_at="12 Mei 10:20",
+                expires_at="18 Mei 23:59",
+            )
+        ]
+
+        self._activity_log: List[ActivityLog] = [
+            ActivityLog(
+                timestamp="12 Mei 09:12",
+                actor="Ayu",
+                action="Mengaktifkan voucher Loyalis Ramadan",
+            ),
+            ActivityLog(
+                timestamp="11 Mei 21:45",
+                actor="Sari",
+                action="Memperbarui status 8 pesanan ke 'Dikirim'",
+            ),
+            ActivityLog(
+                timestamp="11 Mei 16:05",
+                actor="Rifky",
+                action="Mengunggah draft portofolio verifikasi brand",
+            ),
+            ActivityLog(
+                timestamp="10 Mei 13:22",
+                actor="Galih",
+                action="Menambahkan stok masuk untuk SKU STJ-EFP-50",
+            ),
+        ]
+
+        self._analytics_ranges = [
+            {
+                "key": "7d",
+                "label": "7 Hari",
+                "summary": {
+                    "revenue": "Rp42,8 Jt",
+                    "orders": 182,
+                    "avg_order": "Rp1,32 Jt",
+                    "conversion": "3,8%",
+                },
+                "points": [12, 16, 14, 18, 21, 19, 24],
+                "x_labels": ["Sel", "Rab", "Kam", "Jum", "Sab", "Min", "Sen"],
+                "top_products": [
+                    {"name": "Euforia Pagi", "share": "28%"},
+                    {"name": "Discovery Set", "share": "22%"},
+                    {"name": "Kolaborasi Nusantarum", "share": "17%"},
+                ],
+                "segments": [
+                    {"label": "Pelanggan Baru", "value": "38%"},
+                    {"label": "Pelanggan Kembali", "value": "62%"},
+                ],
+            },
+            {
+                "key": "30d",
+                "label": "30 Hari",
+                "summary": {
+                    "revenue": "Rp182,4 Jt",
+                    "orders": 712,
+                    "avg_order": "Rp1,42 Jt",
+                    "conversion": "4,2%",
+                },
+                "points": [9, 11, 12, 15, 18, 17, 19, 22, 21, 20, 24, 23, 25, 26, 28],
+                "x_labels": ["M1", "M2", "M3", "M4", "M5", "M6", "M7", "M8", "M9", "M10", "M11", "M12", "M13", "M14", "M15"],
+                "top_products": [
+                    {"name": "Euforia Pagi", "share": "31%"},
+                    {"name": "Discovery Set", "share": "19%"},
+                    {"name": "Refill Base Oil", "share": "12%"},
+                ],
+                "segments": [
+                    {"label": "Jabodetabek", "value": "44%"},
+                    {"label": "Jawa Tengah", "value": "23%"},
+                    {"label": "Kalimantan", "value": "11%"},
+                    {"label": "Sulawesi", "value": "9%"},
+                ],
+            },
+            {
+                "key": "90d",
+                "label": "90 Hari",
+                "summary": {
+                    "revenue": "Rp512,7 Jt",
+                    "orders": 1_862,
+                    "avg_order": "Rp1,37 Jt",
+                    "conversion": "4,0%",
+                },
+                "points": [6, 8, 7, 9, 11, 15, 14, 16, 18, 21, 19, 23, 24, 26, 25, 28, 30, 29, 31],
+                "x_labels": ["W1", "W2", "W3", "W4", "W5", "W6", "W7", "W8", "W9", "W10", "W11", "W12", "W13", "W14", "W15", "W16", "W17", "W18", "W19"],
+                "top_products": [
+                    {"name": "Kolaborasi Nusantarum", "share": "26%"},
+                    {"name": "Euforia Pagi", "share": "25%"},
+                    {"name": "Discovery Set", "share": "18%"},
+                ],
+                "segments": [
+                    {"label": "Marketplace", "value": "52%"},
+                    {"label": "Sambatan", "value": "33%"},
+                    {"label": "Retail Offline", "value": "15%"},
+                ],
+            },
+        ]
+
+        self._verification_timeline = [
+            {
+                "date": date(2024, 5, 9),
+                "actor": "Kurator Nusantarum",
+                "message": "Review awal dokumen legal selesai – menunggu unggahan portofolio.",
+            },
+            {
+                "date": date(2024, 5, 11),
+                "actor": "Ayu Prameswari",
+                "message": "Mengunggah portofolio brand dan menambahkan catatan produksi.",
+            },
+            {
+                "date": date(2024, 5, 12),
+                "actor": "Kurator Nusantarum",
+                "message": "Meminta revisi foto workshop dan sertifikat pelatihan staf.",
+            },
+        ]
+
+    def get_kpis(self) -> Iterable[DashboardKPI]:
+        return tuple(self._kpis)
+
+    def get_order_statuses(self) -> Iterable[OrderStatusSummary]:
+        return tuple(self._order_statuses)
+
+    def get_notifications(self) -> Iterable[DashboardNotification]:
+        return tuple(self._notifications)
+
+    def get_products(self) -> Iterable[ManagedProduct]:
+        return tuple(self._products)
+
+    def get_orders(self) -> Iterable[ManagedOrder]:
+        return tuple(self._orders)
+
+    def get_promotions(self) -> Iterable[PromotionSnapshot]:
+        return tuple(self._promotions)
+
+    def get_verification_steps(self) -> Iterable[VerificationStep]:
+        return tuple(self._verification_steps)
+
+    def get_verification_documents(self) -> Iterable[VerificationDocument]:
+        return tuple(self._verification_documents)
+
+    def get_team_members(self) -> Iterable[TeamMember]:
+        return tuple(self._team_members)
+
+    def get_invitations(self) -> Iterable[TeamInvitation]:
+        return tuple(self._invitations)
+
+    def get_activity_log(self) -> Iterable[ActivityLog]:
+        return tuple(self._activity_log)
+
+    def get_analytics_ranges(self) -> Iterable[dict]:
+        return tuple(self._analytics_ranges)
+
+    def get_verification_timeline(self) -> Iterable[dict]:
+        return tuple(self._verification_timeline)
+
+    def get_snapshot(self) -> dict:
+        """Return an aggregated snapshot used by the template renderer."""
+
+        return {
+            "brand_profile": self._brand_profile,
+            "kpis": self.get_kpis(),
+            "order_statuses": self.get_order_statuses(),
+            "notifications": self.get_notifications(),
+            "products": self.get_products(),
+            "orders": self.get_orders(),
+            "promotions": self.get_promotions(),
+            "verification_steps": self.get_verification_steps(),
+            "verification_documents": self.get_verification_documents(),
+            "verification_timeline": self.get_verification_timeline(),
+            "team_members": self.get_team_members(),
+            "team_invitations": self.get_invitations(),
+            "activity_log": self.get_activity_log(),
+            "analytics_ranges": self.get_analytics_ranges(),
+        }
+
+
+brand_dashboard_service = BrandOwnerDashboardService()
+"""Singleton service used by the router to populate dashboard views."""
+

--- a/src/app/web/static/css/dashboard.css
+++ b/src/app/web/static/css/dashboard.css
@@ -1,0 +1,768 @@
+.dashboard-hero {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 2.5rem;
+  padding: 2.75rem;
+  align-items: center;
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+}
+
+.hero-main h1 {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  margin: 0.75rem 0 0.5rem;
+}
+
+.hero-main p {
+  font-size: 1.05rem;
+  max-width: 36ch;
+}
+
+.hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1.35rem 0;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+.hero-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+
+.hero-kpis {
+  align-self: stretch;
+}
+
+.kpi-grid {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.25rem;
+  padding: 0;
+  margin: 0;
+}
+
+.kpi-card {
+  padding: 1.35rem 1.5rem;
+}
+
+.kpi-label {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  margin: 0 0 0.5rem;
+}
+
+.kpi-value {
+  font-size: 1.65rem;
+  font-weight: 600;
+  margin: 0 0 0.35rem;
+}
+
+.kpi-delta {
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.kpi-delta.positive {
+  color: #4ade80;
+}
+
+.kpi-delta.negative {
+  color: #f97316;
+}
+
+.dashboard-overview {
+  padding: 2.25rem;
+  display: grid;
+  gap: 2rem;
+}
+
+.section-heading {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+
+.section-heading h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1.8rem;
+}
+
+.section-heading p {
+  margin: 0;
+  max-width: 48ch;
+}
+
+.section-tools {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.overview-content {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  gap: 2rem;
+}
+
+.status-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.status-pill {
+  min-width: 140px;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.6);
+  display: grid;
+  gap: 0.25rem;
+}
+
+.status-count {
+  font-size: 1.6rem;
+  font-weight: 600;
+}
+
+.status-label {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+.status-pill.tone-info {
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.status-pill.tone-primary {
+  border-color: rgba(129, 140, 248, 0.55);
+}
+
+.status-pill.tone-success {
+  border-color: rgba(74, 222, 128, 0.55);
+}
+
+.status-pill.tone-warning {
+  border-color: rgba(250, 204, 21, 0.55);
+}
+
+.notification-panel {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.notification-panel h3 {
+  margin: 0;
+}
+
+.notification-list {
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.notification-item {
+  padding: 1.25rem 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.notification-empty {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.notification-header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.notification-item p {
+  margin: 0;
+}
+
+.dashboard-management {
+  display: grid;
+  gap: 2rem;
+}
+
+.management-card {
+  padding: 2.25rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.management-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 0.95rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background var(--transition-base), color var(--transition-base), border-color var(--transition-base), transform var(--transition-base);
+}
+
+.chip:hover,
+.chip:focus-visible {
+  border-color: rgba(96, 165, 250, 0.7);
+  color: var(--text-primary);
+  transform: translateY(-1px);
+}
+
+.chip.is-active {
+  background: var(--accent-primary);
+  color: #0f172a;
+  border-color: transparent;
+  box-shadow: 0 12px 24px rgba(192, 38, 211, 0.25);
+}
+
+.search-field {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.search-field input {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: var(--radius-sm);
+  padding: 0.65rem 0.9rem;
+  color: var(--text-primary);
+}
+
+.search-field input:focus {
+  outline: 2px solid rgba(96, 165, 250, 0.6);
+  outline-offset: 2px;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: var(--radius-md);
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 680px;
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.9rem 1.1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.data-table thead th {
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.data-table tbody tr:hover {
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.table-primary {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.primary-text {
+  font-weight: 600;
+}
+
+.secondary-text {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(148, 163, 184, 0.12);
+  text-transform: capitalize;
+}
+
+.status-aktif {
+  color: #4ade80;
+  border-color: rgba(74, 222, 128, 0.5);
+}
+
+.status-baru {
+  color: #facc15;
+  border-color: rgba(250, 204, 21, 0.55);
+}
+
+.status-diproses {
+  color: #38bdf8;
+  border-color: rgba(56, 189, 248, 0.55);
+}
+
+.status-dikirim {
+  color: #a5b4fc;
+  border-color: rgba(129, 140, 248, 0.55);
+}
+
+.status-draft {
+  color: #facc15;
+  border-color: rgba(250, 204, 21, 0.55);
+}
+
+.status-pending {
+  color: #f97316;
+  border-color: rgba(249, 115, 22, 0.55);
+}
+
+.status-arsip {
+  color: #a5b4fc;
+  border-color: rgba(129, 140, 248, 0.55);
+}
+
+.status-perlu-perhatian {
+  color: #f97316;
+  border-color: rgba(249, 115, 22, 0.55);
+}
+
+.status-lengkap {
+  color: #4ade80;
+  border-color: rgba(74, 222, 128, 0.55);
+}
+
+.status-perlu-revisi {
+  color: #f97316;
+  border-color: rgba(249, 115, 22, 0.55);
+}
+
+.status-opsional {
+  color: #a5b4fc;
+  border-color: rgba(129, 140, 248, 0.5);
+}
+
+.analytics-section {
+  padding: 2.5rem;
+  display: grid;
+  gap: 1.75rem;
+}
+
+.analytics-panel {
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.75rem;
+  border-radius: var(--radius-lg);
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.analytics-panel.is-hidden {
+  display: none;
+}
+
+.analytics-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+}
+
+.summary-label {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.summary-value {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.analytics-chart {
+  position: relative;
+  height: 220px;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.65), rgba(15, 23, 42, 0.45));
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.analytics-chart svg {
+  width: 100%;
+  height: 100%;
+}
+
+.chart-area {
+  stroke: none;
+  opacity: 0.55;
+}
+
+.chart-line {
+  fill: none;
+  stroke: #38bdf8;
+  stroke-width: 2;
+}
+
+.chart-label {
+  position: absolute;
+  bottom: 6px;
+  transform: translateX(-50%);
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  pointer-events: none;
+}
+
+.analytics-details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.top-products ul,
+.customer-segments ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.top-products li,
+.customer-segments li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.95rem;
+}
+
+.promotion-section {
+  display: grid;
+  gap: 1.75rem;
+  padding: 2.25rem;
+}
+
+.promotion-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.promotion-card {
+  display: grid;
+  gap: 1rem;
+  padding: 1.5rem;
+}
+
+.promotion-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.progress-track {
+  position: relative;
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+  overflow: hidden;
+}
+
+.progress-fill {
+  position: absolute;
+  inset: 0;
+  width: var(--progress);
+  background: var(--accent-primary);
+  border-radius: inherit;
+}
+
+.promotion-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.verification-section {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+}
+
+.verification-steps {
+  padding: 2.5rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.step-list {
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.step-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  align-items: start;
+  padding: 1.1rem 1.35rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.step-icon {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 3px solid rgba(148, 163, 184, 0.5);
+  margin-top: 0.4rem;
+}
+
+.step-selesai .step-icon {
+  border-color: #4ade80;
+  background: rgba(74, 222, 128, 0.35);
+}
+
+.step-revisi .step-icon {
+  border-color: #f97316;
+  background: rgba(249, 115, 22, 0.3);
+}
+
+.step-menunggu .step-icon {
+  border-color: rgba(148, 163, 184, 0.4);
+}
+
+.verification-aside {
+  padding: 2rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.document-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.document-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.25rem;
+}
+
+.document-name {
+  font-weight: 600;
+}
+
+.document-note {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 0.35rem;
+}
+
+.timeline-heading {
+  margin: 0;
+}
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.1rem;
+}
+
+.timeline li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+}
+
+.timeline-date {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.timeline-actor {
+  font-weight: 600;
+}
+
+.team-section {
+  display: grid;
+  gap: 2rem;
+  padding: 2.5rem;
+}
+
+.team-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 0.8fr);
+  gap: 2rem;
+}
+
+.team-members table {
+  min-width: 720px;
+}
+
+.permission-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.team-sidebar {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.invitation-card ul,
+.activity-card ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.invitation-card li,
+.activity-card li {
+  display: grid;
+  gap: 0.5rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.invitation-meta {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  display: flex;
+  gap: 0.75rem;
+}
+
+.invitation-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.activity-time {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.activity-actor {
+  font-weight: 600;
+}
+
+@media (max-width: 1024px) {
+  .dashboard-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .overview-content,
+  .verification-section,
+  .team-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .analytics-chart {
+    height: 200px;
+  }
+}
+
+@media (max-width: 768px) {
+  .dashboard-hero,
+  .dashboard-overview,
+  .management-card,
+  .analytics-section,
+  .promotion-section,
+  .team-section {
+    padding: 1.75rem;
+  }
+
+  .status-pills {
+    gap: 0.75rem;
+  }
+
+  .data-table {
+    min-width: 540px;
+  }
+
+  .analytics-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .section-heading {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .chip {
+    width: fit-content;
+  }
+}

--- a/src/app/web/static/js/dashboard-brand-owner.js
+++ b/src/app/web/static/js/dashboard-brand-owner.js
@@ -1,0 +1,201 @@
+(function () {
+  function normalise(value) {
+    return (value || "").toString().toLowerCase().normalize("NFD").replace(/\p{Diacritic}/gu, "");
+  }
+
+  function bindProductFilters() {
+    const buttons = document.querySelectorAll("[data-product-filter]");
+    const rows = document.querySelectorAll("[data-product-row]");
+    const searchInput = document.querySelector("[data-product-search]");
+    let activeFilter = "semua";
+
+    function apply() {
+      const query = normalise(searchInput ? searchInput.value.trim() : "");
+      rows.forEach((row) => {
+        const status = row.dataset.status || "";
+        const name = normalise(row.dataset.name || "");
+        const sku = normalise(row.dataset.sku || "");
+        const matchesFilter = activeFilter === "semua" || status === activeFilter;
+        const matchesQuery = !query || name.includes(query) || sku.includes(query);
+        const shouldShow = matchesFilter && matchesQuery;
+        row.hidden = !shouldShow;
+      });
+    }
+
+    buttons.forEach((button) => {
+      button.addEventListener("click", () => {
+        const target = button.dataset.productFilter;
+        if (!target) return;
+        activeFilter = target;
+        buttons.forEach((chip) => {
+          const isActive = chip === button;
+          chip.classList.toggle("is-active", isActive);
+          chip.setAttribute("aria-selected", String(isActive));
+        });
+        apply();
+      });
+    });
+
+    if (searchInput) {
+      ["input", "change"].forEach((eventName) => {
+        searchInput.addEventListener(eventName, apply);
+      });
+    }
+  }
+
+  function bindOrderFilters() {
+    const buttons = document.querySelectorAll("[data-order-filter]");
+    const rows = document.querySelectorAll("[data-order-row]");
+    const searchInput = document.querySelector("[data-order-search]");
+    let activeFilter = "semua";
+
+    function apply() {
+      const query = normalise(searchInput ? searchInput.value.trim() : "");
+      rows.forEach((row) => {
+        const status = normalise(row.dataset.status || "");
+        const invoice = normalise(row.dataset.invoice || "");
+        const customer = normalise(row.dataset.customer || "");
+        const matchesFilter = activeFilter === "semua" || status === normalise(activeFilter);
+        const matchesQuery = !query || invoice.includes(query) || customer.includes(query);
+        const shouldShow = matchesFilter && matchesQuery;
+        row.hidden = !shouldShow;
+      });
+    }
+
+    buttons.forEach((button) => {
+      button.addEventListener("click", () => {
+        const target = button.dataset.orderFilter;
+        if (!target) return;
+        activeFilter = target;
+        buttons.forEach((chip) => {
+          const isActive = chip === button;
+          chip.classList.toggle("is-active", isActive);
+          chip.setAttribute("aria-selected", String(isActive));
+        });
+        apply();
+      });
+    });
+
+    if (searchInput) {
+      ["input", "change"].forEach((eventName) => {
+        searchInput.addEventListener(eventName, apply);
+      });
+    }
+  }
+
+  function renderChart(chartEl) {
+    const pointsAttr = chartEl.dataset.chartPoints;
+    if (!pointsAttr) return;
+
+    const points = pointsAttr
+      .split(",")
+      .map((value) => Number.parseFloat(value.trim()))
+      .filter((value) => Number.isFinite(value));
+
+    if (points.length < 2) return;
+
+    const labelsAttr = chartEl.dataset.chartLabels || "";
+    const labels = labelsAttr.split(",").map((label) => label.trim());
+
+    const maxValue = Math.max(...points);
+    const minValue = Math.min(...points);
+    const range = maxValue - minValue || 1;
+
+    const svgWidth = 100;
+    const svgHeight = 40;
+    const verticalPadding = 6;
+    const usableHeight = svgHeight - verticalPadding * 2;
+    const stepX = svgWidth / (points.length - 1);
+
+    const line = chartEl.querySelector("[data-chart-line]");
+    const area = chartEl.querySelector("[data-chart-area]");
+
+    if (!line || !area) return;
+
+    const coordinates = points.map((value, index) => {
+      const normalised = (value - minValue) / range;
+      const y = svgHeight - verticalPadding - normalised * usableHeight;
+      const x = index * stepX;
+      return [x, y];
+    });
+
+    const polylinePoints = coordinates.map(([x, y]) => `${x},${y}`).join(" ");
+    line.setAttribute("points", polylinePoints);
+
+    const areaPath = [
+      `M0 ${svgHeight}`,
+      `L${coordinates[0][0]} ${coordinates[0][1]}`,
+      ...coordinates.slice(1).map(([x, y]) => `L${x} ${y}`),
+      `L${coordinates[coordinates.length - 1][0]} ${svgHeight}`,
+      "Z",
+    ].join(" ");
+    area.setAttribute("d", areaPath);
+
+    if (labels.length === points.length) {
+      const existingLabels = chartEl.querySelectorAll(".chart-label");
+      existingLabels.forEach((label) => label.remove());
+      labels.forEach((label, index) => {
+        const marker = document.createElement("span");
+        marker.className = "chart-label";
+        marker.textContent = label;
+        marker.style.left = `${(index / (labels.length - 1 || 1)) * 100}%`;
+        chartEl.appendChild(marker);
+      });
+    }
+  }
+
+  function initialiseAnalytics() {
+    const buttons = document.querySelectorAll("[data-analytics-range]");
+    const panels = document.querySelectorAll("[data-analytics-panel]");
+
+    buttons.forEach((button) => {
+      button.addEventListener("click", () => {
+        const target = button.dataset.analyticsRange;
+        if (!target) return;
+        buttons.forEach((chip) => {
+          const isActive = chip === button;
+          chip.classList.toggle("is-active", isActive);
+          chip.setAttribute("aria-selected", String(isActive));
+        });
+        panels.forEach((panel) => {
+          const isMatch = panel.dataset.analyticsPanel === target;
+          panel.classList.toggle("is-hidden", !isMatch);
+          if (isMatch) {
+            panel.removeAttribute("hidden");
+          } else {
+            panel.setAttribute("hidden", "hidden");
+          }
+        });
+      });
+    });
+
+    document.querySelectorAll("[data-chart]").forEach((chartEl) => {
+      renderChart(chartEl);
+    });
+  }
+
+  function bindNotificationActions() {
+    const list = document.querySelector("[data-notification-list]");
+    if (!list) return;
+    const emptyState = document.querySelector("[data-notification-empty]");
+
+    list.addEventListener("click", (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) return;
+      if (!target.matches("[data-dismiss-notification]")) return;
+      const item = target.closest(".notification-item");
+      if (!item) return;
+      item.remove();
+      if (!list.children.length && emptyState) {
+        emptyState.hidden = false;
+      }
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    bindProductFilters();
+    bindOrderFilters();
+    initialiseAnalytics();
+    bindNotificationActions();
+  });
+})();

--- a/src/app/web/templates/pages/dashboard/brand_owner.html
+++ b/src/app/web/templates/pages/dashboard/brand_owner.html
@@ -1,0 +1,512 @@
+{% extends 'base.html' %}
+
+{% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/dashboard.css') }}" />
+{% endblock %}
+
+{% block content %}
+{% set profile = snapshot.brand_profile %}
+<section class="dashboard-hero glass-surface">
+  <div class="hero-main">
+    <span class="hero-badge">Dashboard Brand Owner</span>
+    <h1>Halo, {{ profile.owner_name }} 👋</h1>
+    <p>{{ profile.tagline }}</p>
+    <div class="hero-meta">
+      <span class="sync-status">{{ profile.sync_status }}</span>
+      <span class="brand-name">Brand aktif: {{ profile.brand_name }}</span>
+    </div>
+    <div class="hero-actions">
+      <button type="button" class="btn gradient-button">Tambah Produk</button>
+      <button type="button" class="btn btn-outline">Buat Kampanye</button>
+      <button type="button" class="btn btn-ghost">Undang Anggota Tim</button>
+    </div>
+  </div>
+  <div class="hero-kpis">
+    <ul class="kpi-grid">
+      {% for kpi in snapshot.kpis %}
+      <li class="kpi-card glass-card">
+        <p class="kpi-label">{{ kpi.label }}</p>
+        <p class="kpi-value">{{ kpi.value }}</p>
+        <p class="kpi-delta {% if kpi.is_positive %}positive{% else %}negative{% endif %}">{{ kpi.delta_label }}</p>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+</section>
+
+<section class="dashboard-overview glass-surface">
+  <header class="section-heading">
+    <div>
+      <h2>Ringkasan Hari Ini</h2>
+      <p>Pantau KPI utama, status pesanan, dan notifikasi operasional.</p>
+    </div>
+    <div class="section-tools">
+      <button type="button" class="btn btn-ghost">Refresh Data</button>
+      <button type="button" class="btn btn-outline">Ekspor Laporan</button>
+    </div>
+  </header>
+
+  <div class="overview-content">
+    <div class="status-pills" role="list">
+      {% for status in snapshot.order_statuses %}
+      <div class="status-pill tone-{{ status.tone }}" role="listitem">
+        <span class="status-count">{{ status.count }}</span>
+        <span class="status-label">{{ status.label }}</span>
+      </div>
+      {% endfor %}
+    </div>
+
+    <aside class="notification-panel">
+      <h3>Notifikasi Penting</h3>
+      <ul class="notification-list" data-notification-list>
+        {% for notif in snapshot.notifications %}
+        <li class="notification-item glass-card">
+          <div class="notification-header">
+            <span class="notification-category">{{ notif.category }}</span>
+            <span class="notification-urgency">{{ notif.urgency }}</span>
+          </div>
+          <p>{{ notif.message }}</p>
+          <button type="button" class="btn btn-ghost" data-dismiss-notification>Tandai selesai</button>
+        </li>
+        {% endfor %}
+      </ul>
+      <p class="notification-empty" data-notification-empty hidden>Semua notifikasi telah ditangani 🎉</p>
+    </aside>
+  </div>
+</section>
+
+<section class="dashboard-management">
+  <article class="management-card glass-surface" id="product-management">
+    <header class="section-heading">
+      <div>
+        <h2>Manajemen Produk</h2>
+        <p>Kelola katalog, status publikasi, dan stok setiap SKU.</p>
+      </div>
+      <div class="section-tools">
+        <button type="button" class="btn btn-outline">Impor CSV</button>
+        <button type="button" class="btn gradient-button">Produk Baru</button>
+      </div>
+    </header>
+
+    <div class="management-controls">
+      <div class="filter-chips" role="tablist" aria-label="Filter status produk">
+        {% set product_filters = [
+          {"key": "semua", "label": "Semua"},
+          {"key": "aktif", "label": "Aktif"},
+          {"key": "draft", "label": "Draft"},
+          {"key": "pending", "label": "Menunggu Approval"},
+          {"key": "arsip", "label": "Arsip"}
+        ] %}
+        {% for filter in product_filters %}
+        <button
+          type="button"
+          class="chip {% if loop.first %}is-active{% endif %}"
+          data-product-filter="{{ filter.key }}"
+          role="tab"
+          aria-selected="{{ 'true' if loop.first else 'false' }}"
+        >
+          {{ filter.label }}
+        </button>
+        {% endfor %}
+      </div>
+      <label class="search-field">
+        <span>Cari SKU</span>
+        <input type="search" placeholder="Nama produk atau SKU" data-product-search />
+      </label>
+    </div>
+
+    <div class="table-wrapper">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th scope="col">Produk</th>
+            <th scope="col">Status</th>
+            <th scope="col">Stok</th>
+            <th scope="col">Harga</th>
+            <th scope="col">Terakhir Diperbarui</th>
+            <th scope="col" class="actions">Aksi</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for product in snapshot.products %}
+          <tr
+            data-product-row
+            data-status="{{ product.status }}"
+            data-name="{{ product.name | lower }}"
+            data-sku="{{ product.sku | lower }}"
+          >
+            <td>
+              <div class="table-primary">
+                <span class="primary-text">{{ product.name }}</span>
+                <span class="secondary-text">SKU: {{ product.sku }}</span>
+              </div>
+            </td>
+            <td><span class="status-badge status-{{ product.status }}">{{ product.status|title }}</span></td>
+            <td>{{ product.stock_level }}</td>
+            <td>{{ product.price }}</td>
+            <td>{{ product.updated }}</td>
+            <td class="actions">
+              <button type="button" class="btn btn-ghost">Edit</button>
+              <button type="button" class="btn btn-ghost">Lihat</button>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </article>
+
+  <article class="management-card glass-surface" id="order-management">
+    <header class="section-heading">
+      <div>
+        <h2>Manajemen Pesanan</h2>
+        <p>Prioritaskan pesanan baru, pantau SLA, dan respon pelanggan.</p>
+      </div>
+      <div class="section-tools">
+        <button type="button" class="btn btn-outline">Cetak Picking List</button>
+      </div>
+    </header>
+
+    <div class="management-controls">
+      <div class="filter-chips" role="tablist" aria-label="Filter status pesanan">
+        {% set order_filters = [
+          {"key": "semua", "label": "Semua"},
+          {"key": "baru", "label": "Baru"},
+          {"key": "diproses", "label": "Diproses"},
+          {"key": "dikirim", "label": "Dikirim"},
+          {"key": "perlu perhatian", "label": "Perlu Perhatian"}
+        ] %}
+        {% for filter in order_filters %}
+        <button
+          type="button"
+          class="chip {% if loop.first %}is-active{% endif %}"
+          data-order-filter="{{ filter.key }}"
+          role="tab"
+          aria-selected="{{ 'true' if loop.first else 'false' }}"
+        >
+          {{ filter.label }}
+        </button>
+        {% endfor %}
+      </div>
+      <label class="search-field">
+        <span>Cari Invoice</span>
+        <input type="search" placeholder="Nomor invoice atau pelanggan" data-order-search />
+      </label>
+    </div>
+
+    <div class="table-wrapper">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th scope="col">Invoice</th>
+            <th scope="col">Pelanggan</th>
+            <th scope="col">Item</th>
+            <th scope="col">Total</th>
+            <th scope="col">Status</th>
+            <th scope="col">Update Terakhir</th>
+            <th scope="col" class="actions">Tindakan</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for order in snapshot.orders %}
+          <tr
+            data-order-row
+            data-status="{{ order.status | lower }}"
+            data-invoice="{{ order.invoice | lower }}"
+            data-customer="{{ order.customer | lower }}"
+          >
+            <td class="table-primary">
+              <span class="primary-text">{{ order.invoice }}</span>
+            </td>
+            <td>{{ order.customer }}</td>
+            <td>{{ order.items }}</td>
+            <td>{{ order.total }}</td>
+            <td><span class="status-badge status-{{ order.status | replace(' ', '-') | lower }}">{{ order.status }}</span></td>
+            <td>{{ order.updated }}</td>
+            <td class="actions">
+              <button type="button" class="btn btn-ghost">Detail</button>
+              <button type="button" class="btn btn-ghost">Perbarui Status</button>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </article>
+</section>
+
+<section class="analytics-section glass-surface" id="sales-analytics">
+  <header class="section-heading">
+    <div>
+      <h2>Analitik Penjualan</h2>
+      <p>Gunakan rentang waktu untuk melihat tren penjualan dan kontribusi produk.</p>
+    </div>
+    <div class="analytics-controls" role="tablist" aria-label="Rentang waktu analitik">
+      {% for dataset in snapshot.analytics_ranges %}
+      <button
+        type="button"
+        class="chip {% if loop.first %}is-active{% endif %}"
+        data-analytics-range="{{ dataset.key }}"
+        role="tab"
+        aria-selected="{{ 'true' if loop.first else 'false' }}"
+      >
+        {{ dataset.label }}
+      </button>
+      {% endfor %}
+    </div>
+  </header>
+
+  {% for dataset in snapshot.analytics_ranges %}
+  <div
+    class="analytics-panel {% if not loop.first %}is-hidden{% endif %}"
+    data-analytics-panel="{{ dataset.key }}"
+    {% if not loop.first %}hidden{% endif %}
+  >
+    <div class="analytics-summary">
+      <div>
+        <span class="summary-label">Revenue</span>
+        <span class="summary-value">{{ dataset.summary.revenue }}</span>
+      </div>
+      <div>
+        <span class="summary-label">Jumlah Order</span>
+        <span class="summary-value">{{ dataset.summary.orders }}</span>
+      </div>
+      <div>
+        <span class="summary-label">Average Order Value</span>
+        <span class="summary-value">{{ dataset.summary.avg_order }}</span>
+      </div>
+      <div>
+        <span class="summary-label">Konversi</span>
+        <span class="summary-value">{{ dataset.summary.conversion }}</span>
+      </div>
+    </div>
+
+    <div
+      class="analytics-chart"
+      data-chart
+      data-chart-points="{{ dataset.points | join(',') }}"
+      data-chart-labels="{{ dataset.x_labels | join(',') }}"
+      aria-hidden="true"
+    >
+      <svg viewBox="0 0 100 40" preserveAspectRatio="none">
+        <defs>
+          <linearGradient id="gradient-{{ dataset.key }}" x1="0%" y1="0%" x2="0%" y2="100%">
+            <stop offset="0%" stop-color="rgba(56, 189, 248, 0.7)" />
+            <stop offset="100%" stop-color="rgba(56, 189, 248, 0)" />
+          </linearGradient>
+        </defs>
+        <path class="chart-area" data-chart-area d="" fill="url(#gradient-{{ dataset.key }})" />
+        <polyline class="chart-line" data-chart-line points="" />
+      </svg>
+    </div>
+
+    <div class="analytics-details">
+      <div class="top-products">
+        <h3>Produk Terlaris</h3>
+        <ul>
+          {% for product in dataset.top_products %}
+          <li>
+            <span>{{ product.name }}</span>
+            <span>{{ product.share }}</span>
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+      <div class="customer-segments">
+        <h3>Segmentasi Pelanggan</h3>
+        <ul>
+          {% for segment in dataset.segments %}
+          <li>
+            <span>{{ segment.label }}</span>
+            <span>{{ segment.value }}</span>
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</section>
+
+<section class="promotion-section">
+  <header class="section-heading">
+    <div>
+      <h2>Promosi &amp; Kampanye</h2>
+      <p>Pantau performa voucher, kolaborasi sambatan, dan kampanye marketing.</p>
+    </div>
+    <div class="section-tools">
+      <button type="button" class="btn btn-outline">Rekomendasi Kampanye</button>
+      <button type="button" class="btn gradient-button">Buat Voucher</button>
+    </div>
+  </header>
+
+  <div class="promotion-grid">
+    {% for promo in snapshot.promotions %}
+    <article class="promotion-card glass-card">
+      <header>
+        <span class="promotion-status">{{ promo.status }}</span>
+        <h3>{{ promo.name }}</h3>
+      </header>
+      <p>{{ promo.goal }}</p>
+      <div class="promotion-meta">
+        <span>Periode: {{ promo.period }}</span>
+        <span>{{ promo.progress_percent }}% tercapai</span>
+      </div>
+      <div class="progress-track">
+        <div class="progress-fill" style="--progress: {{ promo.progress_percent }}%"></div>
+      </div>
+      <div class="promotion-actions">
+        <button type="button" class="btn btn-ghost">Detail</button>
+        <button type="button" class="btn btn-ghost">Duplikasi</button>
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+</section>
+
+<section class="verification-section" id="brand-verification">
+  <div class="verification-steps glass-surface">
+    <header class="section-heading">
+      <div>
+        <h2>Verifikasi Brand</h2>
+        <p>Pastikan seluruh dokumen lengkap untuk mempercepat approval kurator.</p>
+      </div>
+      <div class="section-tools">
+        <button type="button" class="btn btn-outline">Hubungi Kurator</button>
+      </div>
+    </header>
+
+    <ol class="step-list">
+      {% for step in snapshot.verification_steps %}
+      <li class="step-item step-{{ step.status }}">
+        <div class="step-icon"></div>
+        <div>
+          <h3>{{ step.title }}</h3>
+          <p>{{ step.description }}</p>
+        </div>
+      </li>
+      {% endfor %}
+    </ol>
+  </div>
+
+  <aside class="verification-aside glass-card">
+    <h3>Checklist Dokumen</h3>
+    <ul class="document-list">
+      {% for doc in snapshot.verification_documents %}
+      <li>
+        <div>
+          <span class="document-name">{{ doc.name }}</span>
+          {% if doc.note %}<span class="document-note">{{ doc.note }}</span>{% endif %}
+        </div>
+        <span class="status-badge status-{{ doc.status | lower | replace(' ', '-') }}">{{ doc.status }}</span>
+      </li>
+      {% endfor %}
+    </ul>
+    <h3 class="timeline-heading">Riwayat Komunikasi</h3>
+    <ul class="timeline">
+      {% for item in snapshot.verification_timeline %}
+      <li>
+        <span class="timeline-date">{{ item.date.strftime('%d %b %Y') }}</span>
+        <div>
+          <span class="timeline-actor">{{ item.actor }}</span>
+          <p>{{ item.message }}</p>
+        </div>
+      </li>
+      {% endfor %}
+    </ul>
+  </aside>
+</section>
+
+<section class="team-section glass-surface" id="team-management">
+  <header class="section-heading">
+    <div>
+      <h2>Pengaturan &amp; Tim</h2>
+      <p>Kelola peran, undangan anggota baru, dan audit aktivitas.</p>
+    </div>
+    <div class="section-tools">
+      <button type="button" class="btn btn-outline">Undang Anggota</button>
+      <button type="button" class="btn btn-ghost">Kelola Peran</button>
+    </div>
+  </header>
+
+  <div class="team-layout">
+    <div class="team-members">
+      <h3>Anggota Aktif</h3>
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th scope="col">Nama</th>
+            <th scope="col">Peran</th>
+            <th scope="col">Email</th>
+            <th scope="col">Aktivitas Terakhir</th>
+            <th scope="col">Izin</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for member in snapshot.team_members %}
+          <tr>
+            <td class="table-primary">
+              <span class="primary-text">{{ member.name }}</span>
+            </td>
+            <td>{{ member.role }}</td>
+            <td>{{ member.email }}</td>
+            <td>{{ member.last_active }}</td>
+            <td>
+              <ul class="permission-list">
+                {% for permission in member.permissions %}
+                <li>{{ permission }}</li>
+                {% endfor %}
+              </ul>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    <aside class="team-sidebar">
+      <div class="invitation-card glass-card">
+        <h3>Undangan Tertunda</h3>
+        <ul>
+          {% for invite in snapshot.team_invitations %}
+          <li>
+            <div>
+              <span class="primary-text">{{ invite.email }}</span>
+              <span class="secondary-text">Peran: {{ invite.role }}</span>
+            </div>
+            <div class="invitation-meta">
+              <span>Dikirim: {{ invite.sent_at }}</span>
+              <span>Kedaluwarsa: {{ invite.expires_at }}</span>
+            </div>
+            <div class="invitation-actions">
+              <button type="button" class="btn btn-ghost">Kirim Ulang</button>
+              <button type="button" class="btn btn-ghost">Batalkan</button>
+            </div>
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+
+      <div class="activity-card glass-card">
+        <h3>Log Aktivitas Tim</h3>
+        <ul class="activity-list">
+          {% for log in snapshot.activity_log %}
+          <li>
+            <span class="activity-time">{{ log.timestamp }}</span>
+            <div>
+              <span class="activity-actor">{{ log.actor }}</span>
+              <p>{{ log.action }}</p>
+            </div>
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </aside>
+  </div>
+</section>
+{% endblock %}
+
+{% block body_scripts %}
+{{ super() }}
+<script src="{{ url_for('static', path='js/dashboard-brand-owner.js') }}" defer></script>
+{% endblock %}

--- a/src/app/web/templates/partials/navbar.html
+++ b/src/app/web/templates/partials/navbar.html
@@ -28,6 +28,14 @@
     </li>
     <li>
       <a
+        href="{{ url_for('read_brand_owner_dashboard') }}"
+        class="{% if request.url.path.startswith('/dashboard/brand-owner') %}active{% endif %}"
+      >
+        Dashboard Brand
+      </a>
+    </li>
+    <li>
+      <a
         href="{{ url_for('read_uiux_tracker') }}"
         class="{% if request.url.path.startswith('/ui-ux/implementation') %}active{% endif %}"
       >


### PR DESCRIPTION
## Summary
- add a dedicated service that aggregates demo metrics for the brand-owner dashboard
- implement the brand-owner dashboard page with responsive styling, interactivity, and navigation entry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8ca23ca288327a9853874828b671a