### PR TITLE
Refactor profile service to use Supabase gateway

### DIFF
--- a/src/app/services/profile.py
+++ b/src/app/services/profile.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Protocol
+
+try:  # pragma: no cover - optional dependency for the Supabase gateway
+    import httpx
+except ModuleNotFoundError:  # pragma: no cover - environments without httpx
+    httpx = None  # type: ignore[assignment]
 
 
 class ProfileError(Exception):
@@ -20,6 +25,40 @@ class ProfileNotFound(ProfileError):
     """Raised when attempting to access an unknown profile."""
 
     status_code = 404
+
+
+class ProfileGateway(Protocol):
+    """Abstraction for profile persistence backed by Supabase."""
+
+    async def fetch_profile(self, identifier: str) -> Optional[Dict[str, Any]]:
+        ...
+
+    async def fetch_profile_stats(self, profile_id: str) -> Optional[Dict[str, Any]]:
+        ...
+
+    async def fetch_follow_graph(self, profile_id: str) -> Dict[str, List[str]]:
+        ...
+
+    async def fetch_followers(self, profile_id: str) -> List[Dict[str, Any]]:
+        ...
+
+    async def fetch_following(self, profile_id: str) -> List[Dict[str, Any]]:
+        ...
+
+    async def fetch_perfumer_products(self, profile_id: str) -> List[Dict[str, Any]]:
+        ...
+
+    async def fetch_owned_brands(self, profile_id: str) -> List[Dict[str, Any]]:
+        ...
+
+    async def check_following(self, *, follower_id: str, following_id: str) -> bool:
+        ...
+
+    async def create_follow(self, *, follower_id: str, following_id: str) -> None:
+        ...
+
+    async def delete_follow(self, *, follower_id: str, following_id: str) -> None:
+        ...
 
 
 @dataclass
@@ -78,7 +117,7 @@ class TimelineEntry:
 
 @dataclass
 class ProfileRecord:
-    """Internal representation of a user profile."""
+    """Representation of a user profile loaded from Supabase."""
 
     id: str
     username: str
@@ -123,26 +162,428 @@ class ProfileView:
     viewer: ProfileViewerState
 
 
-class ProfileService:
-    """Simple in-memory profile store used for SSR demos."""
+class SupabaseProfileGateway(ProfileGateway):
+    """HTTP-based gateway that interacts with Supabase PostgREST endpoints."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str,
+        schema: str = "public",
+        timeout: float = 10.0,
+    ) -> None:
+        if httpx is None:  # pragma: no cover - handled during runtime configuration
+            raise RuntimeError(
+                "httpx package is required for Supabase integration. "
+                "Install httpx to enable the Supabase profile gateway."
+            )
+
+        base = base_url.rstrip("/") + "/rest/v1"
+        self._client = httpx.AsyncClient(base_url=base, timeout=timeout)
+        self._schema = schema
+        self._headers = {
+            "apikey": api_key,
+            "Authorization": f"Bearer {api_key}",
+            "Accept-Profile": schema,
+        }
+
+    async def _get(self, resource: str, params: Dict[str, Any]) -> List[Dict[str, Any]]:
+        response = await self._client.get(resource, params=params, headers=self._headers)
+        response.raise_for_status()
+        return response.json()
+
+    async def fetch_profile(self, identifier: str) -> Optional[Dict[str, Any]]:
+        params = {
+            "select": "id,username,full_name,bio,preferred_aroma,avatar_url,location,tagline",
+            "or": f"(username.eq.{identifier},id.eq.{identifier})",
+            "limit": 1,
+        }
+        rows = await self._get("/user_profiles", params)
+        return rows[0] if rows else None
+
+    async def fetch_profile_stats(self, profile_id: str) -> Optional[Dict[str, Any]]:
+        params = {
+            "select": "profile_id,follower_count,following_count,perfumer_product_count,owned_brand_count",
+            "profile_id": f"eq.{profile_id}",
+            "limit": 1,
+        }
+        rows = await self._get("/user_profile_stats", params)
+        return rows[0] if rows else None
+
+    async def fetch_follow_graph(self, profile_id: str) -> Dict[str, List[str]]:
+        params = {
+            "select": "follower_id,following_id",
+            "or": f"(follower_id.eq.{profile_id},following_id.eq.{profile_id})",
+        }
+        rows = await self._get("/user_follows", params)
+        followers = [row["follower_id"] for row in rows if row["following_id"] == profile_id]
+        following = [row["following_id"] for row in rows if row["follower_id"] == profile_id]
+        return {"followers": followers, "following": following}
+
+    async def fetch_followers(self, profile_id: str) -> List[Dict[str, Any]]:
+        graph = await self.fetch_follow_graph(profile_id)
+        follower_ids = graph.get("followers", [])
+        if not follower_ids:
+            return []
+        params = {
+            "select": "id,username,full_name,avatar_url",
+            "id": f"in.({','.join(follower_ids)})",
+        }
+        rows = await self._get("/user_profiles", params)
+        return sorted(rows, key=lambda item: item.get("full_name", ""))
+
+    async def fetch_following(self, profile_id: str) -> List[Dict[str, Any]]:
+        graph = await self.fetch_follow_graph(profile_id)
+        following_ids = graph.get("following", [])
+        if not following_ids:
+            return []
+        params = {
+            "select": "id,username,full_name,avatar_url",
+            "id": f"in.({','.join(following_ids)})",
+        }
+        rows = await self._get("/user_profiles", params)
+        return sorted(rows, key=lambda item: item.get("full_name", ""))
+
+    async def fetch_perfumer_products(self, profile_id: str) -> List[Dict[str, Any]]:
+        params = {
+            "select": (
+                "product_id:id,role,"
+                "product:products(id,name,highlight,aroma_notes,"
+                "brand:brands(id,name,slug))"
+            ),
+            "perfumer_profile_id": f"eq.{profile_id}",
+        }
+        rows = await self._get("/product_perfumers", params)
+        items: List[Dict[str, Any]] = []
+        for row in rows:
+            product = row.get("product", {})
+            brand = product.get("brand", {})
+            items.append(
+                {
+                    "id": product.get("id", ""),
+                    "name": product.get("name", ""),
+                    "brand_name": brand.get("name", ""),
+                    "brand_slug": brand.get("slug", ""),
+                    "aroma_notes": product.get("aroma_notes", ""),
+                    "highlight": product.get("highlight", ""),
+                }
+            )
+        return items
+
+    async def fetch_owned_brands(self, profile_id: str) -> List[Dict[str, Any]]:
+        params = {
+            "select": "brand_id:id,name,slug,logo_path,status,tagline",
+            "profile_id": f"eq.{profile_id}",
+        }
+        rows = await self._get("/profile_brand_summary", params)
+        items: List[Dict[str, Any]] = []
+        for row in rows:
+            items.append(
+                {
+                    "id": row.get("brand_id", ""),
+                    "name": row.get("name", ""),
+                    "slug": row.get("slug", ""),
+                    "logo_url": row.get("logo_path", ""),
+                    "status": row.get("status", ""),
+                    "tagline": row.get("tagline", ""),
+                }
+            )
+        return items
+
+    async def check_following(self, *, follower_id: str, following_id: str) -> bool:
+        params = {
+            "select": "follower_id,following_id",
+            "follower_id": f"eq.{follower_id}",
+            "following_id": f"eq.{following_id}",
+            "limit": 1,
+        }
+        rows = await self._get("/user_follows", params)
+        return bool(rows)
+
+    async def create_follow(self, *, follower_id: str, following_id: str) -> None:
+        payload = {"follower_id": follower_id, "following_id": following_id}
+        headers = {"Prefer": "return=minimal", **self._headers}
+        response = await self._client.post("/user_follows", json=payload, headers=headers)
+        if response.status_code not in (200, 201, 204):  # pragma: no cover - httpx raises elsewhere
+            response.raise_for_status()
+
+    async def delete_follow(self, *, follower_id: str, following_id: str) -> None:
+        params = {
+            "follower_id": f"eq.{follower_id}",
+            "following_id": f"eq.{following_id}",
+        }
+        headers = {"Prefer": "return=minimal", **self._headers}
+        response = await self._client.delete("/user_follows", params=params, headers=headers)
+        if response.status_code not in (200, 204):  # pragma: no cover - httpx raises elsewhere
+            response.raise_for_status()
+
+
+class InMemoryProfileGateway(ProfileGateway):
+    """In-memory implementation used for local development and tests."""
 
     def __init__(self) -> None:
-        self._profiles: Dict[str, ProfileRecord] = {}
-        self._profiles_by_username: Dict[str, ProfileRecord] = {}
+        self._profiles: Dict[str, Dict[str, Any]] = {}
+        self._profiles_by_username: Dict[str, Dict[str, Any]] = {}
+        self._followers: Dict[str, set[str]] = {}
+        self._following: Dict[str, set[str]] = {}
+        self._perfumer_products: Dict[str, List[Dict[str, Any]]] = {}
+        self._owned_brands: Dict[str, List[Dict[str, Any]]] = {}
         self._initial_relationships: Dict[str, tuple[set[str], set[str]]] = {}
         self._seed_demo_profiles()
 
-    # ------------------------------------------------------------------
-    # Public API
-    # ------------------------------------------------------------------
-    def get_profile(self, profile_identifier: str, *, viewer_id: Optional[str] = None) -> ProfileView:
-        profile = self._resolve_profile(profile_identifier)
+    async def fetch_profile(self, identifier: str) -> Optional[Dict[str, Any]]:
+        if identifier in self._profiles:
+            return dict(self._profiles[identifier])
+        if identifier in self._profiles_by_username:
+            return dict(self._profiles_by_username[identifier])
+        return None
 
-        stats = ProfileStats(
-            follower_count=len(profile.followers),
-            following_count=len(profile.following),
-            perfumer_product_count=len(profile.perfumer_products),
-            owned_brand_count=len(profile.owned_brands),
+    async def fetch_profile_stats(self, profile_id: str) -> Optional[Dict[str, Any]]:
+        follower_ids = self._followers.get(profile_id, set())
+        following_ids = self._following.get(profile_id, set())
+        perfumer_products = self._perfumer_products.get(profile_id, [])
+        owned_brands = [
+            brand for brand in self._owned_brands.get(profile_id, []) if brand.get("status") == "active"
+        ]
+        return {
+            "profile_id": profile_id,
+            "follower_count": len(follower_ids),
+            "following_count": len(following_ids),
+            "perfumer_product_count": len(perfumer_products),
+            "owned_brand_count": len(owned_brands),
+        }
+
+    async def fetch_follow_graph(self, profile_id: str) -> Dict[str, List[str]]:
+        followers = list(self._followers.get(profile_id, set()))
+        following = list(self._following.get(profile_id, set()))
+        return {"followers": followers, "following": following}
+
+    async def fetch_followers(self, profile_id: str) -> List[Dict[str, Any]]:
+        follower_ids = self._followers.get(profile_id, set())
+        profiles = [dict(self._profiles[follower_id]) for follower_id in follower_ids]
+        return sorted(profiles, key=lambda item: item.get("full_name", ""))
+
+    async def fetch_following(self, profile_id: str) -> List[Dict[str, Any]]:
+        following_ids = self._following.get(profile_id, set())
+        profiles = [dict(self._profiles[following_id]) for following_id in following_ids]
+        return sorted(profiles, key=lambda item: item.get("full_name", ""))
+
+    async def fetch_perfumer_products(self, profile_id: str) -> List[Dict[str, Any]]:
+        return [dict(item) for item in self._perfumer_products.get(profile_id, [])]
+
+    async def fetch_owned_brands(self, profile_id: str) -> List[Dict[str, Any]]:
+        return [dict(item) for item in self._owned_brands.get(profile_id, [])]
+
+    async def check_following(self, *, follower_id: str, following_id: str) -> bool:
+        return follower_id in self._followers.get(following_id, set())
+
+    async def create_follow(self, *, follower_id: str, following_id: str) -> None:
+        self._followers.setdefault(following_id, set()).add(follower_id)
+        self._following.setdefault(follower_id, set()).add(following_id)
+
+    async def delete_follow(self, *, follower_id: str, following_id: str) -> None:
+        self._followers.setdefault(following_id, set()).discard(follower_id)
+        self._following.setdefault(follower_id, set()).discard(following_id)
+
+    async def reset_relationships(self) -> None:
+        for profile_id, snapshot in self._initial_relationships.items():
+            followers, following = snapshot
+            self._followers[profile_id] = set(followers)
+            self._following[profile_id] = set(following)
+
+    def _register_profile(self, profile: Dict[str, Any]) -> None:
+        self._profiles[profile["id"]] = profile
+        self._profiles_by_username[profile["username"]] = profile
+        self._followers.setdefault(profile["id"], set())
+        self._following.setdefault(profile["id"], set())
+
+    def _seed_demo_profiles(self) -> None:
+        amelia = {
+            "id": "user_amelia",
+            "username": "amelia-damayanti",
+            "full_name": "Amelia Damayanti",
+            "bio": (
+                "Perfumer independen yang gemar mengeksplorasi aroma rempah Nusantara. "
+                "Percaya bahwa setiap wewangian punya cerita manis untuk dibagikan."
+            ),
+            "preferred_aroma": "Rempah hangat & floral gourmand",
+            "avatar_url": "https://images.unsplash.com/photo-1542293787938-4d2226c3d9f1?auto=format&fit=crop&w=300&q=80",
+            "location": "Bandung, Indonesia",
+            "tagline": "Meracik cerita wangi untuk komunitas.",
+            "activities": [
+                {
+                    "title": "Merilis batch perdana Langit Sepia",
+                    "timestamp": "2 hari lalu",
+                    "description": "Batch pertama ludes dalam 36 jam setelah teaser di komunitas PerfumeLoka.",
+                },
+                {
+                    "title": "Sesi live blending dengan komunitas",
+                    "timestamp": "1 minggu lalu",
+                    "description": "Berbagi proses layering rempah manis dan musk yang bisa dicoba di rumah.",
+                },
+            ],
+            "favorites": [
+                "Aroma Senopati – Rumah Wangi",
+                "Kopi Sore – SukaSuara",
+                "Damar Biru – Cahaya Laut",
+            ],
+            "sambatan_updates": [
+                "Mengkurasi 12 peserta untuk Sambatan Hujan Pagi batch 2.",
+                "Membantu brand Arunika memilih packaging eco friendly.",
+            ],
+        }
+
+        bintang = {
+            "id": "user_bintang",
+            "username": "bintang-waskita",
+            "full_name": "Bintang Waskita",
+            "bio": "Founder Arunika Fragrance. Fokus mengangkat aroma kopi dan cokelat Indonesia.",
+            "preferred_aroma": "Gourmand & woody",
+            "avatar_url": "https://images.unsplash.com/photo-1502323777036-f29e3972d82f?auto=format&fit=crop&w=300&q=80",
+            "location": "Yogyakarta, Indonesia",
+            "tagline": "Menguatkan rasa lokal lewat aroma.",
+            "activities": [
+                {
+                    "title": "Memenangkan penghargaan UKM Aroma 2024",
+                    "timestamp": "5 hari lalu",
+                    "description": "Arunika terpilih sebagai brand parfum terinovatif kategori bahan lokal.",
+                },
+            ],
+            "favorites": [
+                "Langit Sepia – Langit Senja",
+                "Rimba Malam – Cahaya Laut",
+            ],
+            "sambatan_updates": [
+                "Mengajak 20 anggota komunitas mencoba eksperimen Macchiato Accord.",
+            ],
+        }
+
+        chandra = {
+            "id": "user_chandra",
+            "username": "chandra-pratama",
+            "full_name": "Chandra Pratama",
+            "bio": "Collector fragrance niche dan reviewer tetap di Nusantarum.",
+            "preferred_aroma": "Citrus aromatic",
+            "avatar_url": "https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=300&q=80",
+            "location": "Jakarta, Indonesia",
+            "tagline": "Berbagi insight wewangian buat pemula.",
+            "activities": [
+                {
+                    "title": "Mengulas Langit Sepia",
+                    "timestamp": "3 hari lalu",
+                    "description": "Memberi rating 4.5/5 dan highlight pada dry-down manisnya yang tahan lama.",
+                },
+                {
+                    "title": "Membuka diskusi komunitas tentang teknik layering",
+                    "timestamp": "2 minggu lalu",
+                    "description": "Mengulas cara memadukan citrus segar dengan gourmand berat.",
+                },
+            ],
+            "favorites": [
+                "Hujan Pagi – Langit Senja",
+                "Macchiato Drift – Arunika",
+                "Teh Senja – Rumah Wangi",
+            ],
+            "sambatan_updates": [
+                "Mengikuti Sambatan Macchiato Drift batch 1.",
+            ],
+        }
+
+        self._perfumer_products = {
+            "user_amelia": [
+                {
+                    "id": "prod_langitsepia",
+                    "name": "Langit Sepia",
+                    "brand_name": "Langit Senja",
+                    "brand_slug": "langit-senja",
+                    "aroma_notes": "Bergamot • Tonka Bean • Patchouli",
+                    "highlight": "Racikan signature bertema golden hour dengan nuansa cozy.",
+                },
+                {
+                    "id": "prod_hujanpagi",
+                    "name": "Hujan Pagi",
+                    "brand_name": "Langit Senja",
+                    "brand_slug": "langit-senja",
+                    "aroma_notes": "Rain Accord • Vetiver • White Musk",
+                    "highlight": "Aroma petrichor lembut yang menenangkan suasana pagi.",
+                },
+            ],
+        }
+
+        self._owned_brands = {
+            "user_amelia": [
+                {
+                    "id": "brand_langitsenja",
+                    "name": "Langit Senja",
+                    "slug": "langit-senja",
+                    "logo_url": "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=120&q=80",
+                    "status": "active",
+                    "tagline": "Cerita aroma hangat untuk nostalgia senja.",
+                },
+            ],
+            "user_bintang": [
+                {
+                    "id": "brand_arunika",
+                    "name": "Arunika",
+                    "slug": "arunika",
+                    "logo_url": "https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=120&q=80",
+                    "status": "active",
+                    "tagline": "Eksperimen rasa kopi dan cokelat premium.",
+                },
+            ],
+            "user_chandra": [],
+        }
+
+        for profile in (amelia, bintang, chandra):
+            self._register_profile(profile)
+
+        self._followers = {
+            "user_amelia": {"user_bintang", "user_chandra"},
+            "user_bintang": {"user_chandra"},
+            "user_chandra": set(),
+        }
+        self._following = {
+            "user_amelia": {"user_bintang"},
+            "user_bintang": {"user_amelia"},
+            "user_chandra": {"user_amelia", "user_bintang"},
+        }
+
+        self._initial_relationships = {
+            profile_id: (set(followers), set(self._following.get(profile_id, set())))
+            for profile_id, followers in self._followers.items()
+        }
+
+
+class ProfileService:
+    """Profile orchestration layer backed by a Supabase gateway."""
+
+    def __init__(self, gateway: Optional[ProfileGateway] = None) -> None:
+        self._gateway = gateway or InMemoryProfileGateway()
+
+    async def get_profile(self, profile_identifier: str, *, viewer_id: Optional[str] = None) -> ProfileView:
+        profile_data = await self._resolve_profile_data(profile_identifier)
+        profile_id = profile_data["id"]
+
+        stats_data = await self._gateway.fetch_profile_stats(profile_id)
+        follow_graph = await self._gateway.fetch_follow_graph(profile_id)
+        perfumer_products = await self._gateway.fetch_perfumer_products(profile_id)
+        owned_brands = await self._gateway.fetch_owned_brands(profile_id)
+
+        profile = self._build_profile_record(
+            profile_data,
+            followers=follow_graph.get("followers", []),
+            following=follow_graph.get("following", []),
+            perfumer_products=perfumer_products,
+            owned_brands=owned_brands,
+        )
+
+        stats = self._build_profile_stats(stats_data, profile)
+
+        viewer = ProfileViewerState(
+            id=viewer_id,
+            is_owner=viewer_id == profile.id if viewer_id else False,
+            is_following=(viewer_id in profile.followers) if viewer_id else False,
         )
 
         badges: List[ProfileBadge] = []
@@ -167,235 +608,147 @@ class ProfileService:
                 )
             )
 
-        viewer = ProfileViewerState(
-            id=viewer_id,
-            is_owner=viewer_id == profile.id if viewer_id else False,
-            is_following=viewer_id in profile.followers if viewer_id else False,
-        )
-
         return ProfileView(profile=profile, stats=stats, badges=badges, viewer=viewer)
 
-    def follow_profile(self, target_identifier: str, *, follower_id: str) -> ProfileView:
-        follower = self._resolve_profile(follower_id)
-        target = self._resolve_profile(target_identifier)
+    async def follow_profile(self, target_identifier: str, *, follower_id: str) -> ProfileView:
+        follower = await self._resolve_profile_data(follower_id)
+        target = await self._resolve_profile_data(target_identifier)
 
-        if follower.id == target.id:
+        if follower["id"] == target["id"]:
             raise ProfileError("Tidak dapat mengikuti profil sendiri.")
 
-        if follower.id in target.followers:
-            # Idempotent response to simplify HTMX interactions.
-            return self.get_profile(target.id, viewer_id=follower.id)
+        is_following = await self._gateway.check_following(
+            follower_id=follower["id"], following_id=target["id"]
+        )
+        if not is_following:
+            await self._gateway.create_follow(follower_id=follower["id"], following_id=target["id"])
 
-        target.followers.add(follower.id)
-        follower.following.add(target.id)
-        return self.get_profile(target.id, viewer_id=follower.id)
+        return await self.get_profile(target["id"], viewer_id=follower["id"])
 
-    def unfollow_profile(self, target_identifier: str, *, follower_id: str) -> ProfileView:
-        follower = self._resolve_profile(follower_id)
-        target = self._resolve_profile(target_identifier)
+    async def unfollow_profile(self, target_identifier: str, *, follower_id: str) -> ProfileView:
+        follower = await self._resolve_profile_data(follower_id)
+        target = await self._resolve_profile_data(target_identifier)
 
-        if follower.id == target.id:
+        if follower["id"] == target["id"]:
             raise ProfileError("Tidak dapat berhenti mengikuti profil sendiri.")
 
-        if follower.id in target.followers:
-            target.followers.remove(follower.id)
-            follower.following.remove(target.id)
+        is_following = await self._gateway.check_following(
+            follower_id=follower["id"], following_id=target["id"]
+        )
+        if is_following:
+            await self._gateway.delete_follow(follower_id=follower["id"], following_id=target["id"])
 
-        return self.get_profile(target.id, viewer_id=follower.id)
+        return await self.get_profile(target["id"], viewer_id=follower["id"])
 
-    def list_followers(self, profile_identifier: str) -> List[ProfileRecord]:
-        profile = self._resolve_profile(profile_identifier)
-        return sorted((self._profiles[follower_id] for follower_id in profile.followers), key=lambda p: p.full_name)
+    async def list_followers(self, profile_identifier: str) -> List[ProfileRecord]:
+        profile_data = await self._resolve_profile_data(profile_identifier)
+        followers = await self._gateway.fetch_followers(profile_data["id"])
+        return [self._build_profile_record(item) for item in followers]
 
-    def list_following(self, profile_identifier: str) -> List[ProfileRecord]:
-        profile = self._resolve_profile(profile_identifier)
-        return sorted((self._profiles[following_id] for following_id in profile.following), key=lambda p: p.full_name)
+    async def list_following(self, profile_identifier: str) -> List[ProfileRecord]:
+        profile_data = await self._resolve_profile_data(profile_identifier)
+        following = await self._gateway.fetch_following(profile_data["id"])
+        return [self._build_profile_record(item) for item in following]
 
-    def list_perfumer_products(self, profile_identifier: str) -> List[PerfumerProduct]:
-        profile = self._resolve_profile(profile_identifier)
-        return profile.perfumer_products
+    async def list_perfumer_products(self, profile_identifier: str) -> List[PerfumerProduct]:
+        profile_data = await self._resolve_profile_data(profile_identifier)
+        products = await self._gateway.fetch_perfumer_products(profile_data["id"])
+        return [self._build_perfumer_product(item) for item in products]
 
-    def list_owned_brands(self, profile_identifier: str) -> List[OwnedBrand]:
-        profile = self._resolve_profile(profile_identifier)
-        return profile.owned_brands
+    async def list_owned_brands(self, profile_identifier: str) -> List[OwnedBrand]:
+        profile_data = await self._resolve_profile_data(profile_identifier)
+        brands = await self._gateway.fetch_owned_brands(profile_data["id"])
+        return [self._build_owned_brand(item) for item in brands]
 
-    def reset_relationships(self) -> None:
-        """Reset follow relationships to the initial demo state (used in tests)."""
+    async def reset_relationships(self) -> None:
+        reset = getattr(self._gateway, "reset_relationships", None)
+        if reset is None:
+            return
+        result = reset()
+        if hasattr(result, "__await__"):
+            await result  # type: ignore[func-returns-value]
 
-        for profile_id, snapshot in self._initial_relationships.items():
-            followers, following = snapshot
-            profile = self._profiles[profile_id]
-            profile.followers.clear()
-            profile.followers.update(followers)
-            profile.following.clear()
-            profile.following.update(following)
+    async def _resolve_profile_data(self, identifier: str) -> Dict[str, Any]:
+        profile_data = await self._gateway.fetch_profile(identifier)
+        if not profile_data:
+            raise ProfileNotFound("Profil tidak ditemukan.")
+        return profile_data
 
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-    def _resolve_profile(self, profile_identifier: str) -> ProfileRecord:
-        if profile_identifier in self._profiles:
-            return self._profiles[profile_identifier]
-        if profile_identifier in self._profiles_by_username:
-            return self._profiles_by_username[profile_identifier]
-        raise ProfileNotFound("Profil tidak ditemukan.")
-
-    def _register_profile(self, profile: ProfileRecord) -> None:
-        self._profiles[profile.id] = profile
-        self._profiles_by_username[profile.username] = profile
-
-    def _seed_demo_profiles(self) -> None:
-        """Create demo data to satisfy the profile UX mocks."""
-
-        amelia = ProfileRecord(
-            id="user_amelia",
-            username="amelia-damayanti",
-            full_name="Amelia Damayanti",
-            bio=(
-                "Perfumer independen yang gemar mengeksplorasi aroma rempah Nusantara. "
-                "Percaya bahwa setiap wewangian punya cerita manis untuk dibagikan."
-            ),
-            preferred_aroma="Rempah hangat & floral gourmand",
-            avatar_url="https://images.unsplash.com/photo-1542293787938-4d2226c3d9f1?auto=format&fit=crop&w=300&q=80",
-            location="Bandung, Indonesia",
-            tagline="Meracik cerita wangi untuk komunitas.",
-            perfumer_products=[
-                PerfumerProduct(
-                    id="prod_langitsepia",
-                    name="Langit Sepia",
-                    brand_name="Langit Senja",
-                    brand_slug="langit-senja",
-                    aroma_notes="Bergamot • Tonka Bean • Patchouli",
-                    highlight="Racikan signature bertema golden hour dengan nuansa cozy.",
-                ),
-                PerfumerProduct(
-                    id="prod_hujanpagi",
-                    name="Hujan Pagi",
-                    brand_name="Langit Senja",
-                    brand_slug="langit-senja",
-                    aroma_notes="Rain Accord • Vetiver • White Musk",
-                    highlight="Aroma petrichor lembut yang menenangkan suasana pagi.",
-                ),
-            ],
-            owned_brands=[
-                OwnedBrand(
-                    id="brand_langitsenja",
-                    name="Langit Senja",
-                    slug="langit-senja",
-                    logo_url="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=120&q=80",
-                    status="active",
-                    tagline="Cerita aroma hangat untuk nostalgia senja.",
-                ),
-            ],
-            activities=[
-                TimelineEntry(
-                    title="Merilis batch perdana Langit Sepia",
-                    timestamp="2 hari lalu",
-                    description="Batch pertama ludes dalam 36 jam setelah teaser di komunitas PerfumeLoka.",
-                ),
-                TimelineEntry(
-                    title="Sesi live blending dengan komunitas",
-                    timestamp="1 minggu lalu",
-                    description="Berbagi proses layering rempah manis dan musk yang bisa dicoba di rumah.",
-                ),
-            ],
-            favorites=[
-                "Aroma Senopati – Rumah Wangi",
-                "Kopi Sore – SukaSuara",
-                "Damar Biru – Cahaya Laut",
-            ],
-            sambatan_updates=[
-                "Mengkurasi 12 peserta untuk Sambatan Hujan Pagi batch 2.",
-                "Membantu brand Arunika memilih packaging eco friendly.",
-            ],
+    def _build_profile_record(
+        self,
+        data: Dict[str, Any],
+        *,
+        followers: Iterable[str] | None = None,
+        following: Iterable[str] | None = None,
+        perfumer_products: Iterable[Dict[str, Any]] | Iterable[PerfumerProduct] | None = None,
+        owned_brands: Iterable[Dict[str, Any]] | Iterable[OwnedBrand] | None = None,
+    ) -> ProfileRecord:
+        return ProfileRecord(
+            id=data.get("id", ""),
+            username=data.get("username", ""),
+            full_name=data.get("full_name", ""),
+            bio=data.get("bio", ""),
+            preferred_aroma=data.get("preferred_aroma"),
+            avatar_url=data.get("avatar_url"),
+            location=data.get("location"),
+            tagline=data.get("tagline"),
+            followers=set(followers or []),
+            following=set(following or []),
+            perfumer_products=[self._build_perfumer_product(item) for item in perfumer_products or []],
+            owned_brands=[self._build_owned_brand(item) for item in owned_brands or []],
+            activities=[self._build_timeline_entry(item) for item in data.get("activities", [])],
+            favorites=list(data.get("favorites", [])),
+            sambatan_updates=list(data.get("sambatan_updates", [])),
         )
 
-        bintang = ProfileRecord(
-            id="user_bintang",
-            username="bintang-waskita",
-            full_name="Bintang Waskita",
-            bio="Founder Arunika Fragrance. Fokus mengangkat aroma kopi dan cokelat Indonesia.",
-            preferred_aroma="Gourmand & woody",
-            avatar_url="https://images.unsplash.com/photo-1502323777036-f29e3972d82f?auto=format&fit=crop&w=300&q=80",
-            location="Yogyakarta, Indonesia",
-            tagline="Menguatkan rasa lokal lewat aroma.",
-            owned_brands=[
-                OwnedBrand(
-                    id="brand_arunika",
-                    name="Arunika",
-                    slug="arunika",
-                    logo_url="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=120&q=80",
-                    status="active",
-                    tagline="Eksperimen rasa kopi dan cokelat premium.",
-                ),
-            ],
-            activities=[
-                TimelineEntry(
-                    title="Memenangkan penghargaan UKM Aroma 2024",
-                    timestamp="5 hari lalu",
-                    description="Arunika terpilih sebagai brand parfum terinovatif kategori bahan lokal.",
-                ),
-            ],
-            favorites=[
-                "Langit Sepia – Langit Senja",
-                "Rimba Malam – Cahaya Laut",
-            ],
-            sambatan_updates=[
-                "Mengajak 20 anggota komunitas mencoba eksperimen Macchiato Accord.",
-            ],
+    def _build_profile_stats(self, stats: Optional[Dict[str, Any]], profile: ProfileRecord) -> ProfileStats:
+        if not stats:
+            return ProfileStats(
+                follower_count=len(profile.followers),
+                following_count=len(profile.following),
+                perfumer_product_count=len(profile.perfumer_products),
+                owned_brand_count=len(profile.owned_brands),
+            )
+        return ProfileStats(
+            follower_count=stats.get("follower_count", len(profile.followers)),
+            following_count=stats.get("following_count", len(profile.following)),
+            perfumer_product_count=stats.get("perfumer_product_count", len(profile.perfumer_products)),
+            owned_brand_count=stats.get("owned_brand_count", len(profile.owned_brands)),
         )
 
-        chandra = ProfileRecord(
-            id="user_chandra",
-            username="chandra-pratama",
-            full_name="Chandra Pratama",
-            bio="Collector fragrance niche dan reviewer tetap di Nusantarum.",
-            preferred_aroma="Citrus aromatic",
-            avatar_url="https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=300&q=80",
-            location="Jakarta, Indonesia",
-            tagline="Berbagi insight wewangian buat pemula.",
-            activities=[
-                TimelineEntry(
-                    title="Mengulas Langit Sepia",
-                    timestamp="3 hari lalu",
-                    description="Memberi rating 4.5/5 dan highlight pada dry-down manisnya yang tahan lama.",
-                ),
-                TimelineEntry(
-                    title="Membuka diskusi komunitas tentang teknik layering",
-                    timestamp="2 minggu lalu",
-                    description="Mengulas cara memadukan citrus segar dengan gourmand berat.",
-                ),
-            ],
-            favorites=[
-                "Hujan Pagi – Langit Senja",
-                "Macchiato Drift – Arunika",
-                "Teh Senja – Rumah Wangi",
-            ],
-            sambatan_updates=[
-                "Mengikuti Sambatan Macchiato Drift batch 1.",
-            ],
+    def _build_perfumer_product(self, data: Dict[str, Any] | PerfumerProduct) -> PerfumerProduct:
+        if isinstance(data, PerfumerProduct):
+            return data
+        return PerfumerProduct(
+            id=data.get("id", ""),
+            name=data.get("name", ""),
+            brand_name=data.get("brand_name", ""),
+            brand_slug=data.get("brand_slug", ""),
+            aroma_notes=data.get("aroma_notes", ""),
+            highlight=data.get("highlight", ""),
         )
 
-        # Register demo profiles.
-        for profile in (amelia, bintang, chandra):
-            self._register_profile(profile)
+    def _build_owned_brand(self, data: Dict[str, Any] | OwnedBrand) -> OwnedBrand:
+        if isinstance(data, OwnedBrand):
+            return data
+        return OwnedBrand(
+            id=data.get("id", ""),
+            name=data.get("name", ""),
+            slug=data.get("slug", ""),
+            logo_url=data.get("logo_url", ""),
+            status=data.get("status", ""),
+            tagline=data.get("tagline", ""),
+        )
 
-        # Establish initial follow graph.
-        amelia.followers.update({"user_bintang", "user_chandra"})
-        amelia.following.update({"user_bintang"})
-
-        bintang.followers.update({"user_chandra"})
-        bintang.following.update({"user_amelia"})
-
-        chandra.followers.update(set())
-        chandra.following.update({"user_amelia", "user_bintang"})
-
-        # Snapshot initial relationships for test resets.
-        self._initial_relationships = {
-            profile.id: profile.clone_relationships() for profile in (amelia, bintang, chandra)
-        }
+    def _build_timeline_entry(self, data: Dict[str, Any] | TimelineEntry) -> TimelineEntry:
+        if isinstance(data, TimelineEntry):
+            return data
+        return TimelineEntry(
+            title=data.get("title", ""),
+            timestamp=data.get("timestamp", ""),
+            description=data.get("description", ""),
+        )
 
 
 profile_service = ProfileService()
 """Singleton profile service instance shared across routers and tests."""
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from app.services.profile import InMemoryProfileGateway
+
+
+class FakeSupabaseProfileGateway(InMemoryProfileGateway):
+    """Test double exposing follow write operations for assertions."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.follow_writes: List[tuple[str, str]] = []
+        self.unfollow_writes: List[tuple[str, str]] = []
+
+    async def create_follow(self, *, follower_id: str, following_id: str) -> None:  # type: ignore[override]
+        await super().create_follow(follower_id=follower_id, following_id=following_id)
+        self.follow_writes.append((follower_id, following_id))
+
+    async def delete_follow(self, *, follower_id: str, following_id: str) -> None:  # type: ignore[override]
+        await super().delete_follow(follower_id=follower_id, following_id=following_id)
+        self.unfollow_writes.append((follower_id, following_id))
+
+    async def reset_relationships(self) -> None:  # type: ignore[override]
+        await super().reset_relationships()
+        self.follow_writes.clear()
+        self.unfollow_writes.clear()
+
+
+@pytest.fixture
+def fake_profile_gateway() -> FakeSupabaseProfileGateway:
+    return FakeSupabaseProfileGateway()

--- a/tests/test_profile_api.py
+++ b/tests/test_profile_api.py
@@ -3,8 +3,10 @@ from urllib.parse import urlsplit
 
 import pytest
 
+from app.api.routes.profile import get_profile_service
 from app.main import app
-from app.services.profile import profile_service
+from app.services.profile import ProfileService
+from tests.conftest import FakeSupabaseProfileGateway
 
 
 async def _request(method: str, raw_path: str, headers: dict[str, str] | None = None) -> tuple[int, str]:
@@ -52,14 +54,21 @@ def request(method: str, raw_path: str, headers: dict[str, str] | None = None) -
     return asyncio.run(_request(method, raw_path, headers))
 
 
+@pytest.fixture
+def profile_service(fake_profile_gateway: FakeSupabaseProfileGateway) -> ProfileService:
+    service = ProfileService(gateway=fake_profile_gateway)
+    asyncio.run(service.reset_relationships())
+    app.dependency_overrides[get_profile_service] = lambda: service
+    return service
+
+
 @pytest.fixture(autouse=True)
-def reset_profile_state() -> None:
-    profile_service.reset_relationships()
+def cleanup_dependency_override() -> None:
     yield
-    profile_service.reset_relationships()
+    app.dependency_overrides.pop(get_profile_service, None)
 
 
-def test_profile_detail_page_renders() -> None:
+def test_profile_detail_page_renders(profile_service: ProfileService) -> None:
     status, body = request("GET", "/profile/amelia-damayanti?viewer=user_chandra")
 
     assert status == 200
@@ -67,14 +76,18 @@ def test_profile_detail_page_renders() -> None:
     assert "Perfumer" in body
 
 
-def test_profile_tab_endpoint_returns_perfumer_products() -> None:
+def test_profile_tab_endpoint_returns_perfumer_products(
+    profile_service: ProfileService,
+) -> None:
     status, body = request("GET", "/profile/amelia-damayanti/tab/karya")
 
     assert status == 200
     assert "Langit Sepia" in body
 
 
-def test_follow_and_unfollow_flow_via_htmx() -> None:
+def test_follow_and_unfollow_flow_via_htmx(
+    profile_service: ProfileService, fake_profile_gateway: FakeSupabaseProfileGateway
+) -> None:
     status_follow, follow_body = request(
         "POST",
         "/profile/chandra-pratama/follow?viewer=user_bintang",
@@ -82,8 +95,9 @@ def test_follow_and_unfollow_flow_via_htmx() -> None:
     )
     assert status_follow == 200
     assert "Mengikuti" in follow_body
+    assert ("user_bintang", "user_chandra") in fake_profile_gateway.follow_writes
 
-    view = profile_service.get_profile("chandra-pratama", viewer_id="user_bintang")
+    view = asyncio.run(profile_service.get_profile("chandra-pratama", viewer_id="user_bintang"))
     assert view.viewer.is_following is True
 
     status_unfollow, unfollow_body = request(
@@ -93,12 +107,15 @@ def test_follow_and_unfollow_flow_via_htmx() -> None:
     )
     assert status_unfollow == 200
     assert "Ikuti" in unfollow_body
+    assert ("user_bintang", "user_chandra") in fake_profile_gateway.unfollow_writes
 
-    view_after = profile_service.get_profile("chandra-pratama", viewer_id="user_bintang")
+    view_after = asyncio.run(
+        profile_service.get_profile("chandra-pratama", viewer_id="user_bintang")
+    )
     assert view_after.viewer.is_following is False
 
 
-def test_followers_modal_lists_profiles() -> None:
+def test_followers_modal_lists_profiles(profile_service: ProfileService) -> None:
     status, body = request("GET", "/profile/amelia-damayanti/followers")
 
     assert status == 200

--- a/tests/test_profile_service.py
+++ b/tests/test_profile_service.py
@@ -1,17 +1,22 @@
+import asyncio
+
 import pytest
 
-from app.services.profile import ProfileError, profile_service
+from app.services.profile import ProfileError, ProfileService
+from tests.conftest import FakeSupabaseProfileGateway
 
 
-@pytest.fixture(autouse=True)
-def reset_profile_service() -> None:
-    profile_service.reset_relationships()
-    yield
-    profile_service.reset_relationships()
+@pytest.fixture
+def profile_service(fake_profile_gateway: FakeSupabaseProfileGateway) -> ProfileService:
+    service = ProfileService(gateway=fake_profile_gateway)
+    asyncio.run(service.reset_relationships())
+    return service
 
 
-def test_get_profile_returns_badges_and_stats() -> None:
-    view = profile_service.get_profile("amelia-damayanti")
+def test_get_profile_returns_badges_and_stats(
+    profile_service: ProfileService,
+) -> None:
+    view = asyncio.run(profile_service.get_profile("amelia-damayanti"))
 
     assert view.profile.full_name == "Amelia Damayanti"
     assert view.stats.follower_count == 2
@@ -20,23 +25,39 @@ def test_get_profile_returns_badges_and_stats() -> None:
     assert "brand-owner" in badge_slugs
 
 
-def test_follow_profile_updates_relationship() -> None:
-    view = profile_service.follow_profile("chandra-pratama", follower_id="user_bintang")
+def test_follow_profile_updates_relationship(
+    profile_service: ProfileService, fake_profile_gateway: FakeSupabaseProfileGateway
+) -> None:
+    view = asyncio.run(
+        profile_service.follow_profile("chandra-pratama", follower_id="user_bintang")
+    )
 
     assert view.stats.follower_count >= 1
-    viewer_state = profile_service.get_profile("chandra-pratama", viewer_id="user_bintang").viewer
-    assert viewer_state.is_following is True
+    assert ("user_bintang", "user_chandra") in fake_profile_gateway.follow_writes
+    viewer_state = asyncio.run(
+        profile_service.get_profile("chandra-pratama", viewer_id="user_bintang")
+    )
+    assert viewer_state.viewer.is_following is True
 
 
-def test_unfollow_profile_resets_relationship() -> None:
-    profile_service.follow_profile("chandra-pratama", follower_id="user_bintang")
-    view = profile_service.unfollow_profile("chandra-pratama", follower_id="user_bintang")
+def test_unfollow_profile_resets_relationship(
+    profile_service: ProfileService, fake_profile_gateway: FakeSupabaseProfileGateway
+) -> None:
+    asyncio.run(profile_service.follow_profile("chandra-pratama", follower_id="user_bintang"))
+    view = asyncio.run(
+        profile_service.unfollow_profile("chandra-pratama", follower_id="user_bintang")
+    )
 
     assert view.stats.follower_count >= 0
-    viewer_state = profile_service.get_profile("chandra-pratama", viewer_id="user_bintang").viewer
-    assert viewer_state.is_following is False
+    assert ("user_bintang", "user_chandra") in fake_profile_gateway.unfollow_writes
+    viewer_state = asyncio.run(
+        profile_service.get_profile("chandra-pratama", viewer_id="user_bintang")
+    )
+    assert viewer_state.viewer.is_following is False
 
 
-def test_cannot_follow_self() -> None:
+def test_cannot_follow_self(profile_service: ProfileService) -> None:
     with pytest.raises(ProfileError):
-        profile_service.follow_profile("user_bintang", follower_id="user_bintang")
+        asyncio.run(
+            profile_service.follow_profile("user_bintang", follower_id="user_bintang")
+        )


### PR DESCRIPTION
## Summary
- introduce a Supabase-aware profile gateway and refactor the profile service to load data and persist follows through it
- update profile routes to await the asynchronous service while keeping HTMX responses populated with full context
- add reusable fake Supabase gateway fixtures and refresh service/API tests to validate follow/unfollow behaviour with persistent data

## Testing
- `pytest tests/test_profile_service.py tests/test_profile_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68ddce511908832793ecda14f300c4e5