### PR TITLE
Remove Nusantarum filter panel

### DIFF
--- a/src/app/web/templates/pages/nusantarum/index.html
+++ b/src/app/web/templates/pages/nusantarum/index.html
@@ -14,69 +14,60 @@
         Jelajahi parfum dari brand terverifikasi, temukan profil perfumer komunitas, dan pantau ketersediaan produk di marketplace Sensasiwangi.
       </p>
     </div>
-
-    <form
-      id="nusantarum-search-form"
-      class="nusantarum-search"
-      hx-get="/nusantarum/search"
-      hx-target="#nusantarum-search-results"
-      hx-trigger="keyup changed delay:400ms"
-      hx-indicator="#nusantarum-search-results"
-    >
-      <label class="sr-only" for="nusantarum-search-input">Cari parfum, brand, atau perfumer</label>
-      <input
-        id="nusantarum-search-input"
-        type="search"
-        name="q"
-        placeholder="Cari parfum, brand, atau perfumer"
-        autocomplete="off"
-      />
-    </form>
-    <div id="nusantarum-search-results">
-      {% with results={'perfumes': [], 'brands': [], 'perfumers': []}, error_message=None %}
-      {% include 'components/nusantarum/search-results.html' %}
-      {% endwith %}
-    </div>
-
-    <nav class="nusantarum-tabs" role="tablist">
-      <button
-        type="button"
-        class="nusantarum-tab"
-        role="tab"
-        aria-selected="{{ 'true' if active_tab == 'parfum' else 'false' }}"
-        hx-get="/nusantarum/tab/parfum"
-        hx-target="#nusantarum-tab-content"
-        hx-include="#nusantarum-filter-form"
-        hx-on::after-request="document.getElementById('nusantarum-filter-form')?.setAttribute('hx-get', '/nusantarum/tab/parfum')"
-      >Parfum</button>
-      <button
-        type="button"
-        class="nusantarum-tab"
-        role="tab"
-        aria-selected="{{ 'true' if active_tab == 'brand' else 'false' }}"
-        hx-get="/nusantarum/tab/brand"
-        hx-target="#nusantarum-tab-content"
-        hx-include="#nusantarum-filter-form"
-        hx-on::after-request="document.getElementById('nusantarum-filter-form')?.setAttribute('hx-get', '/nusantarum/tab/brand')"
-      >Brand</button>
-      <button
-        type="button"
-        class="nusantarum-tab"
-        role="tab"
-        aria-selected="{{ 'true' if active_tab == 'perfumer' else 'false' }}"
-        hx-get="/nusantarum/tab/perfumer"
-        hx-target="#nusantarum-tab-content"
-        hx-include="#nusantarum-filter-form"
-        hx-on::after-request="document.getElementById('nusantarum-filter-form')?.setAttribute('hx-get', '/nusantarum/tab/perfumer')"
-      >Perfumer</button>
-    </nav>
   </header>
 
-  <div class="nusantarum-body">
-    {% with filters=filters, sync_status=sync_status, active_tab=active_tab %}
-    {% include 'components/nusantarum/filter-panel.html' %}
-    {% endwith %}
+  <nav class="nusantarum-tabs" role="tablist">
+    <button
+      type="button"
+      class="nusantarum-tab"
+      role="tab"
+      aria-selected="{{ 'true' if active_tab == 'parfum' else 'false' }}"
+      hx-get="/nusantarum/tab/parfum"
+      hx-target="#nusantarum-tab-content"
+    >Parfum</button>
+    <button
+      type="button"
+      class="nusantarum-tab"
+      role="tab"
+      aria-selected="{{ 'true' if active_tab == 'brand' else 'false' }}"
+      hx-get="/nusantarum/tab/brand"
+      hx-target="#nusantarum-tab-content"
+    >Brand</button>
+    <button
+      type="button"
+      class="nusantarum-tab"
+      role="tab"
+      aria-selected="{{ 'true' if active_tab == 'perfumer' else 'false' }}"
+      hx-get="/nusantarum/tab/perfumer"
+      hx-target="#nusantarum-tab-content"
+    >Perfumer</button>
+  </nav>
 
+  <form
+    id="nusantarum-search-form"
+    class="nusantarum-search"
+    hx-get="/nusantarum/search"
+    hx-target="#nusantarum-search-results"
+    hx-trigger="keyup changed delay:400ms"
+    hx-indicator="#nusantarum-search-results"
+  >
+    <label class="sr-only" for="nusantarum-search-input">Cari parfum, brand, atau perfumer</label>
+    <input
+      id="nusantarum-search-input"
+      type="search"
+      name="q"
+      placeholder="Cari parfum, brand, atau perfumer"
+      autocomplete="off"
+    />
+  </form>
+
+  <div id="nusantarum-search-results">
+    {% with results={'perfumes': [], 'brands': [], 'perfumers': []}, error_message=None %}
+    {% include 'components/nusantarum/search-results.html' %}
+    {% endwith %}
+  </div>
+
+  <div class="nusantarum-body">
     <section id="nusantarum-tab-content" aria-live="polite" aria-busy="false">
       {% with page=perfume_page, error_message=error_message, active_tab=active_tab %}
       {% include 'components/nusantarum/perfume-list.html' %}


### PR DESCRIPTION
## Summary
- remove the Nusantarum filter panel include from the main page layout
- simplify the tab buttons by removing references to the deleted filter form

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da0eb2dba88327a8e7e6e7b8512726