### PR TITLE
Extend session persistence to 30 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ src/app/
 ```
 
 `create_app` pada `src/app/core/application.py` menyiapkan middleware, static
-files, dan registrasi router untuk halaman landing awal.
+files, dan registrasi router untuk halaman landing awal. Middleware sesi
+in-memory menjaga cookie login terenkripsi aktif hingga 30 hari untuk
+memudahkan pengguna yang jarang logout manual.
 
 ## Menjalankan Secara Lokal
 

--- a/src/app/core/application.py
+++ b/src/app/core/application.py
@@ -29,7 +29,7 @@ def create_app() -> FastAPI:
 
     app.add_middleware(
         InMemorySessionMiddleware,
-        max_age=60 * 60 * 24 * 14,
+        max_age=60 * 60 * 24 * 30,
         same_site="lax",
     )
 

--- a/src/app/core/session.py
+++ b/src/app/core/session.py
@@ -61,7 +61,7 @@ class InMemorySessionMiddleware(BaseHTTPMiddleware):
         app,
         *,
         cookie_name: str = "session",
-        max_age: int = 60 * 60 * 24 * 14,
+        max_age: int = 60 * 60 * 24 * 30,
         same_site: str = "lax",
         https_only: bool = False,
     ) -> None:

--- a/src/app/web/templates/auth.html
+++ b/src/app/web/templates/auth.html
@@ -28,7 +28,7 @@
         <button type="submit" class="btn btn-outline">Masuk</button>
         <div class="login-divider" role="separator" aria-hidden="true">atau</div>
         <a class="btn gradient-button register-button" href="{{ url_for('read_onboarding') }}">Daftar Akun Baru</a>
-        <p class="form-note">Sesi login disimpan pada cookie terenkripsi selama 14 hari. Jika belum menerima tautan verifikasi, cek folder spam atau ajukan pengiriman ulang melalui halaman onboarding.</p>
+        <p class="form-note">Sesi login disimpan pada cookie terenkripsi selama 30 hari. Jika belum menerima tautan verifikasi, cek folder spam atau ajukan pengiriman ulang melalui halaman onboarding.</p>
       </form>
     </div>
   </div>

--- a/tests/test_auth_api.py
+++ b/tests/test_auth_api.py
@@ -142,6 +142,8 @@ def test_register_login_logout_flow():
         payload = json.loads(body.decode())
         assert payload["message"] == "Login berhasil"
         assert payload["status"] == AccountStatus.ACTIVE.value
+        assert "set-cookie" in headers
+        assert "max-age=2592000" in headers["set-cookie"].lower()
         jar.update(new_cookies)
         assert jar.get("session")
 


### PR DESCRIPTION
## Summary
- increase the session middleware max_age to 30 days via the application factory and middleware default
- refresh the login template copy and README to communicate the longer 30-day session retention window
- assert the login flow issues a session cookie with a 30-day Max-Age in the auth API integration test

## Testing
- pytest *(fails: tests/test_auth_service.py::test_register_and_authenticate_user, tests/test_auth_service.py::test_register_duplicate_email)*

------
https://chatgpt.com/codex/tasks/task_e_68ddcb1e62288327bad7fe17932bd332