### PR TITLE
Streamline auth login experience

### DIFF
--- a/src/app/web/static/css/auth.css
+++ b/src/app/web/static/css/auth.css
@@ -1,96 +1,58 @@
-.auth-hero {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: 2.5rem;
-  padding: 3rem;
-}
-
-.auth-hero .badge {
-  margin-bottom: 1rem;
-}
-
-.auth-perks {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 1.25rem;
-}
-
-.auth-perks li {
-  padding: 1.5rem;
-}
-
-.auth-grid {
-  padding: 2.5rem;
+.auth-page {
+  min-height: calc(100vh - 6rem);
   display: flex;
-  flex-direction: column;
-  gap: 2rem;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(2rem, 5vw, 4rem);
+  position: relative;
+  overflow: hidden;
 }
 
-.auth-columns {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 2rem;
-  align-items: start;
+.auth-page::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 10% 20%, rgba(59, 130, 246, 0.14), transparent 55%),
+    radial-gradient(circle at 85% 80%, rgba(16, 185, 129, 0.15), transparent 60%),
+    linear-gradient(135deg, rgba(15, 23, 42, 0.6), rgba(30, 64, 175, 0.4));
+  opacity: 0.75;
+  pointer-events: none;
 }
 
-.auth-form {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-  background: rgba(15, 23, 42, 0.45);
+.auth-login-section {
+  position: relative;
+  width: min(460px, 100%);
+  z-index: 1;
+}
+
+.auth-login-section::before {
+  content: "";
+  position: absolute;
+  inset: -30px;
+  border-radius: var(--radius-xl);
+  background: linear-gradient(160deg, rgba(59, 130, 246, 0.2), transparent 70%);
+  filter: blur(45px);
+  z-index: -1;
+}
+
+.login-backdrop {
+  position: relative;
+  padding: clamp(2rem, 4vw, 2.75rem);
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(148, 163, 184, 0.25);
-  border-radius: var(--radius-md);
-  padding: 1.75rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
-}
-
-.auth-form fieldset {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  border: none;
-  margin: 0;
-  padding: 0;
-}
-
-.auth-form label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  font-weight: 500;
-  color: var(--text-primary);
-}
-
-.auth-form input {
-  border-radius: var(--radius-sm);
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(15, 23, 42, 0.65);
-  color: var(--text-primary);
-  padding: 0.75rem 1rem;
-  font-size: 0.95rem;
-  transition: border-color var(--transition-base), box-shadow var(--transition-base);
-}
-
-.auth-form input:focus {
-  outline: none;
-  border-color: rgba(56, 189, 248, 0.85);
-  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
-}
-
-.form-note {
-  font-size: 0.85rem;
-  color: var(--muted);
-  line-height: 1.4;
+  backdrop-filter: blur(14px);
+  background: rgba(15, 23, 42, 0.55);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.45);
 }
 
 .auth-feedback {
   border-radius: var(--radius-md);
   padding: 1rem 1.2rem;
+  margin-bottom: 1.25rem;
   display: none;
   background: rgba(56, 189, 248, 0.08);
   border: 1px solid rgba(56, 189, 248, 0.25);
+  color: var(--text-primary);
 }
 
 .auth-feedback.visible {
@@ -100,7 +62,6 @@
 .auth-feedback[data-tone='success'] {
   background: rgba(52, 211, 153, 0.12);
   border-color: rgba(52, 211, 153, 0.4);
-  color: var(--text-primary);
 }
 
 .auth-feedback[data-tone='danger'] {
@@ -109,89 +70,100 @@
   color: #fecaca;
 }
 
-.auth-session {
-  background: rgba(15, 23, 42, 0.32);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  border-radius: var(--radius-md);
-  padding: 1.75rem;
+.auth-form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.15rem;
 }
 
-.auth-session dl {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.5rem 1.25rem;
-  margin: 0;
-}
-
-.auth-session dt {
-  color: var(--muted);
+.auth-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
   font-weight: 500;
-}
-
-.auth-session dd {
-  margin: 0;
   color: var(--text-primary);
 }
 
-.session-hints {
-  background: rgba(15, 23, 42, 0.4);
-  border: 1px dashed rgba(148, 163, 184, 0.35);
+.auth-form input {
   border-radius: var(--radius-sm);
-  padding: 1rem 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.7);
+  color: var(--text-primary);
+  padding: 0.85rem 1rem;
+  font-size: 0.95rem;
+  transition: border-color var(--transition-base), box-shadow var(--transition-base), background var(--transition-base);
 }
 
-.session-hints h4 {
-  margin-top: 0;
-  margin-bottom: 0.75rem;
-  font-size: 1.05rem;
+.auth-form input:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.85);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.22);
+  background: rgba(15, 23, 42, 0.85);
 }
 
-.session-hints ul {
-  margin: 0;
-  padding-left: 1.2rem;
-  color: var(--text-secondary);
+.login-header {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
 }
 
-.muted {
+.login-header h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 3vw, 2.2rem);
+}
+
+.login-header p {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.login-aux {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.forgot-link {
+  font-size: 0.85rem;
+  color: rgba(191, 219, 254, 0.9);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color var(--transition-base), color var(--transition-base);
+}
+
+.forgot-link:hover {
+  color: rgba(224, 242, 254, 1);
+  border-color: rgba(191, 219, 254, 0.5);
+}
+
+.login-form .btn {
+  width: 100%;
+}
+
+.login-divider {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  text-align: center;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.register-button {
+  text-align: center;
+}
+
+.form-note {
+  font-size: 0.85rem;
   color: var(--muted);
-}
-
-.anchor-target {
-  position: relative;
-  top: -120px;
-}
-
-@media (max-width: 960px) {
-  .auth-hero {
-    grid-template-columns: 1fr;
-  }
-
-  .auth-perks {
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  }
-
-  .auth-grid {
-    padding: 2rem;
-  }
+  line-height: 1.4;
+  margin: 0;
 }
 
 @media (max-width: 640px) {
-  .auth-grid {
-    padding: 1.5rem;
+  .auth-page {
+    padding: 1.75rem 1.25rem 2.5rem;
   }
 
-  .auth-form,
-  .auth-session {
-    padding: 1.25rem;
-  }
-
-  .anchor-target {
-    top: -80px;
+  .login-backdrop {
+    padding: 1.75rem;
   }
 }

--- a/src/app/web/templates/auth.html
+++ b/src/app/web/templates/auth.html
@@ -5,115 +5,32 @@
 {% endblock %}
 
 {% block content %}
-<section class="auth-hero glass-surface">
-  <div>
-    <span class="badge">Akses Komunitas</span>
-    <h1>Masuk dan daftar ke Sensasiwangi.id</h1>
-    <p>
-      Lacak alur registrasi, login, dan logout dalam satu layar. Gunakan halaman ini untuk
-      validasi UX sebelum integrasi dengan Supabase atau penyedia auth lainnya.
-    </p>
-  </div>
-  <ul class="auth-perks">
-    {% for perk in perks %}
-    <li class="glass-card">
-      <h3>{{ perk.title }}</h3>
-      <p>{{ perk.description }}</p>
-    </li>
-    {% endfor %}
-  </ul>
-</section>
-
-<section class="auth-grid glass-surface" id="register">
-  <header class="section-header">
-    <div>
-      <h2>Workflow Autentikasi</h2>
-      <p>
-        Mulai dari pendaftaran, login, hingga logout dengan penyimpanan sesi dasar. Status sesi
-        terkini akan ditampilkan di panel samping.
-      </p>
-    </div>
-    <div class="status-chip" data-auth-status>
-      {% if session_user %}Sudah masuk sebagai {{ session_user.full_name }}{% else %}Belum masuk{% endif %}
-    </div>
-  </header>
-
-  <div class="auth-feedback" data-auth-feedback role="status" aria-live="polite"></div>
-
-  <div class="auth-columns">
-    <form id="auth-register-form" class="auth-form">
-      <fieldset>
-        <legend>1. Registrasi Akun Baru</legend>
+<section class="auth-page">
+  <div class="auth-login-section" id="login">
+    <div class="login-backdrop glass-surface">
+      <div class="auth-feedback" data-auth-feedback role="status" aria-live="polite"></div>
+      <form id="auth-login-form" class="auth-form login-form" aria-labelledby="login-title">
+        <header class="login-header">
+          <h2 id="login-title">Masuk</h2>
+          <p>Gunakan email dan password yang sama dengan akun Sensasiwangi.id Anda.</p>
+        </header>
         <label>
-          Nama Lengkap
-          <input type="text" name="full_name" minlength="3" maxlength="120" placeholder="Mis. Intan Dewi" required />
-        </label>
-        <label>
-          Email
-          <input type="email" name="email" placeholder="anda@contoh.com" required />
-        </label>
-        <label>
-          Password
-          <input
-            type="password"
-            name="password"
-            minlength="8"
-            maxlength="128"
-            placeholder="Minimal 8 karakter dengan huruf & angka"
-            required
-          />
-        </label>
-      </fieldset>
-      <button type="submit" class="btn gradient-button">Daftar Sekarang</button>
-      <p class="form-note">Password disimpan menggunakan hashing SHA-256 untuk demonstrasi.</p>
-    </form>
-
-    <div id="login" class="anchor-target" aria-hidden="true"></div>
-    <form id="auth-login-form" class="auth-form" aria-labelledby="login-title">
-      <fieldset>
-        <legend id="login-title">2. Login</legend>
-        <label>
-          Email
+          Email atau username
           <input type="email" name="email" placeholder="anda@contoh.com" required />
         </label>
         <label>
           Password
           <input type="password" name="password" minlength="8" maxlength="128" placeholder="Password" required />
         </label>
-      </fieldset>
-      <button type="submit" class="btn btn-outline">Masuk</button>
-      <p class="form-note">Sesi login disimpan pada cookie terenkripsi selama 14 hari.</p>
-    </form>
-
-    <aside class="auth-session" id="login-status">
-      <h3>Status Sesi</h3>
-      {% if session_user %}
-      <dl>
-        <div>
-          <dt>Nama</dt>
-          <dd>{{ session_user.full_name }}</dd>
+        <div class="login-aux">
+          <a href="#" class="forgot-link">Lupa password?</a>
         </div>
-        <div>
-          <dt>Email</dt>
-          <dd>{{ session_user.email }}</dd>
-        </div>
-      </dl>
-      <button class="btn btn-ghost" type="button" data-action="logout" data-redirect="{{ url_for('read_auth') }}">
-        Keluar dari sesi
-      </button>
-      {% else %}
-      <p class="muted">Belum ada sesi aktif. Coba daftar atau login menggunakan formulir di samping.</p>
-      {% endif %}
-
-      <div class="session-hints">
-        <h4>Catatan QA</h4>
-        <ul>
-          <li>Registrasi dengan email yang sama akan menghasilkan error 409.</li>
-          <li>Password harus berisi kombinasi huruf dan angka.</li>
-          <li>Logout akan menghapus data sesi dari cookie dan memperbarui navbar.</li>
-        </ul>
-      </div>
-    </aside>
+        <button type="submit" class="btn btn-outline">Masuk</button>
+        <div class="login-divider" role="separator" aria-hidden="true">atau</div>
+        <a class="btn gradient-button register-button" href="{{ url_for('read_onboarding') }}">Daftar Akun Baru</a>
+        <p class="form-note">Sesi login disimpan pada cookie terenkripsi selama 14 hari.</p>
+      </form>
+    </div>
   </div>
 </section>
 {% endblock %}
@@ -122,8 +39,6 @@
 <script>
   (() => {
     const feedbackEl = document.querySelector('[data-auth-feedback]');
-    const statusEl = document.querySelector('[data-auth-status]');
-    const registerForm = document.getElementById('auth-register-form');
     const loginForm = document.getElementById('auth-login-form');
 
     const setFeedback = (message, tone = 'info') => {
@@ -133,40 +48,10 @@
       feedbackEl.classList.toggle('visible', Boolean(message));
     };
 
-    const setStatus = (message) => {
-      if (statusEl) {
-        statusEl.textContent = message;
-      }
-    };
-
     const handleResponseError = async (response) => {
       const payload = await response.json().catch(() => ({}));
       setFeedback(payload.detail || 'Permintaan gagal diproses', 'danger');
     };
-
-    if (registerForm) {
-      registerForm.addEventListener('submit', async (event) => {
-        event.preventDefault();
-        const formData = new FormData(registerForm);
-        const payload = Object.fromEntries(formData.entries());
-
-        setFeedback('Memproses registrasi...');
-        const response = await fetch('/api/auth/register', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload),
-        });
-
-        if (!response.ok) {
-          await handleResponseError(response);
-          return;
-        }
-
-        const data = await response.json();
-        setFeedback(`Registrasi berhasil untuk ${data.full_name}. Silakan login.`, 'success');
-        registerForm.reset();
-      });
-    }
 
     if (loginForm) {
       loginForm.addEventListener('submit', async (event) => {
@@ -188,7 +73,6 @@
 
         const data = await response.json();
         setFeedback(`Login berhasil. Selamat datang, ${data.full_name}!`, 'success');
-        setStatus(`Sudah masuk sebagai ${data.full_name}`);
         window.setTimeout(() => {
           window.location.href = '{{ url_for('read_auth') }}';
         }, 600);

--- a/src/app/web/templates/partials/navbar.html
+++ b/src/app/web/templates/partials/navbar.html
@@ -49,7 +49,7 @@
         </li>
         {% else %}
         <li><a href="{{ url_for('read_auth') }}#login">Masuk</a></li>
-        <li><a href="{{ url_for('read_auth') }}#register">Daftar</a></li>
+        <li><a href="{{ url_for('read_onboarding') }}">Daftar</a></li>
         {% endif %}
       </ul>
     </details>


### PR DESCRIPTION
## Summary
- replace the auth page layout with a single login card and register call-to-action
- remove the register panel and social login styles for a simpler presentation
- update the navbar registration link to direct users to the onboarding flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db1c00b5d48327af0ba629f3827f1f