### PR TITLE
Refine Nusantarum directory layout and data sources

### DIFF
--- a/src/app/services/nusantarum_service.py
+++ b/src/app/services/nusantarum_service.py
@@ -305,7 +305,7 @@ class NusantarumService:
         price_max: float | None = None,
         verified_only: bool = True,
     ) -> PagedResult:
-        filters: List[Tuple[str, Any]] = []
+        filters: List[Tuple[str, Any]] = [("marketplace_product_id", "not.is.null")]
         if verified_only:
             filters.append(("brand_is_verified", "eq.true"))
         if families:
@@ -359,7 +359,7 @@ class NusantarumService:
         page_size: int = 20,
         verified_only: bool = True,
     ) -> PagedResult:
-        filters: List[Tuple[str, Any]] = []
+        filters: List[Tuple[str, Any]] = [("is_linked_to_active_perfume", "eq.true")]
         if verified_only:
             filters.append(("is_verified", "eq.true"))
 
@@ -384,7 +384,10 @@ class NusantarumService:
         if not q:
             return {"perfumes": [], "brands": [], "perfumers": []}
 
-        filters = [("name", f"ilike.*{q}*")]
+        filters = [
+            ("name", f"ilike.*{q}*"),
+            ("marketplace_product_id", "not.is.null"),
+        ]
         perfume_results = await self._fetch_with_cache(
             "perfumes-search",
             filters,
@@ -395,7 +398,7 @@ class NusantarumService:
         )
         brand_results = await self._fetch_with_cache(
             "brands-search",
-            [("name", f"ilike.*{q}*")],
+            [("name", f"ilike.*{q}*"), ("is_verified", "eq.true")],
             1,
             limit,
             resource="nusantarum_brand_directory",
@@ -403,7 +406,11 @@ class NusantarumService:
         )
         perfumer_results = await self._fetch_with_cache(
             "perfumers-search",
-            [("display_name", f"ilike.*{q}*")],
+            [
+                ("display_name", f"ilike.*{q}*"),
+                ("is_verified", "eq.true"),
+                ("is_linked_to_active_perfume", "eq.true"),
+            ],
             1,
             limit,
             resource="nusantarum_perfumer_directory",

--- a/src/app/web/static/css/nusantarum.css
+++ b/src/app/web/static/css/nusantarum.css
@@ -1,35 +1,27 @@
 .nusantarum-page {
   display: grid;
-  gap: 2rem;
-}
-
-.nusantarum-header {
-  display: flex;
-  flex-direction: column;
   gap: 1.5rem;
-  padding: 2rem;
-  border-radius: 24px;
-  background: rgba(255, 255, 255, 0.12);
-  backdrop-filter: blur(18px);
-  border: 1px solid rgba(255, 255, 255, 0.25);
-  color: var(--text-primary);
 }
 
-.text-muted {
-  color: rgba(255, 255, 255, 0.7);
-  font-size: 0.95rem;
-}
-
-.nusantarum-header h1 {
-  font-size: clamp(1.8rem, 2vw + 1rem, 2.6rem);
-  font-weight: 600;
-}
-
-.nusantarum-search {
+.nusantarum-controls {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
   align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: var(--text-primary);
+}
+
+.nusantarum-search {
+  display: flex;
+  flex: 1 1 240px;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 220px;
 }
 
 .nusantarum-search-results {
@@ -54,8 +46,8 @@
 }
 
 .nusantarum-search input[type="search"] {
-  flex: 1;
-  min-width: 240px;
+  flex: 1 1 auto;
+  min-width: 0;
   padding: 0.75rem 1rem;
   border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.35);
@@ -67,21 +59,11 @@
   color: rgba(255, 255, 255, 0.6);
 }
 
-.nusantarum-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.35rem 0.85rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.18);
-  font-size: 0.85rem;
-  letter-spacing: 0.02em;
-}
-
 .nusantarum-tabs {
   display: flex;
   gap: 0.75rem;
   flex-wrap: wrap;
+  align-items: center;
 }
 
 .nusantarum-tab {
@@ -99,80 +81,6 @@
 .nusantarum-tab:focus-visible {
   background: rgba(255, 255, 255, 0.35);
   border-color: rgba(255, 255, 255, 0.5);
-}
-
-.nusantarum-body {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 1.5rem;
-}
-
-@media (min-width: 992px) {
-  .nusantarum-body {
-    grid-template-columns: 260px 1fr;
-  }
-}
-
-.nusantarum-filter-panel {
-  position: sticky;
-  top: 1.5rem;
-  display: grid;
-  gap: 1rem;
-  align-content: start;
-  padding: 1.5rem;
-  border-radius: 20px;
-  background: rgba(15, 23, 42, 0.55);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  color: var(--text-primary);
-}
-
-.filter-chip-group {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.filter-chip {
-  padding: 0.45rem 0.9rem;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.25);
-  background: transparent;
-  color: inherit;
-  cursor: pointer;
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-}
-
-.filter-chip input[type="checkbox"] {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  cursor: pointer;
-}
-
-.filter-chip span {
-  pointer-events: none;
-}
-
-.filter-chip input[type="checkbox"]:checked + span {
-  background: rgba(255, 255, 255, 0.35);
-  border-radius: 999px;
-  padding: 0.45rem 0.9rem;
-}
-
-.toggle {
-  display: inline-flex;
-  gap: 0.75rem;
-  align-items: center;
-}
-
-.toggle input[type="checkbox"] {
-  width: 1.15rem;
-  height: 1.15rem;
-  accent-color: #f59e0b;
 }
 
 .nusantarum-list {

--- a/src/app/web/templates/components/nusantarum/brand-list.html
+++ b/src/app/web/templates/components/nusantarum/brand-list.html
@@ -21,7 +21,6 @@
     type="button"
     hx-get="/nusantarum/tab/{{ active_tab }}"
     hx-target="#nusantarum-tab-content"
-    hx-include="#nusantarum-filter-form"
     hx-vals='{"page": {{ page.page - 1 }}, "page_size": {{ page.page_size }}}'
     {% if page.page <= 1 %}disabled{% endif %}
   >Sebelumnya</button>
@@ -30,7 +29,6 @@
     type="button"
     hx-get="/nusantarum/tab/{{ active_tab }}"
     hx-target="#nusantarum-tab-content"
-    hx-include="#nusantarum-filter-form"
     hx-vals='{"page": {{ page.page + 1 }}, "page_size": {{ page.page_size }}}'
     {% if page.page >= page.pages %}disabled{% endif %}
   >Berikutnya</button>

--- a/src/app/web/templates/components/nusantarum/perfume-list.html
+++ b/src/app/web/templates/components/nusantarum/perfume-list.html
@@ -21,7 +21,6 @@
     type="button"
     hx-get="/nusantarum/tab/{{ active_tab }}"
     hx-target="#nusantarum-tab-content"
-    hx-include="#nusantarum-filter-form"
     hx-vals='{"page": {{ page.page - 1 }}, "page_size": {{ page.page_size }}}'
     {% if page.page <= 1 %}disabled{% endif %}
   >Sebelumnya</button>
@@ -30,7 +29,6 @@
     type="button"
     hx-get="/nusantarum/tab/{{ active_tab }}"
     hx-target="#nusantarum-tab-content"
-    hx-include="#nusantarum-filter-form"
     hx-vals='{"page": {{ page.page + 1 }}, "page_size": {{ page.page_size }}}'
     {% if page.page >= page.pages %}disabled{% endif %}
   >Berikutnya</button>

--- a/src/app/web/templates/components/nusantarum/perfumer-list.html
+++ b/src/app/web/templates/components/nusantarum/perfumer-list.html
@@ -21,7 +21,6 @@
     type="button"
     hx-get="/nusantarum/tab/{{ active_tab }}"
     hx-target="#nusantarum-tab-content"
-    hx-include="#nusantarum-filter-form"
     hx-vals='{"page": {{ page.page - 1 }}, "page_size": {{ page.page_size }}}'
     {% if page.page <= 1 %}disabled{% endif %}
   >Sebelumnya</button>
@@ -30,7 +29,6 @@
     type="button"
     hx-get="/nusantarum/tab/{{ active_tab }}"
     hx-target="#nusantarum-tab-content"
-    hx-include="#nusantarum-filter-form"
     hx-vals='{"page": {{ page.page + 1 }}, "page_size": {{ page.page_size }}}'
     {% if page.page >= page.pages %}disabled{% endif %}
   >Berikutnya</button>

--- a/src/app/web/templates/components/nusantarum/search-results.html
+++ b/src/app/web/templates/components/nusantarum/search-results.html
@@ -3,7 +3,7 @@
   <p>{{ error_message }}</p>
   {% elif results.perfumes or results.brands or results.perfumers %}
   <div>
-    <strong>Parfum</strong>
+    <strong>Perfume</strong>
     <ul>
       {% for item in results.perfumes %}
       <li>{{ item }}</li>
@@ -35,7 +35,5 @@
       {% endif %}
     </ul>
   </div>
-  {% else %}
-  <p>Masukkan kata kunci untuk menelusuri katalog.</p>
   {% endif %}
 </div>

--- a/src/app/web/templates/pages/nusantarum/index.html
+++ b/src/app/web/templates/pages/nusantarum/index.html
@@ -6,14 +6,33 @@
 
 {% block content %}
 <section class="nusantarum-page">
-  <header class="nusantarum-header">
-    <div>
-      <span class="nusantarum-badge">Direktori Nusantara</span>
-      <h1>Pusat Kurasi Parfum Lokal Indonesia</h1>
-      <p>
-        Jelajahi parfum dari brand terverifikasi, temukan profil perfumer komunitas, dan pantau ketersediaan produk di marketplace Sensasiwangi.
-      </p>
-    </div>
+  <div class="nusantarum-controls">
+    <nav class="nusantarum-tabs" role="tablist">
+      <button
+        type="button"
+        class="nusantarum-tab"
+        role="tab"
+        aria-selected="{{ 'true' if active_tab == 'parfum' else 'false' }}"
+        hx-get="/nusantarum/tab/parfum"
+        hx-target="#nusantarum-tab-content"
+      >Perfume</button>
+      <button
+        type="button"
+        class="nusantarum-tab"
+        role="tab"
+        aria-selected="{{ 'true' if active_tab == 'brand' else 'false' }}"
+        hx-get="/nusantarum/tab/brand"
+        hx-target="#nusantarum-tab-content"
+      >Brand</button>
+      <button
+        type="button"
+        class="nusantarum-tab"
+        role="tab"
+        aria-selected="{{ 'true' if active_tab == 'perfumer' else 'false' }}"
+        hx-get="/nusantarum/tab/perfumer"
+        hx-target="#nusantarum-tab-content"
+      >Perfumer</button>
+    </nav>
 
     <form
       id="nusantarum-search-form"
@@ -32,56 +51,18 @@
         autocomplete="off"
       />
     </form>
-    <div id="nusantarum-search-results">
-      {% with results={'perfumes': [], 'brands': [], 'perfumers': []}, error_message=None %}
-      {% include 'components/nusantarum/search-results.html' %}
-      {% endwith %}
-    </div>
-
-    <nav class="nusantarum-tabs" role="tablist">
-      <button
-        type="button"
-        class="nusantarum-tab"
-        role="tab"
-        aria-selected="{{ 'true' if active_tab == 'parfum' else 'false' }}"
-        hx-get="/nusantarum/tab/parfum"
-        hx-target="#nusantarum-tab-content"
-        hx-include="#nusantarum-filter-form"
-        hx-on::after-request="document.getElementById('nusantarum-filter-form')?.setAttribute('hx-get', '/nusantarum/tab/parfum')"
-      >Parfum</button>
-      <button
-        type="button"
-        class="nusantarum-tab"
-        role="tab"
-        aria-selected="{{ 'true' if active_tab == 'brand' else 'false' }}"
-        hx-get="/nusantarum/tab/brand"
-        hx-target="#nusantarum-tab-content"
-        hx-include="#nusantarum-filter-form"
-        hx-on::after-request="document.getElementById('nusantarum-filter-form')?.setAttribute('hx-get', '/nusantarum/tab/brand')"
-      >Brand</button>
-      <button
-        type="button"
-        class="nusantarum-tab"
-        role="tab"
-        aria-selected="{{ 'true' if active_tab == 'perfumer' else 'false' }}"
-        hx-get="/nusantarum/tab/perfumer"
-        hx-target="#nusantarum-tab-content"
-        hx-include="#nusantarum-filter-form"
-        hx-on::after-request="document.getElementById('nusantarum-filter-form')?.setAttribute('hx-get', '/nusantarum/tab/perfumer')"
-      >Perfumer</button>
-    </nav>
-  </header>
-
-  <div class="nusantarum-body">
-    {% with filters=filters, sync_status=sync_status, active_tab=active_tab %}
-    {% include 'components/nusantarum/filter-panel.html' %}
-    {% endwith %}
-
-    <section id="nusantarum-tab-content" aria-live="polite" aria-busy="false">
-      {% with page=perfume_page, error_message=error_message, active_tab=active_tab %}
-      {% include 'components/nusantarum/perfume-list.html' %}
-      {% endwith %}
-    </section>
   </div>
+
+  <div id="nusantarum-search-results">
+    {% with results={'perfumes': [], 'brands': [], 'perfumers': []}, error_message=None %}
+    {% include 'components/nusantarum/search-results.html' %}
+    {% endwith %}
+  </div>
+
+  <section id="nusantarum-tab-content" aria-live="polite" aria-busy="false">
+    {% with page=perfume_page, error_message=error_message, active_tab=active_tab %}
+    {% include 'components/nusantarum/perfume-list.html' %}
+    {% endwith %}
+  </section>
 </section>
 {% endblock %}

--- a/tests/test_nusantarum_api.py
+++ b/tests/test_nusantarum_api.py
@@ -81,7 +81,7 @@ class FakeNusantarumService:
 
     async def search(self, query: str, limit: int = 5) -> Dict[str, List[str]]:
         return {
-            "perfumes": [f"{query.title()} Parfum"],
+            "perfumes": [f"{query.title()} Perfume"],
             "brands": [f"{query.title()} Brand"],
             "perfumers": [f"{query.title()} Perfumer"],
         }
@@ -159,7 +159,8 @@ def test_index_page_renders_with_perfume_list(fake_service: FakeNusantarumServic
     assert headers["content-type"].startswith("text/html")
     text = body.decode()
     assert "Hutan Senja" in text
-    assert "Pusat Kurasi Parfum Lokal Indonesia" in text
+    assert ">Perfume</button>" in text
+    assert "id=\"nusantarum-search-input\"" in text
 
 
 def test_tab_endpoint_returns_partial(fake_service: FakeNusantarumService) -> None:
@@ -175,7 +176,7 @@ def test_search_endpoint_returns_html(fake_service: FakeNusantarumService) -> No
     )
     assert status == 200
     assert headers["content-type"].startswith("text/html")
-    assert "Senja Parfum" in body.decode()
+    assert "Senja Perfume" in body.decode()
 
 
 def test_trigger_sync_records_source(fake_service: FakeNusantarumService) -> None:


### PR DESCRIPTION
## Summary
- remove the hero banner, merge the Nusantarum tab controls with the search bar, and update copy to match the requested labels
- refresh the directory styling and HTMX pagination to reflect the simplified layout
- ensure perfume, brand, and perfumer listings and search results only surface marketplace products from verified brands and linked perfumers
- drop the "Masukkan kata kunci..." empty state prompt so the results panel stays blank until there are results

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da0eb2dba88327a8e7e6e7b8512726