### PR TITLE
Implement auth verification flow backed by Supabase repository

### DIFF
--- a/src/app/api/routes/auth.py
+++ b/src/app/api/routes/auth.py
@@ -2,10 +2,19 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, Field
 
-from app.services.auth import AuthService, AuthError, auth_service
+from app.services.auth import (
+    AccountStatus,
+    AuthService,
+    AuthUser,
+    AuthError,
+    RegistrationResult,
+    auth_service,
+)
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
@@ -20,12 +29,36 @@ class AuthPayload(BaseModel):
     user_id: str
     email: str
     full_name: str
+    status: AccountStatus
+    message: str
+
+
+class RegisterResponse(BaseModel):
+    registration_id: str
+    account_id: str
+    email: str
+    full_name: str
+    status: AccountStatus
+    verification_token: str
+    verification_expires_at: datetime
     message: str
 
 
 class LoginRequest(BaseModel):
     email: str = Field(..., pattern=r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
     password: str = Field(..., min_length=8, max_length=128)
+
+
+class VerificationRequest(BaseModel):
+    token: str = Field(..., min_length=8)
+
+
+class VerificationResponse(BaseModel):
+    user_id: str
+    email: str
+    full_name: str
+    status: AccountStatus
+    message: str
 
 
 class SessionResponse(BaseModel):
@@ -37,14 +70,35 @@ def get_auth_service() -> AuthService:
     return auth_service
 
 
-def _serialize_user(user) -> dict:
-    return {"user_id": user.id, "email": user.email, "full_name": user.full_name}
+def _serialize_user(user: AuthUser) -> dict:
+    return {
+        "user_id": user.id,
+        "email": user.email,
+        "full_name": user.full_name,
+        "status": user.status.value,
+    }
 
 
-@router.post("/register", response_model=AuthPayload, status_code=status.HTTP_201_CREATED)
-def register_user(payload: RegisterRequest, service: AuthService = Depends(get_auth_service)) -> AuthPayload:
+def _handle_registration_result(result: RegistrationResult) -> RegisterResponse:
+    registration = result.registration
+    account = result.account
+    expires_at = registration.verification_expires_at or account.updated_at
+    return RegisterResponse(
+        registration_id=registration.id,
+        account_id=account.id,
+        email=account.email,
+        full_name=account.full_name,
+        status=account.status,
+        verification_token=registration.verification_token or "",
+        verification_expires_at=expires_at,
+        message="Registrasi berhasil. Periksa email Anda untuk verifikasi.",
+    )
+
+
+@router.post("/register", response_model=RegisterResponse, status_code=status.HTTP_201_CREATED)
+def register_user(payload: RegisterRequest, service: AuthService = Depends(get_auth_service)) -> RegisterResponse:
     try:
-        user = service.register_user(
+        result = service.register_user(
             email=payload.email,
             full_name=payload.full_name,
             password=payload.password,
@@ -52,11 +106,24 @@ def register_user(payload: RegisterRequest, service: AuthService = Depends(get_a
     except AuthError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
 
-    return AuthPayload(
+    return _handle_registration_result(result)
+
+
+@router.post("/verify", response_model=VerificationResponse)
+def verify_user(
+    payload: VerificationRequest, service: AuthService = Depends(get_auth_service)
+) -> VerificationResponse:
+    try:
+        user = service.verify_registration(token=payload.token)
+    except AuthError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+
+    return VerificationResponse(
         user_id=user.id,
         email=user.email,
         full_name=user.full_name,
-        message="Registrasi berhasil",
+        status=user.status,
+        message="Verifikasi berhasil",
     )
 
 
@@ -77,6 +144,7 @@ def login_user(
         user_id=user.id,
         email=user.email,
         full_name=user.full_name,
+        status=user.status,
         message="Login berhasil",
     )
 


### PR DESCRIPTION
## Summary
- replace the in-memory auth service with a Supabase-oriented repository that stores pending registrations, verification tokens, and login timestamps
- extend the FastAPI auth routes with registration, email verification, and login responses that expose account status for the client session
- update the auth API test to exercise the register → verify → login flow

## Testing
- pytest tests/test_auth_api.py

------
https://chatgpt.com/codex/tasks/task_e_68dcfd746768832792f26e88216e930b