### PR TITLE
Add cache-busting for static assets

### DIFF
--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -27,6 +27,7 @@ class Settings(BaseSettings):
 
     # Session management
     session_secret: str = "development-session-secret-placeholder"
+    static_asset_version: str = "2024051901"
 
     @field_validator("session_secret")
     @classmethod

--- a/src/app/web/templates/__init__.py
+++ b/src/app/web/templates/__init__.py
@@ -1,8 +1,19 @@
 """Template utilities for Jinja2 rendering."""
 
 from pathlib import Path
+
 from fastapi.templating import Jinja2Templates
+
+from app.core.config import get_settings
 
 TEMPLATES_DIR = Path(__file__).parent
 
 template_engine = Jinja2Templates(directory=str(TEMPLATES_DIR))
+
+settings = get_settings()
+
+template_engine.env.globals.update(
+    app_name=settings.app_name,
+    static_asset_version=settings.static_asset_version,
+    static_asset_query=f"v={settings.static_asset_version}",
+)

--- a/src/app/web/templates/auth.html
+++ b/src/app/web/templates/auth.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block head_extra %}
-<link rel="stylesheet" href="{{ url_for('static', path='css/auth.css') }}" />
+<link rel="stylesheet" href="{{ url_for('static', path='css/auth.css') }}?{{ static_asset_query }}" />
 {% endblock %}
 
 {% block content %}

--- a/src/app/web/templates/base.html
+++ b/src/app/web/templates/base.html
@@ -11,7 +11,7 @@
       rel="stylesheet"
     />
       <link rel="stylesheet" href="https://unpkg.com/modern-css-reset/dist/reset.min.css" />
-      <link rel="stylesheet" href="{{ url_for('static', path='css/base.css') }}" />
+      <link rel="stylesheet" href="{{ url_for('static', path='css/base.css') }}?{{ static_asset_query }}" />
       {% block head_extra %}{% endblock %}
       <script src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-9gCsk+S4iigFsMghvYDn8ApX2HFqRSbuuSSMzdg3NofM8JrIoYNewc19hXtF87dj" crossorigin="anonymous"></script>
   </head>
@@ -24,7 +24,7 @@
       </main>
       {% include 'partials/footer.html' %}
     </div>
-    <script src="{{ url_for('static', path='js/session.js') }}" defer></script>
+    <script src="{{ url_for('static', path='js/session.js') }}?{{ static_asset_query }}" defer></script>
     {% block body_scripts %}{% endblock %}
   </body>
 </html>

--- a/src/app/web/templates/pages/brand/detail.html
+++ b/src/app/web/templates/pages/brand/detail.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block head_extra %}
-<link rel="stylesheet" href="{{ url_for('static', path='css/brand.css') }}" />
+<link rel="stylesheet" href="{{ url_for('static', path='css/brand.css') }}?{{ static_asset_query }}" />
 {% endblock %}
 
 {% block content %}

--- a/src/app/web/templates/pages/brand/index.html
+++ b/src/app/web/templates/pages/brand/index.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block head_extra %}
-<link rel="stylesheet" href="{{ url_for('static', path='css/brand.css') }}" />
+<link rel="stylesheet" href="{{ url_for('static', path='css/brand.css') }}?{{ static_asset_query }}" />
 {% endblock %}
 
 {% block content %}

--- a/src/app/web/templates/pages/dashboard/brand_owner.html
+++ b/src/app/web/templates/pages/dashboard/brand_owner.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block head_extra %}
-<link rel="stylesheet" href="{{ url_for('static', path='css/dashboard.css') }}" />
+<link rel="stylesheet" href="{{ url_for('static', path='css/dashboard.css') }}?{{ static_asset_query }}" />
 {% endblock %}
 
 {% block content %}
@@ -508,5 +508,5 @@
 
 {% block body_scripts %}
 {{ super() }}
-<script src="{{ url_for('static', path='js/dashboard-brand-owner.js') }}" defer></script>
+<script src="{{ url_for('static', path='js/dashboard-brand-owner.js') }}?{{ static_asset_query }}" defer></script>
 {% endblock %}

--- a/src/app/web/templates/pages/dashboard/moderation.html
+++ b/src/app/web/templates/pages/dashboard/moderation.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block head_extra %}
-<link rel="stylesheet" href="{{ url_for('static', path='css/moderation-dashboard.css') }}" />
+<link rel="stylesheet" href="{{ url_for('static', path='css/moderation-dashboard.css') }}?{{ static_asset_query }}" />
 {% endblock %}
 
 {% block content %}

--- a/src/app/web/templates/pages/nusantarum/index.html
+++ b/src/app/web/templates/pages/nusantarum/index.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block head_extra %}
-<link rel="stylesheet" href="{{ url_for('static', path='css/nusantarum.css') }}" />
+<link rel="stylesheet" href="{{ url_for('static', path='css/nusantarum.css') }}?{{ static_asset_query }}" />
 {% endblock %}
 
 {% block content %}

--- a/src/app/web/templates/pages/profile/detail.html
+++ b/src/app/web/templates/pages/profile/detail.html
@@ -2,7 +2,7 @@
 
 {% block head_extra %}
   {{ super() }}
-  <link rel="stylesheet" href="{{ url_for('static', path='css/profile.css') }}" />
+  <link rel="stylesheet" href="{{ url_for('static', path='css/profile.css') }}?{{ static_asset_query }}" />
 {% endblock %}
 
 {% block body_scripts %}

--- a/src/app/web/templates/purchase_workflow.html
+++ b/src/app/web/templates/purchase_workflow.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block head_extra %}
-<link rel="stylesheet" href="{{ url_for('static', path='css/purchase-workflow.css') }}" />
+<link rel="stylesheet" href="{{ url_for('static', path='css/purchase-workflow.css') }}?{{ static_asset_query }}" />
 {% endblock %}
 
 {% block content %}

--- a/src/app/web/templates/ui_ux_tracker.html
+++ b/src/app/web/templates/ui_ux_tracker.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block head_extra %}
-      <link rel="stylesheet" href="{{ url_for('static', path='css/ui-ux-tracker.css') }}" />
+      <link rel="stylesheet" href="{{ url_for('static', path='css/ui-ux-tracker.css') }}?{{ static_asset_query }}" />
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- add a configurable static asset version so deployments can force new CSS and JS to load
- expose the version as Jinja globals and append it to every static asset reference used by the templates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db409ad63483278e13ffe25b099514