### PR TITLE
Refine navbar and footer navigation

### DIFF
--- a/src/app/web/static/css/base.css
+++ b/src/app/web/static/css/base.css
@@ -212,12 +212,97 @@ p {
   gap: 0.75rem;
 }
 
-.navbar-user {
+.navbar-dropdown {
+  position: relative;
+  display: inline-flex;
+}
+
+.navbar-dropdown__toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  cursor: pointer;
   color: var(--text-secondary);
   font-weight: 600;
+  text-decoration: none;
+  user-select: none;
+  margin: 0;
+}
+
+.navbar-dropdown__toggle:hover {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.navbar-dropdown__toggle::-webkit-details-marker {
+  display: none;
+}
+
+.navbar-dropdown__toggle:focus-visible {
+  outline: 2px solid var(--accent-secondary);
+  outline-offset: 3px;
+}
+
+.navbar-dropdown[open] .navbar-dropdown__toggle {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.navbar-dropdown__icon {
+  font-size: 0.75rem;
+  transition: transform var(--transition-fast);
+}
+
+.navbar-dropdown[open] .navbar-dropdown__icon {
+  transform: rotate(180deg);
+}
+
+.navbar-dropdown__menu {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  min-width: 200px;
+  padding: 0.75rem;
+  border-radius: 1rem;
+  background: rgba(18, 18, 18, 0.7);
+  backdrop-filter: blur(16px);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.35);
+  list-style: none;
+  display: grid;
+  gap: 0.35rem;
+  z-index: 25;
+}
+
+.navbar-dropdown:not([open]) .navbar-dropdown__menu {
+  display: none;
+}
+
+.navbar-dropdown__menu a,
+.navbar-dropdown__menu button {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 0.4rem;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  padding: 0.45rem 0.6rem;
+  border-radius: 0.65rem;
+  cursor: pointer;
+  text-align: left;
+  text-decoration: none;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.navbar-dropdown__menu a:hover,
+.navbar-dropdown__menu a:focus-visible,
+.navbar-dropdown__menu button:hover,
+.navbar-dropdown__menu button:focus-visible {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .navbar-actions .is-loading {

--- a/src/app/web/templates/partials/footer.html
+++ b/src/app/web/templates/partials/footer.html
@@ -5,19 +5,29 @@
   </div>
   <div class="footer-links">
     <div>
-      <h4>Komunitas</h4>
+      <h4>Navigasi</h4>
       <ul>
-        <li><a href="#komunitas">Newsletter</a></li>
-        <li><a href="#sambatan">Sambatan</a></li>
-        <li><a href="#nusantarum">Nusantarum</a></li>
+        <li><a href="{{ url_for('read_home') }}">Beranda</a></li>
+        <li><a href="{{ url_for('read_marketplace') }}">Marketplace</a></li>
+        <li><a href="{{ url_for('list_brands') }}">Brand Partner</a></li>
+        <li><a href="{{ url_for('read_onboarding') }}">Onboarding</a></li>
+        <li><a href="{{ url_for('read_uiux_tracker') }}">UI/UX Tracker</a></li>
+        <li><a href="{{ url_for('read_purchase_foundation') }}">Flow Pembelian</a></li>
       </ul>
     </div>
     <div>
-      <h4>Dukungan</h4>
+      <h4>Dashboard</h4>
       <ul>
-        <li><a href="#kontak">Kontak</a></li>
-        <li><a href="#kebijakan">Kebijakan Privasi</a></li>
-        <li><a href="#syarat">Syarat Layanan</a></li>
+        <li><a href="{{ url_for('read_brand_owner_dashboard') }}">Dashboard Brand</a></li>
+        <li><a href="{{ url_for('read_moderation_dashboard') }}">Dashboard Moderasi</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4>Komunitas</h4>
+      <ul>
+        <li><a href="{{ url_for('read_home') }}#sambatan">Sambatan</a></li>
+        <li><a href="{{ url_for('read_home') }}#nusantarum">Nusantarum</a></li>
+        <li><a href="{{ url_for('read_home') }}#profil">Profil</a></li>
       </ul>
     </div>
     <div>

--- a/src/app/web/templates/partials/navbar.html
+++ b/src/app/web/templates/partials/navbar.html
@@ -1,7 +1,7 @@
 <nav class="navbar glass-surface">
-  <div class="navbar-brand">
+  <a class="navbar-brand" href="{{ url_for('read_home') }}">
     <span class="logo">Sensasiwangi.id</span>
-  </div>
+  </a>
   <button class="navbar-toggle" aria-label="Buka navigasi">
     <span></span>
     <span></span>
@@ -9,69 +9,49 @@
   </button>
   <ul class="navbar-menu">
     <li>
-      <a href="{{ url_for('read_home') }}" class="{% if request.url.path == '/' %}active{% endif %}">Beranda</a>
-    </li>
-    <li>
       <a href="{{ url_for('read_marketplace') }}" class="{% if request.url.path.startswith('/marketplace') %}active{% endif %}">
         Marketplace
       </a>
     </li>
     <li>
-      <a href="{{ url_for('list_brands') }}" class="{% if request.url.path.startswith('/brands') %}active{% endif %}">
-        Brand
+      <a href="{{ url_for('read_home') }}#nusantarum" class="{% if request.url.path == '/' %}active{% endif %}">
+        Nusantarum
       </a>
     </li>
-    <li>
-      <a href="{{ url_for('read_onboarding') }}" class="{% if request.url.path.startswith('/onboarding') %}active{% endif %}">
-        Onboarding
-      </a>
-    </li>
-    <li>
-      <a
-        href="{{ url_for('read_brand_owner_dashboard') }}"
-        class="{% if request.url.path.startswith('/dashboard/brand-owner') %}active{% endif %}"
-      >
-        Dashboard Brand
-      </a>
-    </li>
-    <li>
-      <a
-        href="{{ url_for('read_moderation_dashboard') }}"
-        class="{% if request.url.path.startswith('/dashboard/moderation') %}active{% endif %}"
-      >
-        Dashboard Moderasi
-      </a>
-    </li>
-    <li>
-      <a
-        href="{{ url_for('read_uiux_tracker') }}"
-        class="{% if request.url.path.startswith('/ui-ux/implementation') %}active{% endif %}"
-      >
-        UI/UX Tracker
-      </a>
-    </li>
-    <li>
-      <a
-        href="{{ url_for('read_purchase_foundation') }}"
-        class="{% if request.url.path.startswith('/ui-ux/foundation') %}active{% endif %}"
-      >
-        Flow Pembelian
-      </a>
-    </li>
-    <li><a href="{{ url_for('read_home') }}#sambatan">Sambatan</a></li>
-    <li><a href="{{ url_for('read_home') }}#nusantarum">Nusantarum</a></li>
-    <li><a href="{{ url_for('read_home') }}#dashboard">Dashboard</a></li>
-    <li><a href="{{ url_for('read_home') }}#profil">Profil</a></li>
   </ul>
   {% set session_user = request.session.get('user') %}
   <div class="navbar-actions">
-    {% if session_user %}
-    <span class="navbar-user">👋 {{ session_user.full_name }}</span>
-    <button class="btn btn-ghost" type="button" data-action="logout">Keluar</button>
-    <a class="btn gradient-button" href="{{ url_for('read_marketplace') }}">Marketplace</a>
-    {% else %}
-    <a class="btn btn-ghost" href="{{ url_for('read_auth') }}#login">Masuk</a>
-    <a class="btn gradient-button" href="{{ url_for('read_auth') }}#register">Daftar</a>
-    {% endif %}
+    <details class="navbar-dropdown">
+      <summary class="navbar-dropdown__toggle">
+        <span>{% if session_user %}{{ session_user.full_name }}{% else %}Login{% endif %}</span>
+        <span class="navbar-dropdown__icon" aria-hidden="true">▾</span>
+      </summary>
+      <ul class="navbar-dropdown__menu">
+        {% if session_user %}
+        {% set profile_username = session_user.get('username') if session_user else None %}
+        <li>
+          {% if profile_username %}
+          <a href="{{ url_for('profile_detail', username=profile_username) }}">Profil</a>
+          {% else %}
+          <a href="{{ url_for('read_auth') }}#login">Profil</a>
+          {% endif %}
+        </li>
+        <li>
+          <a href="{{ url_for('read_brand_owner_dashboard') }}">Dashboard Brand</a>
+        </li>
+        {% if session_user.get('is_admin') %}
+        <li>
+          <a href="{{ url_for('read_moderation_dashboard') }}">Admin Menu</a>
+        </li>
+        {% endif %}
+        <li>
+          <button type="button" data-action="logout">Keluar</button>
+        </li>
+        {% else %}
+        <li><a href="{{ url_for('read_auth') }}#login">Masuk</a></li>
+        <li><a href="{{ url_for('read_auth') }}#register">Daftar</a></li>
+        {% endif %}
+      </ul>
+    </details>
   </div>
 </nav>


### PR DESCRIPTION
## Summary
- simplify the global navbar to show only the logo, marketplace, nusantarum, and a dropdown account/login menu
- add a styled dropdown experience for account actions including profile, dashboard, admin, and logout handling
- move the remaining navigation links into the footer footbar for continued access to other pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d8e2e307148327bf830aba92ac4781