### PR TITLE
Adjust Nusantarum page layout to emphasize tabs and search

### DIFF
--- a/src/app/web/static/css/nusantarum.css
+++ b/src/app/web/static/css/nusantarum.css
@@ -3,6 +3,11 @@
   gap: 2rem;
 }
 
+.nusantarum-controls {
+  display: grid;
+  gap: 1rem;
+}
+
 .nusantarum-header {
   display: flex;
   flex-direction: column;

--- a/src/app/web/templates/pages/nusantarum/index.html
+++ b/src/app/web/templates/pages/nusantarum/index.html
@@ -6,16 +6,6 @@
 
 {% block content %}
 <section class="nusantarum-page">
-  <header class="nusantarum-header">
-    <div>
-      <span class="nusantarum-badge">Direktori Nusantara</span>
-      <h1>Pusat Kurasi Parfum Lokal Indonesia</h1>
-      <p>
-        Jelajahi parfum dari brand terverifikasi, temukan profil perfumer komunitas, dan pantau ketersediaan produk di marketplace Sensasiwangi.
-      </p>
-    </div>
-  </header>
-
   <nav class="nusantarum-tabs" role="tablist">
     <button
       type="button"
@@ -43,28 +33,30 @@
     >Perfumer</button>
   </nav>
 
-  <form
-    id="nusantarum-search-form"
-    class="nusantarum-search"
-    hx-get="/nusantarum/search"
-    hx-target="#nusantarum-search-results"
-    hx-trigger="keyup changed delay:400ms"
-    hx-indicator="#nusantarum-search-results"
-  >
-    <label class="sr-only" for="nusantarum-search-input">Cari parfum, brand, atau perfumer</label>
-    <input
-      id="nusantarum-search-input"
-      type="search"
-      name="q"
-      placeholder="Cari parfum, brand, atau perfumer"
-      autocomplete="off"
-    />
-  </form>
+  <div class="nusantarum-controls">
+    <form
+      id="nusantarum-search-form"
+      class="nusantarum-search"
+      hx-get="/nusantarum/search"
+      hx-target="#nusantarum-search-results"
+      hx-trigger="keyup changed delay:400ms"
+      hx-indicator="#nusantarum-search-results"
+    >
+      <label class="sr-only" for="nusantarum-search-input">Cari parfum, brand, atau perfumer</label>
+      <input
+        id="nusantarum-search-input"
+        type="search"
+        name="q"
+        placeholder="Cari parfum, brand, atau perfumer"
+        autocomplete="off"
+      />
+    </form>
 
-  <div id="nusantarum-search-results">
-    {% with results={'perfumes': [], 'brands': [], 'perfumers': []}, error_message=None %}
-    {% include 'components/nusantarum/search-results.html' %}
-    {% endwith %}
+    <div id="nusantarum-search-results">
+      {% with results={'perfumes': [], 'brands': [], 'perfumers': []}, error_message=None %}
+      {% include 'components/nusantarum/search-results.html' %}
+      {% endwith %}
+    </div>
   </div>
 
   <div class="nusantarum-body">

--- a/tests/test_nusantarum_api.py
+++ b/tests/test_nusantarum_api.py
@@ -159,7 +159,9 @@ def test_index_page_renders_with_perfume_list(fake_service: FakeNusantarumServic
     assert headers["content-type"].startswith("text/html")
     text = body.decode()
     assert "Hutan Senja" in text
-    assert "Pusat Kurasi Parfum Lokal Indonesia" in text
+    assert 'class="nusantarum-tabs"' in text
+    assert 'id="nusantarum-search-form"' in text
+    assert text.index('class="nusantarum-tabs"') < text.index('id="nusantarum-search-form"')
 
 
 def test_tab_endpoint_returns_partial(fake_service: FakeNusantarumService) -> None:


### PR DESCRIPTION
## Summary
- remove the introductory hero from the Nusantarum page so the tab navigation appears immediately after the navbar
- group the search form and results below the tabs and add supporting layout styles
- update the Nusantarum API test to reflect the new layout structure

## Testing
- pytest tests/test_nusantarum_api.py

------
https://chatgpt.com/codex/tasks/task_e_68db1826f6808327b48cec7e0f13d864