### PR TITLE
Add profile editing workflow with HTMX support

### DIFF
--- a/src/app/api/routes/profile.py
+++ b/src/app/api/routes/profile.py
@@ -250,7 +250,9 @@ async def update_profile(
     )
 
     try:
-        profile_view = await service.update_profile(username, viewer_id=viewer_id, payload=payload)
+        profile_view, changes_applied = await service.update_profile(
+            username, viewer_id=viewer_id, payload=payload
+        )
     except ProfileError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
 
@@ -261,7 +263,14 @@ async def update_profile(
             "profile_view": profile_view,
             "profile": profile_view.profile,
             "viewer_query": _viewer_query_param(profile_view.viewer.id),
-            "feedback": {"status": "success", "message": "Profil berhasil diperbarui."},
+            "feedback": {
+                "status": "success" if changes_applied else "info",
+                "message": (
+                    "Profil berhasil diperbarui."
+                    if changes_applied
+                    else "Tidak ada perubahan yang disimpan."
+                ),
+            },
         }
         return templates.TemplateResponse(
             request,

--- a/src/app/api/routes/profile.py
+++ b/src/app/api/routes/profile.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 from typing import Dict
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from fastapi.responses import HTMLResponse
+from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, status
+from fastapi.responses import HTMLResponse, RedirectResponse
 
 from app.services.profile import (
     ProfileError,
     ProfileService,
+    ProfileUpdate,
     ProfileView,
     profile_service,
 )
@@ -168,3 +169,107 @@ async def profile_tab(
 
     template_name = TAB_TEMPLATES[tab]
     return templates.TemplateResponse(request, template_name, context)
+
+
+def _ensure_viewer(viewer: str | None) -> str:
+    if not viewer:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Viewer wajib diisi")
+    return viewer
+
+
+def _build_profile_update(
+    *,
+    full_name: str,
+    bio: str,
+    preferred_aroma: str,
+    avatar_url: str,
+    location: str,
+) -> ProfileUpdate:
+    name = full_name.strip()
+    if not name:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nama wajib diisi")
+
+    def _optional(value: str) -> str | None:
+        trimmed = value.strip()
+        return trimmed or None
+
+    return ProfileUpdate(
+        full_name=name,
+        bio=_optional(bio),
+        preferred_aroma=_optional(preferred_aroma),
+        avatar_url=_optional(avatar_url),
+        location=_optional(location),
+    )
+
+
+@router.get("/{username}/edit", response_class=HTMLResponse, name="profile_edit")
+async def edit_profile(
+    username: str,
+    request: Request,
+    viewer: str | None = Query(default=None),
+    service: ProfileService = Depends(get_profile_service),
+) -> HTMLResponse:
+    viewer_id = _ensure_viewer(viewer)
+    profile_view = await service.get_profile(username, viewer_id=viewer_id)
+    if not profile_view.viewer.is_owner:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Hanya pemilik profil yang dapat melakukan perubahan.",
+        )
+
+    templates = request.app.state.templates
+    context = {
+        "request": request,
+        "profile_view": profile_view,
+        "profile": profile_view.profile,
+        "viewer_query": _viewer_query_param(profile_view.viewer.id),
+        "feedback": None,
+    }
+    return templates.TemplateResponse(request, "pages/profile/edit.html", context)
+
+
+@router.api_route("/{username}", methods=["POST", "PATCH"], response_class=HTMLResponse, name="profile_update")
+async def update_profile(
+    username: str,
+    request: Request,
+    viewer: str | None = Query(default=None),
+    full_name: str = Form(...),
+    bio: str = Form(""),
+    location: str = Form(""),
+    preferred_aroma: str = Form(""),
+    avatar_url: str = Form(""),
+    service: ProfileService = Depends(get_profile_service),
+) -> HTMLResponse:
+    viewer_id = _ensure_viewer(viewer)
+    payload = _build_profile_update(
+        full_name=full_name,
+        bio=bio,
+        preferred_aroma=preferred_aroma,
+        avatar_url=avatar_url,
+        location=location,
+    )
+
+    try:
+        profile_view = await service.update_profile(username, viewer_id=viewer_id, payload=payload)
+    except ProfileError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+
+    if request.headers.get("hx-request"):
+        templates = request.app.state.templates
+        context = {
+            "request": request,
+            "profile_view": profile_view,
+            "profile": profile_view.profile,
+            "viewer_query": _viewer_query_param(profile_view.viewer.id),
+            "feedback": {"status": "success", "message": "Profil berhasil diperbarui."},
+        }
+        return templates.TemplateResponse(
+            request,
+            "components/profile/edit_form.html",
+            context,
+        )
+
+    redirect_url = request.url_for("profile_detail", username=profile_view.profile.username)
+    if profile_view.viewer.id:
+        redirect_url = f"{redirect_url}?{_viewer_query_param(profile_view.viewer.id)}"
+    return RedirectResponse(url=redirect_url, status_code=status.HTTP_303_SEE_OTHER)

--- a/src/app/services/profile.py
+++ b/src/app/services/profile.py
@@ -27,6 +27,27 @@ class ProfileNotFound(ProfileError):
     status_code = 404
 
 
+@dataclass(frozen=True)
+class ProfileUpdate:
+    """Payload for profile mutation submitted from the edit form."""
+
+    full_name: str
+    bio: Optional[str] = None
+    preferred_aroma: Optional[str] = None
+    avatar_url: Optional[str] = None
+    location: Optional[str] = None
+
+    def to_payload(self) -> Dict[str, Any]:
+        data = {
+            "full_name": self.full_name,
+            "bio": self.bio,
+            "preferred_aroma": self.preferred_aroma,
+            "avatar_url": self.avatar_url,
+            "location": self.location,
+        }
+        return data
+
+
 class ProfileGateway(Protocol):
     """Abstraction for profile persistence backed by Supabase."""
 
@@ -58,6 +79,9 @@ class ProfileGateway(Protocol):
         ...
 
     async def delete_follow(self, *, follower_id: str, following_id: str) -> None:
+        ...
+
+    async def update_profile(self, profile_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
         ...
 
 
@@ -318,6 +342,18 @@ class SupabaseProfileGateway(ProfileGateway):
         if response.status_code not in (200, 204):  # pragma: no cover - httpx raises elsewhere
             response.raise_for_status()
 
+    async def update_profile(self, profile_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        headers = {"Prefer": "return=representation", **self._headers}
+        params = {"id": f"eq.{profile_id}"}
+        response = await self._client.patch(
+            "/user_profiles", params=params, json=payload, headers=headers
+        )
+        response.raise_for_status()
+        data = response.json()
+        if isinstance(data, list):
+            return data[0] if data else {}
+        return data
+
 
 class InMemoryProfileGateway(ProfileGateway):
     """In-memory implementation used for local development and tests."""
@@ -385,6 +421,17 @@ class InMemoryProfileGateway(ProfileGateway):
     async def delete_follow(self, *, follower_id: str, following_id: str) -> None:
         self._followers.setdefault(following_id, set()).discard(follower_id)
         self._following.setdefault(follower_id, set()).discard(following_id)
+
+    async def update_profile(self, profile_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        profile = self._profiles.get(profile_id)
+        if not profile:
+            raise ProfileNotFound("Profil tidak ditemukan.")
+
+        username = profile.get("username")
+        profile.update(payload)
+        if username:
+            self._profiles_by_username[username] = profile
+        return dict(profile)
 
     async def reset_relationships(self) -> None:
         for profile_id, snapshot in self._initial_relationships.items():
@@ -639,6 +686,21 @@ class ProfileService:
             await self._gateway.delete_follow(follower_id=follower["id"], following_id=target["id"])
 
         return await self.get_profile(target["id"], viewer_id=follower["id"])
+
+    async def update_profile(
+        self, profile_identifier: str, *, viewer_id: str, payload: ProfileUpdate
+    ) -> ProfileView:
+        profile_data = await self._resolve_profile_data(profile_identifier)
+        viewer_data = await self._resolve_profile_data(viewer_id)
+
+        if profile_data["id"] != viewer_data["id"]:
+            raise ProfileError("Tidak memiliki akses untuk memperbarui profil ini.")
+
+        update_payload = payload.to_payload()
+        if update_payload:
+            await self._gateway.update_profile(profile_data["id"], update_payload)
+
+        return await self.get_profile(profile_data["id"], viewer_id=viewer_data["id"])
 
     async def list_followers(self, profile_identifier: str) -> List[ProfileRecord]:
         profile_data = await self._resolve_profile_data(profile_identifier)

--- a/src/app/web/static/css/profile.css
+++ b/src/app/web/static/css/profile.css
@@ -276,6 +276,12 @@
   border: 1px solid rgba(34, 197, 94, 0.35);
 }
 
+.profile-edit__feedback--info {
+  background: rgba(148, 163, 184, 0.12);
+  color: rgba(226, 232, 240, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
 .profile-edit__form {
   display: flex;
   flex-direction: column;

--- a/src/app/web/static/css/profile.css
+++ b/src/app/web/static/css/profile.css
@@ -199,6 +199,192 @@
   gap: 1.5rem;
 }
 
+.profile-edit-page {
+  display: flex;
+  justify-content: center;
+  padding: 2rem 0 4rem;
+}
+
+.profile-edit-page__shell {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: min(720px, 100%);
+}
+
+.profile-edit-page__back {
+  color: var(--accent-secondary);
+  text-decoration: none;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.profile-edit-page__back:focus,
+.profile-edit-page__back:hover {
+  text-decoration: underline;
+}
+
+.profile-edit {
+  padding: 2.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.profile-edit__header {
+  display: flex;
+  gap: 1.25rem;
+  align-items: center;
+}
+
+.profile-edit__avatar {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 2px solid rgba(148, 163, 184, 0.35);
+  flex-shrink: 0;
+}
+
+.profile-edit__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-edit__intro h1 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.profile-edit__intro p {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+}
+
+.profile-edit__feedback {
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-md);
+  font-weight: 500;
+}
+
+.profile-edit__feedback--success {
+  background: rgba(34, 197, 94, 0.12);
+  color: rgb(134, 239, 172);
+  border: 1px solid rgba(34, 197, 94, 0.35);
+}
+
+.profile-edit__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.profile-edit__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.profile-edit__field label {
+  font-weight: 600;
+}
+
+.profile-edit__field input,
+.profile-edit__field textarea {
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 1rem;
+  color: var(--text-primary);
+  font: inherit;
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+.profile-edit__field input:focus,
+.profile-edit__field textarea:focus {
+  border-color: var(--accent-secondary);
+  box-shadow: 0 0 0 3px rgba(192, 38, 211, 0.25);
+  outline: none;
+}
+
+.profile-edit__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.profile-edit__counter {
+  color: var(--muted);
+  display: block;
+}
+
+.profile-edit__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.profile-edit__submit {
+  background: var(--accent-primary);
+  color: #0f172a;
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+  box-shadow: 0 16px 30px rgba(192, 38, 211, 0.35);
+}
+
+.profile-edit__submit:hover {
+  transform: translateY(-1px);
+}
+
+.profile-edit__submit:focus-visible {
+  outline: 3px solid rgba(192, 38, 211, 0.6);
+  outline-offset: 2px;
+}
+
+.profile-edit__cancel {
+  color: var(--muted);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.profile-edit__cancel:focus,
+.profile-edit__cancel:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  .profile-edit {
+    padding: 1.75rem;
+  }
+
+  .profile-edit__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .profile-edit__avatar {
+    width: 96px;
+    height: 96px;
+  }
+
+  .profile-edit__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .profile-edit__cancel {
+    text-align: center;
+  }
+}
+
 .profile-tabs__nav {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));

--- a/src/app/web/templates/components/profile/edit_form.html
+++ b/src/app/web/templates/components/profile/edit_form.html
@@ -1,0 +1,91 @@
+<section class="profile-edit glass-panel" aria-labelledby="profile-edit-title">
+  <header class="profile-edit__header">
+    <div class="profile-edit__avatar">
+      <img src="{{ profile.avatar_url or '' }}" alt="Avatar {{ profile.full_name }}" />
+    </div>
+    <div class="profile-edit__intro">
+      <h1 id="profile-edit-title">Perbarui Profil</h1>
+      <p>Sesuaikan informasi yang tampil di halaman profil publikmu.</p>
+    </div>
+  </header>
+  {% if feedback %}
+    <div
+      class="profile-edit__feedback profile-edit__feedback--{{ feedback.status }}"
+      role="status"
+      aria-live="polite"
+    >
+      {{ feedback.message }}
+    </div>
+  {% endif %}
+  <form
+    id="profile-edit-form"
+    class="profile-edit__form"
+    action="{{ request.url_for('profile_update', username=profile.username) }}{% if viewer_query %}?{{ viewer_query }}{% endif %}"
+    method="post"
+    hx-patch="{{ request.url_for('profile_update', username=profile.username) }}{% if viewer_query %}?{{ viewer_query }}{% endif %}"
+    hx-target="#profile-edit-panel"
+    hx-swap="outerHTML"
+  >
+    <div class="profile-edit__field">
+      <label for="profile-full-name">Nama lengkap <span aria-hidden="true">*</span></label>
+      <input
+        id="profile-full-name"
+        name="full_name"
+        type="text"
+        required
+        value="{{ profile.full_name }}"
+        autocomplete="name"
+      />
+    </div>
+    <div class="profile-edit__field">
+      <label for="profile-bio">Bio singkat</label>
+      <textarea
+        id="profile-bio"
+        name="bio"
+        rows="4"
+        maxlength="280"
+        data-counter-target="#profile-bio-counter"
+      >{{ profile.bio }}</textarea>
+      <small id="profile-bio-counter" class="profile-edit__counter" aria-live="polite"></small>
+    </div>
+    <div class="profile-edit__grid">
+      <div class="profile-edit__field">
+        <label for="profile-location">Lokasi</label>
+        <input
+          id="profile-location"
+          name="location"
+          type="text"
+          value="{{ profile.location or '' }}"
+          autocomplete="address-level2"
+        />
+      </div>
+      <div class="profile-edit__field">
+        <label for="profile-aroma">Preferensi aroma</label>
+        <input
+          id="profile-aroma"
+          name="preferred_aroma"
+          type="text"
+          value="{{ profile.preferred_aroma or '' }}"
+        />
+      </div>
+    </div>
+    <div class="profile-edit__field">
+      <label for="profile-avatar">URL avatar</label>
+      <input
+        id="profile-avatar"
+        name="avatar_url"
+        type="url"
+        inputmode="url"
+        value="{{ profile.avatar_url or '' }}"
+        placeholder="https://"
+      />
+    </div>
+    <div class="profile-edit__actions">
+      <button type="submit" class="profile-edit__submit">Simpan perubahan</button>
+      <a
+        class="profile-edit__cancel"
+        href="{{ request.url_for('profile_detail', username=profile.username) }}{% if viewer_query %}?{{ viewer_query }}{% endif %}"
+      >Batal</a>
+    </div>
+  </form>
+</section>

--- a/src/app/web/templates/components/profile/follow_button.html
+++ b/src/app/web/templates/components/profile/follow_button.html
@@ -1,6 +1,11 @@
 <div id="profile-follow-button" class="profile-follow">
   {% if profile_view.viewer.is_owner %}
-    <a href="#" class="profile-follow__edit" aria-label="Edit profil">Edit Profil</a>
+    {% set edit_url = request.url_for('profile_edit', username=profile.username) %}
+    <a
+      href="{{ edit_url }}{% if viewer_query %}?{{ viewer_query }}{% endif %}"
+      class="profile-follow__edit"
+      aria-label="Edit profil {{ profile.full_name }}"
+    >Edit Profil</a>
   {% elif profile_view.viewer.is_following %}
     {% set unfollow_url = request.url_for('profile_unfollow', username=profile.username) %}
     <form

--- a/src/app/web/templates/pages/profile/edit.html
+++ b/src/app/web/templates/pages/profile/edit.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+
+{% block head_extra %}
+  {{ super() }}
+  <link rel="stylesheet" href="{{ url_for('static', path='css/profile.css') }}?{{ static_asset_query }}" />
+{% endblock %}
+
+{% block body_scripts %}
+  {{ super() }}
+  <script>
+    (function () {
+      function updateCounter(field) {
+        const selector = field.dataset.counterTarget;
+        if (!selector) {
+          return;
+        }
+        const target = document.querySelector(selector);
+        if (!target) {
+          return;
+        }
+        const maxLength = field.getAttribute("maxlength");
+        const current = field.value.length;
+        const label = maxLength ? `${current}/${maxLength} karakter` : `${current} karakter`;
+        target.textContent = label;
+      }
+
+      function primeCounters(root) {
+        if (!root || typeof root.querySelectorAll !== "function") {
+          return;
+        }
+        root.querySelectorAll("[data-counter-target]").forEach(function (field) {
+          updateCounter(field);
+        });
+      }
+
+      document.addEventListener("input", function (event) {
+        const field = event.target.closest("[data-counter-target]");
+        if (!field) {
+          return;
+        }
+        updateCounter(field);
+      });
+
+      primeCounters(document);
+
+      document.addEventListener("htmx:afterSwap", function (event) {
+        primeCounters(event.target);
+      });
+    })();
+  </script>
+{% endblock %}
+
+{% block content %}
+  <section class="profile-edit-page">
+    <div class="profile-edit-page__shell">
+      <a
+        class="profile-edit-page__back"
+        href="{{ request.url_for('profile_detail', username=profile.username) }}{% if viewer_query %}?{{ viewer_query }}{% endif %}"
+      >
+        ← Kembali ke profil
+      </a>
+      <div id="profile-edit-panel">
+        {% include 'components/profile/edit_form.html' %}
+      </div>
+    </div>
+  </section>
+{% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import Any, Dict, List
 
 import pytest
 
@@ -14,6 +14,7 @@ class FakeSupabaseProfileGateway(InMemoryProfileGateway):
         super().__init__()
         self.follow_writes: List[tuple[str, str]] = []
         self.unfollow_writes: List[tuple[str, str]] = []
+        self.profile_updates: List[Dict[str, Dict[str, Any]]] = []
 
     async def create_follow(self, *, follower_id: str, following_id: str) -> None:  # type: ignore[override]
         await super().create_follow(follower_id=follower_id, following_id=following_id)
@@ -23,10 +24,18 @@ class FakeSupabaseProfileGateway(InMemoryProfileGateway):
         await super().delete_follow(follower_id=follower_id, following_id=following_id)
         self.unfollow_writes.append((follower_id, following_id))
 
+    async def update_profile(  # type: ignore[override]
+        self, profile_id: str, payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        updated = await super().update_profile(profile_id, payload)
+        self.profile_updates.append({profile_id: payload})
+        return updated
+
     async def reset_relationships(self) -> None:  # type: ignore[override]
         await super().reset_relationships()
         self.follow_writes.clear()
         self.unfollow_writes.clear()
+        self.profile_updates.clear()
 
 
 @pytest.fixture

--- a/tests/test_profile_api.py
+++ b/tests/test_profile_api.py
@@ -187,3 +187,28 @@ def test_profile_update_submission_updates_gateway(
 
     view = asyncio.run(profile_service.get_profile("amelia-damayanti", viewer_id="user_amelia"))
     assert view.profile.bio == "Perfumer independen & mentor komunitas."
+
+
+def test_profile_update_submission_without_changes_skips_write(
+    profile_service: ProfileService, fake_profile_gateway: FakeSupabaseProfileGateway
+) -> None:
+    initial_view = asyncio.run(
+        profile_service.get_profile("amelia-damayanti", viewer_id="user_amelia")
+    )
+
+    status, body = request(
+        "PATCH",
+        "/profile/amelia-damayanti?viewer=user_amelia",
+        headers={"hx-request": "true"},
+        data={
+            "full_name": initial_view.profile.full_name,
+            "bio": initial_view.profile.bio,
+            "location": initial_view.profile.location or "",
+            "preferred_aroma": initial_view.profile.preferred_aroma or "",
+            "avatar_url": initial_view.profile.avatar_url or "",
+        },
+    )
+
+    assert status == 200
+    assert "Tidak ada perubahan" in body
+    assert fake_profile_gateway.profile_updates == []

--- a/tests/test_profile_api.py
+++ b/tests/test_profile_api.py
@@ -1,5 +1,6 @@
 import asyncio
-from urllib.parse import urlsplit
+from typing import Any, Dict
+from urllib.parse import urlencode, urlsplit
 
 import pytest
 
@@ -9,7 +10,12 @@ from app.services.profile import ProfileService
 from tests.conftest import FakeSupabaseProfileGateway
 
 
-async def _request(method: str, raw_path: str, headers: dict[str, str] | None = None) -> tuple[int, str]:
+async def _request(
+    method: str,
+    raw_path: str,
+    headers: dict[str, str] | None = None,
+    body: bytes | None = None,
+) -> tuple[int, str]:
     parsed = urlsplit(raw_path)
     scope = {
         "type": "http",
@@ -31,8 +37,15 @@ async def _request(method: str, raw_path: str, headers: dict[str, str] | None = 
 
     messages: list[dict] = []
 
+    body_bytes = body or b""
+    body_sent = False
+
     async def receive() -> dict:
-        return {"type": "http.request", "body": b"", "more_body": False}
+        nonlocal body_sent
+        if body_sent:
+            return {"type": "http.request", "body": b"", "more_body": False}
+        body_sent = True
+        return {"type": "http.request", "body": body_bytes, "more_body": False}
 
     async def send(message: dict) -> None:
         messages.append(message)
@@ -50,8 +63,18 @@ async def _request(method: str, raw_path: str, headers: dict[str, str] | None = 
     return status, body.decode()
 
 
-def request(method: str, raw_path: str, headers: dict[str, str] | None = None) -> tuple[int, str]:
-    return asyncio.run(_request(method, raw_path, headers))
+def request(
+    method: str,
+    raw_path: str,
+    headers: dict[str, str] | None = None,
+    data: Dict[str, Any] | None = None,
+) -> tuple[int, str]:
+    encoded_body: bytes | None = None
+    prepared_headers = dict(headers or {})
+    if data is not None:
+        encoded_body = urlencode(data, doseq=True).encode()
+        prepared_headers.setdefault("content-type", "application/x-www-form-urlencoded")
+    return asyncio.run(_request(method, raw_path, prepared_headers, encoded_body))
 
 
 @pytest.fixture
@@ -120,3 +143,47 @@ def test_followers_modal_lists_profiles(profile_service: ProfileService) -> None
 
     assert status == 200
     assert "Bintang Waskita" in body
+
+
+def test_profile_edit_page_requires_owner(profile_service: ProfileService) -> None:
+    status, body = request(
+        "GET",
+        "/profile/amelia-damayanti/edit?viewer=user_bintang",
+    )
+
+    assert status == 403
+    assert "pemilik" in body
+
+
+def test_profile_edit_page_renders_form(profile_service: ProfileService) -> None:
+    status, body = request("GET", "/profile/amelia-damayanti/edit?viewer=user_amelia")
+
+    assert status == 200
+    assert "Perbarui Profil" in body
+    assert "name=\"full_name\"" in body
+
+
+def test_profile_update_submission_updates_gateway(
+    profile_service: ProfileService, fake_profile_gateway: FakeSupabaseProfileGateway
+) -> None:
+    status, body = request(
+        "PATCH",
+        "/profile/amelia-damayanti?viewer=user_amelia",
+        headers={"hx-request": "true"},
+        data={
+            "full_name": "Amelia Damayanti",
+            "bio": "Perfumer independen & mentor komunitas.",
+            "location": "Bandung, Indonesia",
+            "preferred_aroma": "Rempah hangat",
+            "avatar_url": "https://example.com/avatar.jpg",
+        },
+    )
+
+    assert status == 200
+    assert "Profil berhasil diperbarui" in body
+    assert any(
+        update.get("user_amelia") for update in fake_profile_gateway.profile_updates
+    ), "Update payload should be recorded"
+
+    view = asyncio.run(profile_service.get_profile("amelia-damayanti", viewer_id="user_amelia"))
+    assert view.profile.bio == "Perfumer independen & mentor komunitas."


### PR DESCRIPTION
## Summary
- add profile update payload handling to the profile service and gateways
- expose profile edit and update routes with HTMX-friendly responses and templates
- style the profile edit form and cover the workflow with API tests

## Testing
- pytest tests/test_profile_api.py

------
https://chatgpt.com/codex/tasks/task_e_68dddbc377b08327bacb74c18f5d2593