### PR TITLE
Support tab query parameter on Nusantarum index

### DIFF
--- a/src/app/web/templates/components/nusantarum/brand-list.html
+++ b/src/app/web/templates/components/nusantarum/brand-list.html
@@ -24,7 +24,8 @@
       hx-get="/nusantarum/tab/{{ active_tab }}"
       hx-target="#nusantarum-tab-content"
       hx-include="#nusantarum-filter-form"
-      hx-vals='{"page": {{ page.page - 1 }}, "page_size": {{ page.page_size }}}'
+      hx-vals='{"page": {{ page.page - 1 if page.page > 1 else 1 }}, "page_size": {{ page.page_size }}, "tab": "{{ active_tab }}"}'
+      hx-push-url="/nusantarum?tab={{ active_tab }}&page={{ page.page - 1 if page.page > 1 else 1 }}&page_size={{ page.page_size }}"
       {% if page.page <= 1 %}disabled{% endif %}
     >Sebelumnya</button>
     <span class="nusantarum-pagination__status">Halaman {{ page.page }} dari {{ page.pages }}</span>
@@ -34,7 +35,8 @@
       hx-get="/nusantarum/tab/{{ active_tab }}"
       hx-target="#nusantarum-tab-content"
       hx-include="#nusantarum-filter-form"
-      hx-vals='{"page": {{ page.page + 1 }}, "page_size": {{ page.page_size }}}'
+      hx-vals='{"page": {{ page.page + 1 if page.page < page.pages else page.pages }}, "page_size": {{ page.page_size }}, "tab": "{{ active_tab }}"}'
+      hx-push-url="/nusantarum?tab={{ active_tab }}&page={{ page.page + 1 if page.page < page.pages else page.pages }}&page_size={{ page.page_size }}"
       {% if page.page >= page.pages %}disabled{% endif %}
     >Berikutnya</button>
   </div>

--- a/src/app/web/templates/components/nusantarum/filter-panel.html
+++ b/src/app/web/templates/components/nusantarum/filter-panel.html
@@ -5,7 +5,9 @@
   hx-target="#nusantarum-tab-content"
   hx-trigger="change delay:250ms"
   hx-include="#nusantarum-filter-form"
+  hx-push-url="/nusantarum?tab={{ active_tab }}"
 >
+  <input type="hidden" name="tab" value="{{ active_tab }}" />
   <h2>Filter Nusantarum</h2>
   <p class="text-muted">Sesuaikan direktori berdasarkan aroma, lokasi brand, dan status verifikasi.</p>
 

--- a/src/app/web/templates/components/nusantarum/perfume-list.html
+++ b/src/app/web/templates/components/nusantarum/perfume-list.html
@@ -86,7 +86,8 @@
       hx-get="/nusantarum/tab/{{ active_tab }}"
       hx-target="#nusantarum-tab-content"
       hx-include="#nusantarum-filter-form"
-      hx-vals='{"page": {{ page.page - 1 }}, "page_size": {{ page.page_size }}}'
+      hx-vals='{"page": {{ page.page - 1 if page.page > 1 else 1 }}, "page_size": {{ page.page_size }}, "tab": "{{ active_tab }}"}'
+      hx-push-url="/nusantarum?tab={{ active_tab }}&page={{ page.page - 1 if page.page > 1 else 1 }}&page_size={{ page.page_size }}"
       {% if page.page <= 1 %}disabled{% endif %}
     >Sebelumnya</button>
     <span class="nusantarum-pagination__status">Halaman {{ page.page }} dari {{ page.pages }}</span>
@@ -96,7 +97,8 @@
       hx-get="/nusantarum/tab/{{ active_tab }}"
       hx-target="#nusantarum-tab-content"
       hx-include="#nusantarum-filter-form"
-      hx-vals='{"page": {{ page.page + 1 }}, "page_size": {{ page.page_size }}}'
+      hx-vals='{"page": {{ page.page + 1 if page.page < page.pages else page.pages }}, "page_size": {{ page.page_size }}, "tab": "{{ active_tab }}"}'
+      hx-push-url="/nusantarum?tab={{ active_tab }}&page={{ page.page + 1 if page.page < page.pages else page.pages }}&page_size={{ page.page_size }}"
       {% if page.page >= page.pages %}disabled{% endif %}
     >Berikutnya</button>
   </div>

--- a/src/app/web/templates/components/nusantarum/perfumer-list.html
+++ b/src/app/web/templates/components/nusantarum/perfumer-list.html
@@ -24,7 +24,8 @@
       hx-get="/nusantarum/tab/{{ active_tab }}"
       hx-target="#nusantarum-tab-content"
       hx-include="#nusantarum-filter-form"
-      hx-vals='{"page": {{ page.page - 1 }}, "page_size": {{ page.page_size }}}'
+      hx-vals='{"page": {{ page.page - 1 if page.page > 1 else 1 }}, "page_size": {{ page.page_size }}, "tab": "{{ active_tab }}"}'
+      hx-push-url="/nusantarum?tab={{ active_tab }}&page={{ page.page - 1 if page.page > 1 else 1 }}&page_size={{ page.page_size }}"
       {% if page.page <= 1 %}disabled{% endif %}
     >Sebelumnya</button>
     <span class="nusantarum-pagination__status">Halaman {{ page.page }} dari {{ page.pages }}</span>
@@ -34,7 +35,8 @@
       hx-get="/nusantarum/tab/{{ active_tab }}"
       hx-target="#nusantarum-tab-content"
       hx-include="#nusantarum-filter-form"
-      hx-vals='{"page": {{ page.page + 1 }}, "page_size": {{ page.page_size }}}'
+      hx-vals='{"page": {{ page.page + 1 if page.page < page.pages else page.pages }}, "page_size": {{ page.page_size }}, "tab": "{{ active_tab }}"}'
+      hx-push-url="/nusantarum?tab={{ active_tab }}&page={{ page.page + 1 if page.page < page.pages else page.pages }}&page_size={{ page.page_size }}"
       {% if page.page >= page.pages %}disabled{% endif %}
     >Berikutnya</button>
   </div>

--- a/src/app/web/templates/pages/nusantarum/index.html
+++ b/src/app/web/templates/pages/nusantarum/index.html
@@ -32,39 +32,45 @@
   </header>
 
   <nav class="nusantarum-tabs" role="tablist">
-    <button
-      type="button"
+    <a
       class="nusantarum-tab"
       role="tab"
       aria-selected="{{ 'true' if active_tab == 'parfum' else 'false' }}"
       hx-get="/nusantarum/tab/parfum"
       hx-target="#nusantarum-tab-content"
+      hx-include="#nusantarum-filter-form"
+      hx-push-url="/nusantarum?tab=parfum"
+      href="/nusantarum?tab=parfum"
     >
       <span>Parfum</span>
       <span class="nusantarum-tab__count">{{ directory_totals.perfumes }}</span>
-    </button>
-    <button
-      type="button"
+    </a>
+    <a
       class="nusantarum-tab"
       role="tab"
       aria-selected="{{ 'true' if active_tab == 'brand' else 'false' }}"
       hx-get="/nusantarum/tab/brand"
       hx-target="#nusantarum-tab-content"
+      hx-include="#nusantarum-filter-form"
+      hx-push-url="/nusantarum?tab=brand"
+      href="/nusantarum?tab=brand"
     >
       <span>Brand</span>
       <span class="nusantarum-tab__count">{{ directory_totals.brands }}</span>
-    </button>
-    <button
-      type="button"
+    </a>
+    <a
       class="nusantarum-tab"
       role="tab"
       aria-selected="{{ 'true' if active_tab == 'perfumer' else 'false' }}"
       hx-get="/nusantarum/tab/perfumer"
       hx-target="#nusantarum-tab-content"
+      hx-include="#nusantarum-filter-form"
+      hx-push-url="/nusantarum?tab=perfumer"
+      href="/nusantarum?tab=perfumer"
     >
       <span>Perfumer</span>
       <span class="nusantarum-tab__count">{{ directory_totals.perfumers }}</span>
-    </button>
+    </a>
   </nav>
 
   <div class="nusantarum-controls">
@@ -98,8 +104,8 @@
       {% include 'components/nusantarum/filter-panel.html' %}
     </aside>
     <section id="nusantarum-tab-content" class="nusantarum-content" aria-live="polite" aria-busy="false">
-      {% with page=perfume_page, error_message=error_message, active_tab=active_tab %}
-      {% include 'components/nusantarum/perfume-list.html' %}
+      {% with page=tab_page, error_message=error_message, active_tab=active_tab %}
+      {% include tab_template %}
       {% endwith %}
     </section>
   </div>

--- a/tests/test_nusantarum_api.py
+++ b/tests/test_nusantarum_api.py
@@ -161,6 +161,7 @@ def test_index_page_renders_with_perfume_list(fake_service: FakeNusantarumServic
     assert "Hutan Senja" in text
     assert 'class="nusantarum-tabs"' in text
     assert 'id="nusantarum-search-form"' in text
+    assert 'hx-push-url="/nusantarum?tab=parfum"' in text
     assert text.index('class="nusantarum-tabs"') < text.index('id="nusantarum-search-form"')
 
 
@@ -195,3 +196,23 @@ def test_index_handles_configuration_error() -> None:
     assert status == 200
     assert "Supabase credentials" in body.decode()
     app.dependency_overrides.clear()
+
+
+def test_index_brand_tab_query_parameter(fake_service: FakeNusantarumService) -> None:
+    status, headers, body = asyncio.run(
+        _send_request("GET", "/nusantarum", query_string="tab=brand")
+    )
+    assert status == 200
+    assert headers["content-type"].startswith("text/html")
+    text = body.decode()
+    assert "Langit Senja" in text
+    assert 'hx-push-url="/nusantarum?tab=brand"' in text
+    assert 'name="tab" value="brand"' in text
+    assert '"tab": "brand"' in text
+
+
+def test_index_invalid_tab_returns_404(fake_service: FakeNusantarumService) -> None:
+    status, _, _ = asyncio.run(
+        _send_request("GET", "/nusantarum", query_string="tab=unknown")
+    )
+    assert status == 404


### PR DESCRIPTION
## Summary
- add support for a `tab` query parameter on the Nusantarum index route and drive the active tab plus initial loader from it
- update Nusantarum templates to push the selected tab into the URL and propagate it through HTMX interactions
- cover the new behaviour with API tests for tab persistence and invalid tab handling

## Testing
- pytest tests/test_nusantarum_api.py

------
https://chatgpt.com/codex/tasks/task_e_68dcdfb380e08327a3a2b1009cf9452d