### PR TITLE
Remove marketplace hero text

### DIFF
--- a/src/app/web/templates/marketplace.html
+++ b/src/app/web/templates/marketplace.html
@@ -5,11 +5,6 @@
   <div class="section-header">
     <div>
       <span class="badge brand">Katalog Marketplace</span>
-      <h1>Telusuri produk brand partner dan kreator komunitas</h1>
-      <p>
-        Gunakan tab kategori untuk beralih antara parfum siap pakai, bahan baku, peralatan, dan opsi
-        pendukung lainnya.
-      </p>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- remove the hero heading and description text from the marketplace catalog header

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9134b72888327a44e08840b0d305b