### PR TITLE
Ensure Vercel installs FastAPI dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi>=0.110
+uvicorn[standard]>=0.27
+jinja2>=3.1
+python-multipart>=0.0.6
+pydantic-settings>=2.2
+aiofiles>=23.2
+httpx>=0.27


### PR DESCRIPTION
## Summary
- add a requirements.txt file so serverless deployments install the FastAPI stack

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d90913d5ac832789e2baf20d642156