### PR TITLE
Add moderation control center dashboard page

### DIFF
--- a/src/app/api/routes/root.py
+++ b/src/app/api/routes/root.py
@@ -7,6 +7,7 @@ from fastapi.responses import HTMLResponse
 
 from app.core.config import get_settings
 from app.services.brand_dashboard import brand_dashboard_service
+from app.services.moderation_dashboard import moderation_dashboard_service
 from app.services.products import product_service
 from app.services.sambatan import SambatanCampaign, sambatan_service
 
@@ -1029,3 +1030,21 @@ async def read_brand_owner_dashboard(request: Request) -> HTMLResponse:
         "snapshot": snapshot,
     }
     return templates.TemplateResponse("pages/dashboard/brand_owner.html", context)
+
+
+@router.get("/dashboard/moderation", response_class=HTMLResponse)
+async def read_moderation_dashboard(request: Request) -> HTMLResponse:
+    """Render the moderation, admin, and curator control center."""
+
+    settings = get_settings()
+    templates = request.app.state.templates
+    snapshot = moderation_dashboard_service.get_snapshot()
+
+    context = {
+        "request": request,
+        "app_name": settings.app_name,
+        "environment": settings.environment,
+        "title": "Dashboard Moderasi",
+        "snapshot": snapshot,
+    }
+    return templates.TemplateResponse("pages/dashboard/moderation.html", context)

--- a/src/app/services/__init__.py
+++ b/src/app/services/__init__.py
@@ -3,6 +3,10 @@
 from .auth import AuthService, auth_service
 from .brands import BrandService, brand_service
 from .brand_dashboard import BrandOwnerDashboardService, brand_dashboard_service
+from .moderation_dashboard import (
+    ModerationDashboardService,
+    moderation_dashboard_service,
+)
 from .onboarding import OnboardingService, onboarding_service
 from .products import ProductService, product_service
 from .nusantarum_service import (
@@ -23,6 +27,8 @@ __all__ = [
     "brand_service",
     "BrandOwnerDashboardService",
     "brand_dashboard_service",
+    "ModerationDashboardService",
+    "moderation_dashboard_service",
     "OnboardingService",
     "onboarding_service",
     "ProductService",

--- a/src/app/services/moderation_dashboard.py
+++ b/src/app/services/moderation_dashboard.py
@@ -1,0 +1,508 @@
+"""Demo data provider for the moderation, admin, and curator dashboard."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass(frozen=True)
+class ModerationKPI:
+    """Headline metric surfaced in the overview hero."""
+
+    label: str
+    value: str
+    delta: str
+    tone: str
+
+
+@dataclass(frozen=True)
+class ModerationAlert:
+    """Realtime alert or escalation that needs attention."""
+
+    title: str
+    description: str
+    severity: str
+    timestamp: str
+
+
+@dataclass(frozen=True)
+class TeamMemberSummary:
+    """Represents a moderator/curator/admin within the roster."""
+
+    name: str
+    role: str
+    status: str
+    active_cases: int
+    last_active: str
+    shift: str
+
+
+@dataclass(frozen=True)
+class PendingInvitation:
+    """Invitation that is waiting for activation."""
+
+    email: str
+    role: str
+    sent_at: str
+    expires_at: str
+
+
+@dataclass(frozen=True)
+class AuditTrailEntry:
+    """Audit log row for transparency and compliance."""
+
+    time: str
+    actor: str
+    action: str
+
+
+@dataclass(frozen=True)
+class ReportTicket:
+    """Queue item in the moderation pipeline."""
+
+    ticket_id: str
+    category: str
+    priority: str
+    status: str
+    sla_remaining: str
+    assigned_to: str
+    source: str
+
+
+@dataclass(frozen=True)
+class CurationSubmission:
+    """Submission tracked in the curator module."""
+
+    brand: str
+    submission_type: str
+    owner: str
+    status: str
+    updated: str
+    notes: str
+
+
+@dataclass(frozen=True)
+class InsightTrend:
+    """Analytic trend metric."""
+
+    label: str
+    current: str
+    change: str
+    tone: str
+
+
+@dataclass(frozen=True)
+class HeatmapSlot:
+    """Represents a block in the workload heatmap."""
+
+    label: str
+    load: str
+    state: str
+
+
+@dataclass(frozen=True)
+class PolicyUpdate:
+    """Policy changes that admins can audit."""
+
+    title: str
+    version: str
+    updated_at: str
+    owner: str
+    tags: List[str]
+
+
+@dataclass(frozen=True)
+class HelpResource:
+    """FAQ or learning material for the internal help center."""
+
+    title: str
+    category: str
+    format: str
+    updated_at: str
+
+
+@dataclass(frozen=True)
+class ContactPoint:
+    """Escalation contact for the team."""
+
+    name: str
+    role: str
+    channel: str
+    availability: str
+
+
+class ModerationDashboardService:
+    """Encapsulates demo data to drive the moderation dashboard template."""
+
+    def __init__(self) -> None:
+        self._persona = {
+            "name": "Arif Santoso",
+            "role": "Admin Utama Moderasi",
+            "mission": "Pantau antrian, distribusi tugas, dan kebijakan moderasi dalam satu layar.",
+            "shift": "Shift Pagi • 07.00 - 15.00 WIB",
+            "date": "Selasa, 14 Mei 2024",
+            "focus": "Prioritaskan eskalasi tingkat kritis dan onboarding dua moderator baru.",
+            "acknowledgement": "3 kebijakan baru belum dikonfirmasi oleh 4 anggota tim.",
+        }
+
+        self._kpis = [
+            ModerationKPI(
+                label="Laporan Prioritas Tinggi",
+                value="12",
+                delta="4 overdue > 4 jam",
+                tone="warning",
+            ),
+            ModerationKPI(
+                label="Aktivasi Moderator Minggu Ini",
+                value="5/7 selesai",
+                delta="2 masih menunggu pelatihan",
+                tone="info",
+            ),
+            ModerationKPI(
+                label="Akurasi Kurasi (7 hari)",
+                value="92%",
+                delta="+3% dari baseline",
+                tone="success",
+            ),
+            ModerationKPI(
+                label="Pelanggaran Berulang",
+                value="-28%",
+                delta="vs bulan lalu",
+                tone="positive",
+            ),
+        ]
+
+        self._alerts = [
+            ModerationAlert(
+                title="Eskalasi Urgensi Merah",
+                description="Laporan #PR-9821 (penipuan pembayaran) belum direspon selama 3 jam.",
+                severity="kritis",
+                timestamp="09:42 WIB",
+            ),
+            ModerationAlert(
+                title="Audit Quality Lead",
+                description="Quality Lead meminta sampel 10 kasus kurasi kampanye Ramadhan.",
+                severity="penting",
+                timestamp="08:55 WIB",
+            ),
+            ModerationAlert(
+                title="Onboarding Moderator",
+                description="Undangan ke rani@marketplace.id kadaluwarsa dalam 6 jam.",
+                severity="pengingat",
+                timestamp="07:10 WIB",
+            ),
+        ]
+
+        self._team_members = [
+            TeamMemberSummary(
+                name="Nadia Putri",
+                role="Moderator Senior",
+                status="Sedang mengaudit",
+                active_cases=6,
+                last_active="2 menit lalu",
+                shift="Pagi",
+            ),
+            TeamMemberSummary(
+                name="Dimas Ardi",
+                role="Moderator",
+                status="Menangani tiket prioritas",
+                active_cases=4,
+                last_active="Baru saja",
+                shift="Pagi",
+            ),
+            TeamMemberSummary(
+                name="Sela Wiryawan",
+                role="Kurator Brand",
+                status="Review kampanye",
+                active_cases=3,
+                last_active="10 menit lalu",
+                shift="Siang",
+            ),
+            TeamMemberSummary(
+                name="Grace Halim",
+                role="Quality Lead",
+                status="Sampling audit",
+                active_cases=2,
+                last_active="15 menit lalu",
+                shift="Fleksibel",
+            ),
+        ]
+
+        self._pending_invites = [
+            PendingInvitation(
+                email="rani@marketplace.id",
+                role="Moderator",
+                sent_at="13 Mei 2024 • 11:15",
+                expires_at="Hari ini, 17:15",
+            ),
+            PendingInvitation(
+                email="bintang@marketplace.id",
+                role="Kurator",
+                sent_at="13 Mei 2024 • 09:48",
+                expires_at="15 Mei 2024",
+            ),
+        ]
+
+        self._audit_trail = [
+            AuditTrailEntry(
+                time="09:35",
+                actor="Arif",
+                action="Mengubah SOP validasi bukti level 2 menjadi wajib verifikasi ganda.",
+            ),
+            AuditTrailEntry(
+                time="08:12",
+                actor="Nadia",
+                action="Menutup laporan #PR-9712 (konten SARA) dengan tindakan suspend 7 hari.",
+            ),
+            AuditTrailEntry(
+                time="07:55",
+                actor="Sela",
+                action='Mengeskalasi brand "Aurora Glow" ke admin karena skor risiko tinggi.',
+            ),
+        ]
+
+        self._report_tickets = [
+            ReportTicket(
+                ticket_id="#PR-9821",
+                category="Transaksi",
+                priority="Merah",
+                status="Menunggu admin",
+                sla_remaining="-01:12",
+                assigned_to="Arif",
+                source="Komunitas",
+            ),
+            ReportTicket(
+                ticket_id="#PR-9827",
+                category="Konten",
+                priority="Kuning",
+                status="Dalam review",
+                sla_remaining="00:45",
+                assigned_to="Dimas",
+                source="AI signal",
+            ),
+            ReportTicket(
+                ticket_id="#PR-9819",
+                category="Seller",
+                priority="Hijau",
+                status="Butuh klarifikasi",
+                sla_remaining="04:20",
+                assigned_to="Nadia",
+                source="Internal QA",
+            ),
+            ReportTicket(
+                ticket_id="#PR-9805",
+                category="Pembeli",
+                priority="Kuning",
+                status="Menunggu bukti",
+                sla_remaining="02:55",
+                assigned_to="Belum ditetapkan",
+                source="Pelapor premium",
+            ),
+        ]
+
+        self._report_summary = [
+            {"label": "Total antrean", "value": "86", "tone": "info"},
+            {"label": "Over SLA", "value": "9", "tone": "danger"},
+            {"label": "Butuh eskalasi", "value": "5", "tone": "warning"},
+            {"label": "Mode fokus aktif", "value": "3 moderator", "tone": "primary"},
+        ]
+
+        self._curation_submissions = [
+            CurationSubmission(
+                brand="Aurora Glow",
+                submission_type="Pengajuan Brand",
+                owner="Amelia R.",
+                status="Menunggu admin",
+                updated="23 menit lalu",
+                notes="Perlu verifikasi SIUP & legalitas distributor.",
+            ),
+            CurationSubmission(
+                brand="Rantau Craft",
+                submission_type="Kampanye",
+                owner="Galih P.",
+                status="Butuh revisi",
+                updated="1 jam lalu",
+                notes="Foto hero tidak sesuai panduan, minta versi ulang.",
+            ),
+            CurationSubmission(
+                brand="Laguna Living",
+                submission_type="Produk Baru",
+                owner="Intan M.",
+                status="Disetujui",
+                updated="Kemarin",
+                notes="Produk otomatis aktif karena brand sudah terverifikasi.",
+            ),
+        ]
+
+        self._curation_summary = [
+            {"label": "Pengajuan baru", "value": "18", "tone": "primary"},
+            {"label": "Brand high risk", "value": "3", "tone": "danger"},
+            {"label": "Butuh revisi", "value": "7", "tone": "warning"},
+            {"label": "Verifikasi otomatis", "value": "42 produk", "tone": "success"},
+        ]
+
+        self._checklist_highlights = [
+            "Verifikasi legalitas brand minimal 2 dokumen valid.",
+            "Checklist foto produk wajib resolusi > 1200px.",
+            "Pastikan riwayat pelanggaran brand < 2 dalam 90 hari.",
+        ]
+
+        self._insights = [
+            InsightTrend(
+                label="Trend laporan mingguan",
+                current="+18%",
+                change="Lonjakan dari kategori transaksi",
+                tone="warning",
+            ),
+            InsightTrend(
+                label="Kurasi disetujui",
+                current="74%",
+                change="Stabil dibanding minggu lalu",
+                tone="info",
+            ),
+            InsightTrend(
+                label="SLA 4 jam terpenuhi",
+                current="91%",
+                change="Target minimal 90% terpenuhi",
+                tone="success",
+            ),
+        ]
+
+        self._heatmap = [
+            HeatmapSlot(label="07.00-09.00", load="78%", state="padat"),
+            HeatmapSlot(label="09.00-11.00", load="95%", state="kritikal"),
+            HeatmapSlot(label="11.00-13.00", load="68%", state="stabil"),
+            HeatmapSlot(label="13.00-15.00", load="54%", state="rendah"),
+        ]
+
+        self._violations = [
+            {"category": "Penipuan pembayaran", "count": 21},
+            {"category": "Konten SARA", "count": 15},
+            {"category": "Pelanggaran hak cipta", "count": 11},
+        ]
+
+        self._team_productivity = [
+            {"name": "Nadia", "resolved": 18, "accuracy": "94%"},
+            {"name": "Dimas", "resolved": 15, "accuracy": "89%"},
+            {"name": "Sela", "resolved": 12, "accuracy": "93%"},
+        ]
+
+        self._policies = [
+            PolicyUpdate(
+                title="SOP Verifikasi Pembayaran",
+                version="v2.1",
+                updated_at="13 Mei 2024",
+                owner="Arif",
+                tags=["transaksi", "compliance"],
+            ),
+            PolicyUpdate(
+                title="Panduan Konten Sensitif",
+                version="v1.4",
+                updated_at="10 Mei 2024",
+                owner="Nadia",
+                tags=["konten", "komunitas"],
+            ),
+            PolicyUpdate(
+                title="Checklist Kurasi Brand Premium",
+                version="v0.9",
+                updated_at="8 Mei 2024",
+                owner="Sela",
+                tags=["kurasi", "brand"],
+            ),
+        ]
+
+        self._templates = [
+            {
+                "name": "Template konfirmasi bukti tambahan",
+                "usage": "Moderator",
+                "updated_at": "Kemarin",
+            },
+            {
+                "name": "Template permintaan revisi brand",
+                "usage": "Kurator",
+                "updated_at": "2 hari lalu",
+            },
+            {
+                "name": "Template eskalasi ke legal",
+                "usage": "Admin",
+                "updated_at": "Minggu lalu",
+            },
+        ]
+
+        self._automation_rules = [
+            "Laporan prioritas merah tanpa respon >2 jam otomatis eskalasi ke admin.",
+            "Brand dengan skor risiko > 70 dikirim ke Quality Lead untuk audit.",
+            "3 pelanggaran serupa dalam 30 hari memicu suspend sementara 48 jam.",
+        ]
+
+        self._help_resources = [
+            HelpResource(
+                title="Panduan cepat eskalasi kasus penipuan",
+                category="Moderator",
+                format="Playbook",
+                updated_at="1 minggu lalu",
+            ),
+            HelpResource(
+                title="Checklist onboarding kurator",
+                category="Kurator",
+                format="Spreadsheet",
+                updated_at="3 hari lalu",
+            ),
+            HelpResource(
+                title="Video refresher audit SOP",
+                category="Quality Lead",
+                format="Video",
+                updated_at="April 2024",
+            ),
+        ]
+
+        self._contacts = [
+            ContactPoint(
+                name="Arif Santoso",
+                role="Admin Utama",
+                channel="Slack #ops-escalation",
+                availability="07.00 - 21.00",
+            ),
+            ContactPoint(
+                name="Intan Pratiwi",
+                role="Legal Advisor",
+                channel="legal@sensasiwangi.id",
+                availability="Hari kerja",
+            ),
+            ContactPoint(
+                name="Rudi Hartono",
+                role="Quality Lead",
+                channel="Ext. 8891",
+                availability="09.00 - 18.00",
+            ),
+        ]
+
+    def get_snapshot(self) -> dict:
+        """Return the moderation dashboard snapshot."""
+
+        return {
+            "persona": self._persona,
+            "kpis": self._kpis,
+            "alerts": self._alerts,
+            "report_summary": self._report_summary,
+            "team_members": self._team_members,
+            "pending_invites": self._pending_invites,
+            "audit_trail": self._audit_trail,
+            "report_tickets": self._report_tickets,
+            "curation_summary": self._curation_summary,
+            "curation_submissions": self._curation_submissions,
+            "checklist_highlights": self._checklist_highlights,
+            "insights": self._insights,
+            "heatmap": self._heatmap,
+            "violations": self._violations,
+            "team_productivity": self._team_productivity,
+            "policies": self._policies,
+            "templates": self._templates,
+            "automation_rules": self._automation_rules,
+            "help_resources": self._help_resources,
+            "contacts": self._contacts,
+        }
+
+
+moderation_dashboard_service = ModerationDashboardService()

--- a/src/app/web/static/css/moderation-dashboard.css
+++ b/src/app/web/static/css/moderation-dashboard.css
@@ -1,0 +1,708 @@
+.mod-hero {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 2.5rem;
+  padding: 2.75rem;
+  align-items: start;
+}
+
+.mod-hero__main h1 {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  margin: 0.5rem 0 0.75rem;
+}
+
+.mod-hero__main .mission {
+  font-size: 1.05rem;
+  margin: 0 0 1rem;
+  max-width: 46ch;
+}
+
+.role-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.2);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  font-size: 0.85rem;
+  letter-spacing: 0.03em;
+}
+
+.hero-meta {
+  display: grid;
+  gap: 0.75rem;
+  margin: 1.5rem 0 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.hero-meta dt {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(203, 213, 225, 0.8);
+  margin-bottom: 0.25rem;
+}
+
+.hero-meta dd {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+
+.acknowledgement {
+  margin-top: 1.25rem;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+.mod-hero__kpis {
+  align-self: stretch;
+}
+
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.25rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.kpi-card {
+  padding: 1.4rem 1.5rem;
+}
+
+.kpi-card .kpi-label {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.kpi-card .kpi-value {
+  margin: 0.5rem 0 0.35rem;
+  font-size: 1.65rem;
+  font-weight: 600;
+}
+
+.kpi-card .kpi-delta {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.kpi-card.tone-success {
+  border-left: 3px solid rgba(52, 211, 153, 0.8);
+}
+
+.kpi-card.tone-warning {
+  border-left: 3px solid rgba(250, 204, 21, 0.75);
+}
+
+.kpi-card.tone-info {
+  border-left: 3px solid rgba(56, 189, 248, 0.75);
+}
+
+.kpi-card.tone-positive {
+  border-left: 3px solid rgba(129, 140, 248, 0.75);
+}
+
+.mod-overview {
+  padding: 2.5rem;
+  display: grid;
+  gap: 2.25rem;
+}
+
+.overview-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  gap: 2.25rem;
+}
+
+.summary-pills {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.summary-pill {
+  padding: 1.1rem 1.35rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.6);
+  display: grid;
+  gap: 0.2rem;
+}
+
+.summary-pill .summary-value {
+  font-size: 1.45rem;
+  font-weight: 600;
+}
+
+.summary-pill .summary-label {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.summary-pill.tone-danger {
+  border-color: rgba(248, 113, 113, 0.5);
+}
+
+.summary-pill.tone-warning {
+  border-color: rgba(250, 204, 21, 0.5);
+}
+
+.summary-pill.tone-primary {
+  border-color: rgba(129, 140, 248, 0.5);
+}
+
+.summary-pill.tone-info {
+  border-color: rgba(56, 189, 248, 0.5);
+}
+
+.alert-stream {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.alert-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.1rem;
+}
+
+.alert-item {
+  padding: 1.35rem 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.alert-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.alert-severity {
+  color: var(--text-secondary);
+}
+
+.alert-item.severity-kritis {
+  border-left: 3px solid rgba(248, 113, 113, 0.8);
+}
+
+.alert-item.severity-penting {
+  border-left: 3px solid rgba(129, 140, 248, 0.75);
+}
+
+.alert-item.severity-pengingat {
+  border-left: 3px solid rgba(56, 189, 248, 0.75);
+}
+
+.alert-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.mod-team {
+  display: grid;
+}
+
+.team-roster {
+  padding: 2.5rem;
+  display: grid;
+  gap: 2rem;
+}
+
+.team-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 0.8fr);
+  gap: 2.25rem;
+}
+
+.team-table {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.team-header,
+.team-row {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 1rem;
+  padding: 0.9rem 1.1rem;
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.team-header {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: rgba(15, 23, 42, 0.7);
+}
+
+.team-sidepanel {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.invite-panel ul,
+.audit-trail ol {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.invite-panel li,
+.audit-trail li {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.2rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.panel-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.audit-time {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.mod-queues {
+  padding: 2.5rem;
+  display: grid;
+  gap: 2.25rem;
+}
+
+.queue-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.55fr) minmax(0, 1.45fr);
+  gap: 2rem;
+}
+
+.queue-sidebar ul {
+  list-style: none;
+  margin: 0 0 1.5rem;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.queue-sidebar li {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  font-size: 0.95rem;
+}
+
+.queue-sidebar .indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  display: inline-block;
+}
+
+.indicator.tone-danger {
+  background: rgba(248, 113, 113, 0.85);
+}
+
+.indicator.tone-warning {
+  background: rgba(250, 204, 21, 0.85);
+}
+
+.indicator.tone-primary {
+  background: rgba(129, 140, 248, 0.85);
+}
+
+.indicator.tone-info {
+  background: rgba(56, 189, 248, 0.85);
+}
+
+.queue-note {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.queue-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.queue-table th,
+.queue-table td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.queue-table thead {
+  background: rgba(15, 23, 42, 0.7);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.queue-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.priority-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  border: 1px solid transparent;
+}
+
+.priority-merah {
+  background: rgba(248, 113, 113, 0.18);
+  border-color: rgba(248, 113, 113, 0.45);
+}
+
+.priority-kuning {
+  background: rgba(250, 204, 21, 0.18);
+  border-color: rgba(250, 204, 21, 0.45);
+}
+
+.priority-hijau {
+  background: rgba(52, 211, 153, 0.18);
+  border-color: rgba(52, 211, 153, 0.45);
+}
+
+.mod-curation {
+  padding: 2.5rem;
+  display: grid;
+  gap: 2.25rem;
+}
+
+.curation-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.6fr) minmax(0, 1.4fr);
+  gap: 2rem;
+}
+
+.summary-list {
+  list-style: none;
+  margin: 0 0 1.5rem;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.summary-list li {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.summary-list .summary-value {
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.summary-list .summary-label {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+.summary-list .tone-success {
+  color: #34d399;
+}
+
+.summary-list .tone-danger {
+  color: #f87171;
+}
+
+.summary-list .tone-warning {
+  color: #fbbf24;
+}
+
+.summary-list .tone-primary {
+  color: #818cf8;
+}
+
+.checklist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+}
+
+.curation-table,
+.team-performance {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.curation-table th,
+.curation-table td,
+.team-performance th,
+.team-performance td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.curation-table thead,
+.team-performance thead {
+  background: rgba(15, 23, 42, 0.7);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.mod-analytics {
+  padding: 2.5rem;
+  display: grid;
+  gap: 2.25rem;
+}
+
+.analytics-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
+  gap: 2rem;
+}
+
+.insight-cards {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.insight-card {
+  padding: 1.4rem 1.6rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.insight-card h3 {
+  margin: 0;
+}
+
+.insight-card .insight-value {
+  font-size: 1.8rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.insight-card.tone-warning {
+  border-left: 3px solid rgba(250, 204, 21, 0.75);
+}
+
+.insight-card.tone-info {
+  border-left: 3px solid rgba(56, 189, 248, 0.75);
+}
+
+.insight-card.tone-success {
+  border-left: 3px solid rgba(52, 211, 153, 0.75);
+}
+
+.analytics-details {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.heatmap {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.heatmap-slot {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.2rem;
+  background: rgba(15, 23, 42, 0.55);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.heatmap-slot.state-kritikal {
+  border-color: rgba(248, 113, 113, 0.5);
+}
+
+.heatmap-slot.state-padat {
+  border-color: rgba(250, 204, 21, 0.45);
+}
+
+.heatmap-slot.state-stabil {
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.heatmap-slot.state-rendah {
+  border-color: rgba(129, 140, 248, 0.35);
+}
+
+.violation-list {
+  margin: 0;
+  padding: 0 0 0 1.25rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.mod-policies {
+  padding: 2.5rem;
+  display: grid;
+  gap: 2.25rem;
+}
+
+.policy-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 2rem;
+}
+
+.policy-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.policy-list li {
+  padding: 1.3rem 1.5rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.policy-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.policy-tags span {
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  font-size: 0.85rem;
+}
+
+.template-list,
+.automation-list {
+  list-style: none;
+  margin: 0 0 1.25rem;
+  padding: 0;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.automation-list li {
+  padding-left: 1.25rem;
+  position: relative;
+}
+
+.automation-list li::before {
+  content: "•";
+  position: absolute;
+  left: 0;
+  color: rgba(56, 189, 248, 0.75);
+}
+
+.mod-help {
+  padding: 2.5rem;
+  display: grid;
+  gap: 2.25rem;
+}
+
+.help-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 2rem;
+}
+
+.resource-list,
+.contact-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.resource-list li {
+  padding: 1.2rem 1.4rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.contact-list li {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.2rem;
+}
+
+.feedback-box {
+  margin-top: 1.5rem;
+  padding: 1.4rem 1.6rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+@media (max-width: 1024px) {
+  .mod-hero,
+  .overview-grid,
+  .team-layout,
+  .queue-grid,
+  .curation-grid,
+  .analytics-grid,
+  .policy-grid,
+  .help-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .mod-hero {
+    padding: 2.25rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .team-header,
+  .team-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .queue-table,
+  .curation-table,
+  .team-performance {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+}

--- a/src/app/web/templates/pages/dashboard/moderation.html
+++ b/src/app/web/templates/pages/dashboard/moderation.html
@@ -1,0 +1,428 @@
+{% extends 'base.html' %}
+
+{% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/moderation-dashboard.css') }}" />
+{% endblock %}
+
+{% block content %}
+{% set persona = snapshot.persona %}
+<section class="mod-hero glass-surface">
+  <div class="mod-hero__main">
+    <span class="role-badge">{{ persona.role }}</span>
+    <h1>Halo, {{ persona.name }} 👋</h1>
+    <p class="mission">{{ persona.mission }}</p>
+    <dl class="hero-meta" aria-label="Detail shift dan fokus hari ini">
+      <div>
+        <dt>Hari &amp; Tanggal</dt>
+        <dd>{{ persona.date }}</dd>
+      </div>
+      <div>
+        <dt>Shift Aktif</dt>
+        <dd>{{ persona.shift }}</dd>
+      </div>
+      <div>
+        <dt>Fokus</dt>
+        <dd>{{ persona.focus }}</dd>
+      </div>
+    </dl>
+    <div class="hero-actions">
+      <button type="button" class="btn gradient-button">Tambah Moderator</button>
+      <button type="button" class="btn btn-outline">Lihat SOP</button>
+      <button type="button" class="btn btn-ghost">Bagikan Laporan</button>
+    </div>
+    <p class="acknowledgement">🔔 {{ persona.acknowledgement }}</p>
+  </div>
+  <div class="mod-hero__kpis">
+    <ul class="kpi-grid" role="list">
+      {% for kpi in snapshot.kpis %}
+      <li class="kpi-card glass-card tone-{{ kpi.tone }}" role="listitem">
+        <p class="kpi-label">{{ kpi.label }}</p>
+        <p class="kpi-value">{{ kpi.value }}</p>
+        <p class="kpi-delta">{{ kpi.delta }}</p>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+</section>
+
+<section class="mod-overview glass-surface">
+  <header class="section-heading">
+    <div>
+      <h2>Overview &amp; Alerts</h2>
+      <p>Monitor kesehatan operasional, SLA, dan eskalasi lintas tim dalam satu layar.</p>
+    </div>
+    <div class="section-tools">
+      <button type="button" class="btn btn-ghost">Refresh</button>
+      <button type="button" class="btn btn-outline">Download KPI</button>
+    </div>
+  </header>
+  <div class="overview-grid">
+    <div class="summary-pills" role="list">
+      {% for summary in snapshot.report_summary %}
+      <article class="summary-pill tone-{{ summary.tone }}" role="listitem">
+        <span class="summary-value">{{ summary.value }}</span>
+        <span class="summary-label">{{ summary.label }}</span>
+      </article>
+      {% endfor %}
+    </div>
+    <aside class="alert-stream" aria-label="Daftar alert terbaru">
+      <h3>Alert &amp; Eskalasi</h3>
+      <ul class="alert-list">
+        {% for alert in snapshot.alerts %}
+        <li class="alert-item glass-card severity-{{ alert.severity }}">
+          <div class="alert-header">
+            <span class="alert-severity">{{ alert.severity|title }}</span>
+            <span class="alert-time">{{ alert.timestamp }}</span>
+          </div>
+          <h4>{{ alert.title }}</h4>
+          <p>{{ alert.description }}</p>
+          <div class="alert-actions">
+            <button type="button" class="btn btn-ghost">Tandai selesai</button>
+            <button type="button" class="btn btn-outline">Lihat detail</button>
+          </div>
+        </li>
+        {% endfor %}
+      </ul>
+    </aside>
+  </div>
+</section>
+
+<section class="mod-team">
+  <article class="glass-surface team-roster">
+    <header class="section-heading">
+      <div>
+        <h2>Manajemen Tim &amp; Peran</h2>
+        <p>Kelola moderator, kurator, dan Quality Lead dengan visibilitas penuh terhadap kapasitas.</p>
+      </div>
+      <div class="section-tools">
+        <button type="button" class="btn gradient-button">Undang Pengguna</button>
+        <button type="button" class="btn btn-outline">Atur Shift</button>
+      </div>
+    </header>
+    <div class="team-layout">
+      <div class="team-table" role="table" aria-label="Daftar anggota tim">
+        <div class="team-header" role="row">
+          <span role="columnheader">Nama</span>
+          <span role="columnheader">Peran</span>
+          <span role="columnheader">Status</span>
+          <span role="columnheader">Kasus Aktif</span>
+          <span role="columnheader">Aktivitas Terakhir</span>
+          <span role="columnheader">Shift</span>
+        </div>
+        {% for member in snapshot.team_members %}
+        <div class="team-row" role="row">
+          <span role="cell">{{ member.name }}</span>
+          <span role="cell">{{ member.role }}</span>
+          <span role="cell">{{ member.status }}</span>
+          <span role="cell">{{ member.active_cases }}</span>
+          <span role="cell">{{ member.last_active }}</span>
+          <span role="cell">{{ member.shift }}</span>
+        </div>
+        {% endfor %}
+      </div>
+      <aside class="team-sidepanel">
+        <section class="invite-panel">
+          <h3>Undangan Pending</h3>
+          <ul>
+            {% for invite in snapshot.pending_invites %}
+            <li>
+              <p><strong>{{ invite.email }}</strong> · {{ invite.role }}</p>
+              <p>Dikirim {{ invite.sent_at }} · Kedaluwarsa {{ invite.expires_at }}</p>
+              <div class="panel-actions">
+                <button type="button" class="btn btn-ghost">Kirim ulang</button>
+                <button type="button" class="btn btn-outline">Batalkan</button>
+              </div>
+            </li>
+            {% endfor %}
+          </ul>
+        </section>
+        <section class="audit-trail">
+          <h3>Audit Trail Terbaru</h3>
+          <ol>
+            {% for entry in snapshot.audit_trail %}
+            <li>
+              <span class="audit-time">{{ entry.time }}</span>
+              <div>
+                <strong>{{ entry.actor }}</strong>
+                <p>{{ entry.action }}</p>
+              </div>
+            </li>
+            {% endfor %}
+          </ol>
+        </section>
+      </aside>
+    </div>
+  </article>
+</section>
+
+<section class="mod-queues glass-surface">
+  <header class="section-heading">
+    <div>
+      <h2>Moderasi Laporan</h2>
+      <p>Prioritaskan laporan komunitas, transaksi, dan pelanggaran seller sesuai SLA.</p>
+    </div>
+    <div class="section-tools">
+      <button type="button" class="btn btn-ghost">Mode Fokus</button>
+      <button type="button" class="btn btn-outline">Bulk Action</button>
+    </div>
+  </header>
+  <div class="queue-grid">
+    <aside class="queue-sidebar">
+      <h3>Status Antrian</h3>
+      <ul>
+        {% for item in snapshot.report_summary %}
+        <li><span class="indicator tone-{{ item.tone }}"></span>{{ item.label }} · {{ item.value }}</li>
+        {% endfor %}
+      </ul>
+      <div class="queue-note">
+        <p>Pemetaan otomatis berdasarkan kapasitas moderator aktif. Tiket tanpa pemilik akan muncul paling atas.</p>
+      </div>
+    </aside>
+    <div class="queue-table-wrapper">
+      <table class="queue-table">
+        <thead>
+          <tr>
+            <th scope="col">Ticket</th>
+            <th scope="col">Kategori</th>
+            <th scope="col">Prioritas</th>
+            <th scope="col">Status</th>
+            <th scope="col">SLA</th>
+            <th scope="col">Penanggung Jawab</th>
+            <th scope="col">Sumber</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for ticket in snapshot.report_tickets %}
+          <tr>
+            <td>{{ ticket.ticket_id }}</td>
+            <td>{{ ticket.category }}</td>
+            <td><span class="priority-badge priority-{{ ticket.priority | lower }}">{{ ticket.priority }}</span></td>
+            <td>{{ ticket.status }}</td>
+            <td>{{ ticket.sla_remaining }}</td>
+            <td>{{ ticket.assigned_to }}</td>
+            <td>{{ ticket.source }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<section class="mod-curation glass-surface">
+  <header class="section-heading">
+    <div>
+      <h2>Kurasi Konten &amp; Brand</h2>
+      <p>Checklist kualitas dan riwayat brand terkonsolidasi membantu keputusan lebih cepat.</p>
+    </div>
+    <div class="section-tools">
+      <button type="button" class="btn btn-outline">Checklist Kurasi</button>
+      <button type="button" class="btn btn-ghost">Kolaborasi</button>
+    </div>
+  </header>
+  <div class="curation-grid">
+    <aside>
+      <h3>Ringkasan Pipeline</h3>
+      <ul class="summary-list">
+        {% for summary in snapshot.curation_summary %}
+        <li class="tone-{{ summary.tone }}">
+          <span class="summary-value">{{ summary.value }}</span>
+          <span class="summary-label">{{ summary.label }}</span>
+        </li>
+        {% endfor %}
+      </ul>
+      <h4>Highlight Checklist</h4>
+      <ul class="checklist">
+        {% for item in snapshot.checklist_highlights %}
+        <li>{{ item }}</li>
+        {% endfor %}
+      </ul>
+    </aside>
+    <div class="curation-table-wrapper">
+      <table class="curation-table">
+        <thead>
+          <tr>
+            <th scope="col">Brand / Kampanye</th>
+            <th scope="col">Tipe</th>
+            <th scope="col">Pemilik</th>
+            <th scope="col">Status</th>
+            <th scope="col">Update Terakhir</th>
+            <th scope="col">Catatan</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for submission in snapshot.curation_submissions %}
+          <tr>
+            <td>{{ submission.brand }}</td>
+            <td>{{ submission.submission_type }}</td>
+            <td>{{ submission.owner }}</td>
+            <td>{{ submission.status }}</td>
+            <td>{{ submission.updated }}</td>
+            <td>{{ submission.notes }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<section class="mod-analytics glass-surface">
+  <header class="section-heading">
+    <div>
+      <h2>Analitik &amp; Insight</h2>
+      <p>Jelajahi metrik utama untuk menjaga kualitas keputusan dan efisiensi operasional.</p>
+    </div>
+    <div class="section-tools">
+      <button type="button" class="btn btn-outline">Ekspor CSV</button>
+      <button type="button" class="btn btn-ghost">Penjadwalan Laporan</button>
+    </div>
+  </header>
+  <div class="analytics-grid">
+    <div class="insight-cards">
+      {% for insight in snapshot.insights %}
+      <article class="insight-card glass-card tone-{{ insight.tone }}">
+        <h3>{{ insight.label }}</h3>
+        <p class="insight-value">{{ insight.current }}</p>
+        <p>{{ insight.change }}</p>
+      </article>
+      {% endfor %}
+    </div>
+    <div class="analytics-details">
+      <section>
+        <h3>Heatmap Beban Kerja</h3>
+        <ul class="heatmap">
+          {% for slot in snapshot.heatmap %}
+          <li class="heatmap-slot state-{{ slot.state }}">
+            <span>{{ slot.label }}</span>
+            <strong>{{ slot.load }}</strong>
+          </li>
+          {% endfor %}
+        </ul>
+      </section>
+      <section>
+        <h3>Top Kategori Pelanggaran</h3>
+        <ol class="violation-list">
+          {% for violation in snapshot.violations %}
+          <li>
+            <span>{{ violation.category }}</span>
+            <strong>{{ violation.count }}</strong>
+          </li>
+          {% endfor %}
+        </ol>
+      </section>
+      <section>
+        <h3>Performa Tim</h3>
+        <table class="team-performance">
+          <thead>
+            <tr>
+              <th scope="col">Nama</th>
+              <th scope="col">Kasus Selesai</th>
+              <th scope="col">Akurasi Audit</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for member in snapshot.team_productivity %}
+            <tr>
+              <td>{{ member.name }}</td>
+              <td>{{ member.resolved }}</td>
+              <td>{{ member.accuracy }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  </div>
+</section>
+
+<section class="mod-policies glass-surface">
+  <header class="section-heading">
+    <div>
+      <h2>Pengaturan Kebijakan &amp; Template</h2>
+      <p>Simpan jejak perubahan kebijakan serta template komunikasi lintas peran.</p>
+    </div>
+    <div class="section-tools">
+      <button type="button" class="btn btn-outline">Buat Kebijakan</button>
+      <button type="button" class="btn btn-ghost">Atur Automasi</button>
+    </div>
+  </header>
+  <div class="policy-grid">
+    <section>
+      <h3>Kebijakan Terbaru</h3>
+      <ul class="policy-list">
+        {% for policy in snapshot.policies %}
+        <li class="glass-card">
+          <div>
+            <h4>{{ policy.title }}</h4>
+            <p>Versi {{ policy.version }} · {{ policy.updated_at }} · Oleh {{ policy.owner }}</p>
+          </div>
+          <div class="policy-tags">
+            {% for tag in policy.tags %}<span>{{ tag }}</span>{% endfor %}
+          </div>
+        </li>
+        {% endfor %}
+      </ul>
+    </section>
+    <section>
+      <h3>Template Pesan</h3>
+      <ul class="template-list">
+        {% for template in snapshot.templates %}
+        <li>
+          <strong>{{ template.name }}</strong>
+          <p>Untuk {{ template.usage }} · Update {{ template.updated_at }}</p>
+        </li>
+        {% endfor %}
+      </ul>
+      <h4>Aturan Automasi</h4>
+      <ul class="automation-list">
+        {% for rule in snapshot.automation_rules %}
+        <li>{{ rule }}</li>
+        {% endfor %}
+      </ul>
+    </section>
+  </div>
+</section>
+
+<section class="mod-help glass-surface">
+  <header class="section-heading">
+    <div>
+      <h2>Pusat Bantuan Internal</h2>
+      <p>Dukung pembelajaran berkelanjutan dan jalur eskalasi jelas untuk seluruh tim moderasi.</p>
+    </div>
+    <div class="section-tools">
+      <button type="button" class="btn btn-outline">Kirim Feedback</button>
+      <button type="button" class="btn btn-ghost">Jadwalkan Coaching</button>
+    </div>
+  </header>
+  <div class="help-grid">
+    <section>
+      <h3>Materi &amp; FAQ</h3>
+      <ul class="resource-list">
+        {% for resource in snapshot.help_resources %}
+        <li class="glass-card">
+          <h4>{{ resource.title }}</h4>
+          <p>{{ resource.category }} · {{ resource.format }} · Update {{ resource.updated_at }}</p>
+        </li>
+        {% endfor %}
+      </ul>
+    </section>
+    <section>
+      <h3>Kontak Eskalasi</h3>
+      <ul class="contact-list">
+        {% for contact in snapshot.contacts %}
+        <li>
+          <strong>{{ contact.name }}</strong>
+          <p>{{ contact.role }} · {{ contact.channel }} · {{ contact.availability }}</p>
+        </li>
+        {% endfor %}
+      </ul>
+      <div class="feedback-box glass-card">
+        <h4>Form Masukan Cepat</h4>
+        <p>Catat kendala atau ide perbaikan. Admin akan menindaklanjuti dalam 24 jam.</p>
+        <button type="button" class="btn gradient-button">Buka Form</button>
+      </div>
+    </section>
+  </div>
+</section>
+{% endblock %}

--- a/src/app/web/templates/partials/navbar.html
+++ b/src/app/web/templates/partials/navbar.html
@@ -36,6 +36,14 @@
     </li>
     <li>
       <a
+        href="{{ url_for('read_moderation_dashboard') }}"
+        class="{% if request.url.path.startswith('/dashboard/moderation') %}active{% endif %}"
+      >
+        Dashboard Moderasi
+      </a>
+    </li>
+    <li>
+      <a
         href="{{ url_for('read_uiux_tracker') }}"
         class="{% if request.url.path.startswith('/ui-ux/implementation') %}active{% endif %}"
       >


### PR DESCRIPTION
## Summary
- add a moderation dashboard data service with seeded metrics for admins, moderators, and curators
- render a new moderation dashboard page with navigation entry and tailored glassmorphism styling
- expose the dashboard through a FastAPI route that feeds the template from the service snapshot

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8d6597cfc8327ba3966cdbfe121de