### PR TITLE
Configure Vercel build and validate session secret length

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to .env and fill in the values for local development.
+# The service automatically reads these variables using pydantic-settings.
+
+# --- Supabase configuration ---
+SUPABASE_URL=
+SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# --- RajaOngkir (optional) ---
+RAJAONGKIR_API_KEY=
+
+# --- Session secret (override for production, minimal 32 karakter) ---
+SESSION_SECRET=

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ files, dan registrasi router untuk halaman landing awal.
 3. Akses `http://localhost:8000` untuk melihat landing page awal bertema
 glassmorphism.
 
+4. Salin `.env.example` menjadi `.env` dan isi kredensial Supabase yang sudah
+   disediakan agar integrasi Nusantarum dapat berjalan:
+
+   ```bash
+   cp .env.example .env
+   # kemudian isi SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY
+   ```
+
+   Detail langkah sinkronisasi database dan deployment tersedia di
+   [`docs/vercel-supabase-deployment.md`](docs/vercel-supabase-deployment.md).
+
 ## Pengujian
 
 Gunakan `pytest` untuk menjalankan test dasar yang memverifikasi homepage SSR:

--- a/docs/vercel-supabase-deployment.md
+++ b/docs/vercel-supabase-deployment.md
@@ -1,0 +1,82 @@
+# Vercel Deployment Guide (FastAPI + Supabase)
+
+Panduan ini menjelaskan cara men-deploy backend FastAPI Sensasiwangi.id ke Vercel
+serta menghubungkannya dengan proyek Supabase yang telah disediakan. Langkah-langkah
+ini melanjutkan ringkasan integrasi yang pernah dibagikan sebelumnya.
+
+## 1. Menjalankan Migrasi Supabase
+
+1. Instal Supabase CLI minimal v1.153 di mesin lokal:
+   ```bash
+   npm install -g supabase
+   # atau ikuti https://supabase.com/docs/guides/cli
+   ```
+2. Login ke Supabase CLI dan hubungkan ke project ID yang relevan:
+   ```bash
+   supabase login
+   supabase link --project-ref yguckgrnvzvbxtygbzke
+   ```
+3. Dorong seluruh skema yang tersedia di folder `supabase/migrations`:
+   ```bash
+   supabase db push
+   ```
+   Perintah ini akan membuat tabel marketplace, Nusantarum, onboarding, dan
+   relasi yang sudah diatur pada migrasi SQL.
+
+> **Catatan**: Bila prefer menggunakan `psql`, jalankan masing-masing file SQL
+> secara berurutan terhadap database Supabase produksi/staging Anda.
+
+## 2. Menyiapkan Variabel Lingkungan
+
+1. Gandakan `.env.example` menjadi `.env` untuk pengembangan lokal:
+   ```bash
+   cp .env.example .env
+   ```
+2. Isi variabel yang diberikan:
+   ```bash
+   SUPABASE_URL=https://yguckgrnvzvbxtygbzke.supabase.co
+   SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlndWNrZ3Judnp2Ynh0eWdiemtlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTg5Mzg0NTIsImV4cCI6MjA3NDUxNDQ1Mn0.psMSy6vys-6rEKzJbUmX87j9zmB6dE94zc1_nVakuLU
+   SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlndWNrZ3Judnp2Ynh0eWdiemtlIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1ODkzODQ1MiwiZXhwIjoyMDc0NTE0NDUyfQ.QYhkQk59D3Y_GBEhNz8amto-RP_WHL-2_tQtGnE8Ia0
+   SESSION_SECRET=ganti-dengan-string-acak
+   ```
+   Pastikan `SESSION_SECRET` berisi string acak minimal 32 karakter pada
+   lingkungan produksi.
+3. Untuk pengembangan lokal, jalankan Uvicorn seperti biasa dan backend akan
+   otomatis membaca variabel tersebut melalui `pydantic-settings`.
+
+## 3. Konfigurasi Deployment Vercel
+
+1. Import repositori GitHub ke Vercel dan pilih framework **Other**.
+2. Pada tab **Environment Variables**, tambahkan tiga key Supabase di atas.
+   - `SUPABASE_URL`
+   - `SUPABASE_ANON_KEY`
+   - `SUPABASE_SERVICE_ROLE_KEY` (gunakan **Encrypted**/Production scope saja)
+3. Tambahkan variabel `SESSION_SECRET` terpisah untuk keamanan.
+4. Di tab **Build & Development Settings**, set:
+   - **Build Command**: `pip install -r requirements.txt`
+   - **Output Directory**: kosongkan (karena FastAPI dijalankan sebagai serverless)
+   - **Install Command**: biarkan default
+5. Pastikan Vercel mendeteksi file `main.py` yang mengekspos objek `app`. Bila
+   perlu, buat file `vercel.json` dengan isi berikut di root repo:
+   ```json
+   {
+     "builds": [
+       { "src": "main.py", "use": "@vercel/python" }
+     ],
+     "routes": [
+       { "src": "/(.*)", "dest": "main.py" }
+     ]
+   }
+   ```
+6. Deploy project. Vercel akan menjalankan FastAPI menggunakan adapter Python
+   bawaan, sementara `NusantarumService` akan memanggil PostgREST Supabase dengan
+   kredensial yang sudah dikonfigurasi.
+
+## 4. Verifikasi Integrasi
+
+- Gunakan endpoint Nusantarum (`/nusantarum` pada router web) untuk memastikan
+  data berhasil diambil dari Supabase.
+- Periksa log Vercel jika terjadi error 500; pesan `Supabase credentials belum
+  dikonfigurasi` menandakan variabel lingkungan belum terset dengan benar.
+
+Selamat! Dengan langkah di atas, pipeline Codex × Vercel × Supabase sudah siap.

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -1,6 +1,8 @@
 """Application configuration module."""
 
 from functools import lru_cache
+
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -24,7 +26,16 @@ class Settings(BaseSettings):
     rajaongkir_api_key: str | None = None
 
     # Session management
-    session_secret: str = "insecure-dev-secret"
+    session_secret: str = "development-session-secret-placeholder"
+
+    @field_validator("session_secret")
+    @classmethod
+    def _validate_session_secret(cls, value: str) -> str:
+        if len(value) < 32:
+            raise ValueError(
+                "SESSION_SECRET harus terdiri dari minimal 32 karakter untuk keamanan."
+            )
+        return value
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,16 @@
+"""Tests for application settings helpers."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.core.config import Settings
+
+
+def test_session_secret_requires_minimum_length() -> None:
+    with pytest.raises(ValidationError):
+        Settings(session_secret="short-secret")
+
+
+def test_default_session_secret_is_valid() -> None:
+    settings = Settings()
+    assert len(settings.session_secret) >= 32

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "builds": [
+    { "src": "main.py", "use": "@vercel/python" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "main.py" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Vercel configuration so deployments route all traffic to the FastAPI `main.py` entrypoint
- enforce a 32-character minimum for `SESSION_SECRET` and document the requirement in the example env file
- cover the new validation logic with regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db1c4967ec8327bfcc036bb04807f0