### PR TITLE
Redesign footer layout for a more compact presentation

### DIFF
--- a/src/app/web/static/css/base.css
+++ b/src/app/web/static/css/base.css
@@ -1278,52 +1278,104 @@ p {
 }
 
 .footer {
-  padding: 2.5rem;
-  display: grid;
+  padding: 1.8rem 2.2rem;
+  display: flex;
+  flex-direction: column;
   gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  align-items: start;
 }
 
 .footer .logo {
   font-family: "Playfair Display", "Times New Roman", serif;
-  font-size: 1.3rem;
+  font-size: 1.25rem;
 }
 
-.footer-links {
+.footer-top {
+  display: flex;
+  gap: 2.25rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.footer-brand {
+  max-width: 260px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.footer-brand p {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.footer-nav {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 1.25rem;
+  gap: 1.25rem 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  flex: 1 1 320px;
 }
 
-.footer-links h4 {
+.footer-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.footer-group h4 {
   font-size: 0.95rem;
-  margin-bottom: 0.6rem;
+  margin: 0;
 }
 
-.footer-links ul {
+.footer-group ul {
   list-style: none;
   padding: 0;
   margin: 0;
   display: grid;
-  gap: 0.45rem;
+  gap: 0.35rem;
 }
 
-.footer-links a {
+.footer-group a {
   color: var(--text-secondary);
   text-decoration: none;
 }
 
-.footer-links a:hover {
+.footer-group a:hover {
+  color: var(--accent-secondary);
+}
+
+.footer-bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.footer-social {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 1.1rem;
+}
+
+.footer-social a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.footer-social a:hover {
   color: var(--accent-secondary);
 }
 
 .footer-note {
-  grid-column: 1 / -1;
-  text-align: center;
   color: var(--muted);
   font-size: 0.85rem;
-  margin-top: 0.5rem;
 }
 
 .sr-only {
@@ -1454,7 +1506,23 @@ p {
   }
 
   .footer {
-    padding: 2rem;
+    padding: 1.6rem;
+    gap: 1.25rem;
+  }
+
+  .footer-top {
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .footer-bottom {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.65rem;
+  }
+
+  .footer-social {
+    gap: 0.85rem;
   }
 }
 

--- a/src/app/web/templates/partials/footer.html
+++ b/src/app/web/templates/partials/footer.html
@@ -1,43 +1,44 @@
 <footer class="footer glass-surface">
-  <div class="footer-brand">
-    <span class="logo">{{ app_name }}</span>
-    <p>Menghidupkan aroma Nusantara melalui kolaborasi komunitas parfum.</p>
-  </div>
-  <div class="footer-links">
-    <div>
-      <h4>Navigasi</h4>
-      <ul>
-        <li><a href="{{ url_for('read_home') }}">Beranda</a></li>
-        <li><a href="{{ url_for('read_marketplace') }}">Marketplace</a></li>
-        <li><a href="{{ url_for('list_brands') }}">Brand Partner</a></li>
-        <li><a href="{{ url_for('read_onboarding') }}">Onboarding</a></li>
-        <li><a href="{{ url_for('read_uiux_tracker') }}">UI/UX Tracker</a></li>
-        <li><a href="{{ url_for('read_purchase_foundation') }}">Flow Pembelian</a></li>
-      </ul>
+  <div class="footer-top">
+    <div class="footer-brand">
+      <span class="logo">{{ app_name }}</span>
+      <p>Menghidupkan aroma Nusantara melalui kolaborasi komunitas parfum.</p>
     </div>
-    <div>
-      <h4>Dashboard</h4>
-      <ul>
-        <li><a href="{{ url_for('read_brand_owner_dashboard') }}">Dashboard Brand</a></li>
-        <li><a href="{{ url_for('read_moderation_dashboard') }}">Dashboard Moderasi</a></li>
-      </ul>
-    </div>
-    <div>
-      <h4>Komunitas</h4>
-      <ul>
-        <li><a href="{{ url_for('read_home') }}#sambatan">Sambatan</a></li>
-        <li><a href="{{ url_for('read_home') }}#nusantarum">Nusantarum</a></li>
-        <li><a href="{{ url_for('read_home') }}#profil">Profil</a></li>
-      </ul>
-    </div>
-    <div>
-      <h4>Ikuti Kami</h4>
-      <ul>
-        <li><a href="#instagram">Instagram</a></li>
-        <li><a href="#tiktok">TikTok</a></li>
-        <li><a href="#youtube">YouTube</a></li>
-      </ul>
+    <div class="footer-nav">
+      <div class="footer-group">
+        <h4>Navigasi</h4>
+        <ul>
+          <li><a href="{{ url_for('read_home') }}">Beranda</a></li>
+          <li><a href="{{ url_for('read_marketplace') }}">Marketplace</a></li>
+          <li><a href="{{ url_for('list_brands') }}">Brand Partner</a></li>
+          <li><a href="{{ url_for('read_onboarding') }}">Onboarding</a></li>
+          <li><a href="{{ url_for('read_uiux_tracker') }}">UI/UX Tracker</a></li>
+          <li><a href="{{ url_for('read_purchase_foundation') }}">Flow Pembelian</a></li>
+        </ul>
+      </div>
+      <div class="footer-group">
+        <h4>Dashboard</h4>
+        <ul>
+          <li><a href="{{ url_for('read_brand_owner_dashboard') }}">Dashboard Brand</a></li>
+          <li><a href="{{ url_for('read_moderation_dashboard') }}">Dashboard Moderasi</a></li>
+        </ul>
+      </div>
+      <div class="footer-group">
+        <h4>Komunitas</h4>
+        <ul>
+          <li><a href="{{ url_for('read_home') }}#sambatan">Sambatan</a></li>
+          <li><a href="{{ url_for('read_home') }}#nusantarum">Nusantarum</a></li>
+          <li><a href="{{ url_for('read_home') }}#profil">Profil</a></li>
+        </ul>
+      </div>
     </div>
   </div>
-  <p class="footer-note">&copy; {{ app_name }}. Semua hak dilindungi.</p>
+  <div class="footer-bottom">
+    <ul class="footer-social">
+      <li><a href="#instagram">Instagram</a></li>
+      <li><a href="#tiktok">TikTok</a></li>
+      <li><a href="#youtube">YouTube</a></li>
+    </ul>
+    <p class="footer-note">&copy; {{ app_name }}. Semua hak dilindungi.</p>
+  </div>
 </footer>


### PR DESCRIPTION
## Summary
- redesign the footer markup to use a compact top/bottom structure while retaining existing navigation links
- update the base stylesheet with new footer layout, spacing, and responsive adjustments for tighter presentation

## Testing
- PYTHONPATH=src uvicorn app.main:app --host 0.0.0.0 --port 8000

------
https://chatgpt.com/codex/tasks/task_e_68db2b3709d4832785ac5a7605efbe63