### PR TITLE
Refine brand management form experience

### DIFF
--- a/src/app/api/routes/brands.py
+++ b/src/app/api/routes/brands.py
@@ -1,13 +1,402 @@
 """Routes for the brand storefront experience."""
 
-from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import HTMLResponse
+from __future__ import annotations
+
+import secrets
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping
+
+from fastapi import APIRouter, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, RedirectResponse
 
 from app.core.config import get_settings
-from app.services.brands import BrandNotFound, brand_service
+from app.services.brands import (
+    Brand,
+    BrandAlreadyExists,
+    BrandError,
+    BrandNotFound,
+    brand_service,
+)
 
 
 router = APIRouter()
+
+
+def _render_brand_form(
+    request: Request,
+    *,
+    title: str,
+    form_action: str,
+    form_state: Dict[str, Any],
+    errors: Dict[str, List[str]] | None = None,
+    brand: Brand | None = None,
+    status_code: int = status.HTTP_200_OK,
+    is_edit: bool = False,
+) -> HTMLResponse:
+    templates = request.app.state.templates
+    settings = get_settings()
+    context = {
+        "request": request,
+        "app_name": settings.app_name,
+        "environment": settings.environment,
+        "title": title,
+        "form_action": form_action,
+        "form_state": form_state,
+        "errors": errors or {},
+        "brand": brand,
+        "is_edit": is_edit,
+    }
+    return templates.TemplateResponse(
+        request,
+        "pages/brand/form.html",
+        context,
+        status_code=status_code,
+    )
+
+
+def _empty_member() -> Dict[str, str]:
+    return {
+        "profile_id": "",
+        "full_name": "",
+        "username": "",
+        "role": "co-owner",
+        "status": "pending",
+        "avatar_url": "",
+        "expertise": "",
+        "invited_by": "",
+    }
+
+
+def _default_form_state() -> Dict[str, Any]:
+    member = _empty_member()
+    member.update({"role": "owner", "status": "active"})
+    return {
+        "name": "",
+        "slug": "",
+        "tagline": "",
+        "summary": "",
+        "origin_city": "",
+        "established_year": "",
+        "hero_image_url": "",
+        "logo_url": "",
+        "aroma_focus": "",
+        "story_points": "",
+        "is_verified": False,
+        "members": [member],
+    }
+
+
+def _form_state_from_brand(brand: Brand) -> Dict[str, Any]:
+    return {
+        "name": brand.name,
+        "slug": brand.slug,
+        "tagline": brand.tagline,
+        "summary": brand.summary,
+        "origin_city": brand.origin_city,
+        "established_year": str(brand.established_year),
+        "hero_image_url": brand.hero_image_url,
+        "logo_url": brand.logo_url or "",
+        "aroma_focus": "\n".join(brand.aroma_focus),
+        "story_points": "\n".join(brand.story_points),
+        "is_verified": brand.is_verified,
+        "members": [
+            {
+                "profile_id": member.profile_id,
+                "full_name": member.full_name,
+                "username": member.username,
+                "role": member.role,
+                "status": member.status,
+                "avatar_url": member.avatar_url or "",
+                "expertise": member.expertise or "",
+                "invited_by": member.invited_by or "",
+            }
+            for member in brand.members
+        ],
+    }
+
+
+def _extract_member_indexes(form: Mapping[str, Any]) -> List[str]:
+    indexes: set[str] = set()
+    for key in form.keys():
+        if not key.startswith("members-"):
+            continue
+        parts = key.split("-")
+        if len(parts) >= 3:
+            indexes.add(parts[1])
+    return sorted(indexes, key=lambda value: int(value) if value.isdigit() else value)
+
+
+def _parse_members(
+    form: Mapping[str, Any],
+) -> tuple[List[Dict[str, Any]], List[Dict[str, str]], List[str]]:
+    payloads: List[Dict[str, Any]] = []
+    raw_members: List[Dict[str, str]] = []
+    errors: List[str] = []
+    indexes = _extract_member_indexes(form)
+
+    for index in indexes:
+        prefix = f"members-{index}-"
+        raw_member: Dict[str, str] = {
+            "profile_id": (form.get(prefix + "profile_id", "") or "").strip(),
+            "full_name": (form.get(prefix + "full_name", "") or ""),
+            "username": (form.get(prefix + "username", "") or ""),
+            "role": (form.get(prefix + "role", "") or ""),
+            "status": (form.get(prefix + "status", "") or ""),
+            "avatar_url": (form.get(prefix + "avatar_url", "") or ""),
+            "expertise": (form.get(prefix + "expertise", "") or ""),
+            "invited_by": (form.get(prefix + "invited_by", "") or ""),
+        }
+        raw_members.append(raw_member)
+
+        meaningful = any((raw_member[key] or "").strip() for key in ("profile_id", "full_name", "username"))
+        if not meaningful:
+            continue
+
+        full_name = raw_member["full_name"].strip()
+        username = raw_member["username"].strip()
+        if not full_name or not username:
+            errors.append(f"Data member #{int(index) + 1 if index.isdigit() else index} belum lengkap.")
+            continue
+
+        payloads.append(
+            {
+                "profile_id": raw_member["profile_id"],
+                "full_name": full_name,
+                "username": username,
+                "role": raw_member["role"].strip() or ("owner" if not payloads else "co-owner"),
+                "status": raw_member["status"].strip() or ("active" if not payloads else "pending"),
+                "avatar_url": raw_member["avatar_url"],
+                "expertise": raw_member["expertise"],
+                "invited_by": raw_member["invited_by"],
+            }
+        )
+
+    return payloads, raw_members, errors
+
+
+def _form_state_from_submission(
+    form: Mapping[str, Any],
+    *,
+    fallback_slug: str | None = None,
+    default_members: Iterable[Dict[str, str]] | None = None,
+) -> Dict[str, Any]:
+    members = list(default_members or [])
+    _, raw_members, _ = _parse_members(form)
+    if raw_members:
+        members = raw_members
+
+    def _get(key: str, default: str = "") -> str:
+        value = form.get(key)
+        if value is None:
+            return default
+        return str(value)
+
+    return {
+        "name": _get("name"),
+        "slug": _get("slug", fallback_slug or "") or (fallback_slug or ""),
+        "tagline": _get("tagline"),
+        "summary": _get("summary"),
+        "origin_city": _get("origin_city"),
+        "established_year": _get("established_year"),
+        "hero_image_url": _get("hero_image_url"),
+        "logo_url": _get("logo_url"),
+        "aroma_focus": _get("aroma_focus"),
+        "story_points": _get("story_points"),
+        "is_verified": bool(form.get("is_verified")),
+        "members": members if members else list(default_members or []),
+    }
+
+
+def _split_to_list(value: str) -> List[str]:
+    pieces: List[str] = []
+    for line in value.splitlines():
+        for part in line.split(","):
+            cleaned = part.strip()
+            if cleaned:
+                pieces.append(cleaned)
+    return pieces
+
+
+def _normalise_errors(raw_errors: Mapping[str, Iterable[str]]) -> Dict[str, List[str]]:
+    result: Dict[str, List[str]] = {}
+    for field, messages in raw_errors.items():
+        result[field] = list(messages)
+    return result
+
+
+@router.get("/brands/new", response_class=HTMLResponse, name="new_brand")
+async def new_brand(request: Request) -> HTMLResponse:
+    form_state = _default_form_state()
+    return _render_brand_form(
+        request,
+        title="Buat Brand Baru",
+        form_action="/brands",
+        form_state=form_state,
+    )
+
+
+@router.get("/brands/{slug}/edit", response_class=HTMLResponse, name="edit_brand")
+async def edit_brand(request: Request, slug: str) -> HTMLResponse:
+    try:
+        brand = brand_service.get_brand(slug)
+    except BrandNotFound as exc:  # pragma: no cover - handled by exception mapping
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    form_state = _form_state_from_brand(brand)
+    return _render_brand_form(
+        request,
+        title=f"Edit Brand {brand.name}",
+        form_action=f"/brands/{brand.slug}",
+        form_state=form_state,
+        brand=brand,
+        is_edit=True,
+    )
+
+
+def _handle_members_update(
+    *,
+    brand_slug: str,
+    member_payloads: List[Dict[str, Any]],
+) -> None:
+    if not member_payloads:
+        raise BrandError("Minimal satu member brand wajib tersedia.")
+    brand_service.update_members(brand_slug, members=member_payloads)
+
+
+def _create_brand_from_form(form: Mapping[str, Any]) -> Brand:
+    member_payloads, _, member_errors = _parse_members(form)
+    if member_errors:
+        raise BrandError("; ".join(member_errors))
+    owner = next((member for member in member_payloads if member.get("role") == "owner"), None)
+    if not owner:
+        raise BrandError("Minimal satu owner brand aktif wajib diisi.")
+
+    brand = brand_service.create_brand(
+        owner_profile_id=owner.get("profile_id") or secrets.token_urlsafe(6),
+        owner_name=owner["full_name"],
+        owner_username=owner["username"],
+        owner_avatar=owner.get("avatar_url") or None,
+        name=str(form.get("name", "")),
+        slug=str(form.get("slug") or ""),
+        tagline=str(form.get("tagline", "")),
+        summary=str(form.get("summary", "")),
+        origin_city=str(form.get("origin_city", "")),
+        established_year=str(form.get("established_year", "")),
+        hero_image_url=str(form.get("hero_image_url", "")),
+        logo_url=str(form.get("logo_url") or "") or None,
+        aroma_focus=_split_to_list(str(form.get("aroma_focus", ""))),
+        story_points=_split_to_list(str(form.get("story_points", ""))),
+        is_verified=bool(form.get("is_verified")),
+    )
+
+    _handle_members_update(brand_slug=brand.slug, member_payloads=member_payloads)
+    return brand
+
+
+def _update_brand_from_form(form: Mapping[str, Any], *, slug: str) -> Brand:
+    member_payloads, _, member_errors = _parse_members(form)
+    if member_errors:
+        raise BrandError("; ".join(member_errors))
+
+    brand = brand_service.update_brand(
+        slug,
+        name=str(form.get("name", "")),
+        slug=str(form.get("slug") or ""),
+        tagline=str(form.get("tagline", "")),
+        summary=str(form.get("summary", "")),
+        origin_city=str(form.get("origin_city", "")),
+        established_year=str(form.get("established_year", "")),
+        hero_image_url=str(form.get("hero_image_url", "")),
+        logo_url=str(form.get("logo_url") or "") or None,
+        aroma_focus=_split_to_list(str(form.get("aroma_focus", ""))),
+        story_points=_split_to_list(str(form.get("story_points", ""))),
+        is_verified=bool(form.get("is_verified")),
+    )
+
+    _handle_members_update(brand_slug=brand.slug, member_payloads=member_payloads)
+    return brand
+
+
+@router.post("/brands", response_class=HTMLResponse, name="create_brand")
+async def create_brand(request: Request) -> HTMLResponse:
+    form = await request.form()
+    errors: MutableMapping[str, List[str]] = {}
+    form_state = _form_state_from_submission(form, default_members=_default_form_state()["members"])
+
+    try:
+        brand = _create_brand_from_form(form)
+    except BrandAlreadyExists as exc:
+        errors.setdefault("slug", []).append(str(exc))
+    except BrandError as exc:
+        errors.setdefault("__all__", []).append(str(exc))
+    else:
+        location = f"/brands/{brand.slug}"
+        return RedirectResponse(url=location, status_code=status.HTTP_303_SEE_OTHER)
+
+    return _render_brand_form(
+        request,
+        title="Buat Brand Baru",
+        form_action="/brands",
+        form_state=form_state,
+        errors=_normalise_errors(errors),
+        status_code=status.HTTP_400_BAD_REQUEST,
+    )
+
+
+@router.api_route(
+    "/brands/{slug}",
+    methods=["POST", "PATCH"],
+    response_class=HTMLResponse,
+    name="update_brand",
+)
+async def update_brand(request: Request, slug: str) -> HTMLResponse:
+    form = await request.form()
+    errors: MutableMapping[str, List[str]] = {}
+
+    try:
+        existing_brand = brand_service.get_brand(slug)
+    except BrandNotFound as exc:  # pragma: no cover - handled upstream
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    fallback_members = [
+        {
+            "profile_id": member.profile_id,
+            "full_name": member.full_name,
+            "username": member.username,
+            "role": member.role,
+            "status": member.status,
+            "avatar_url": member.avatar_url or "",
+            "expertise": member.expertise or "",
+            "invited_by": member.invited_by or "",
+        }
+        for member in existing_brand.members
+    ]
+
+    form_state = _form_state_from_submission(
+        form,
+        fallback_slug=existing_brand.slug,
+        default_members=fallback_members,
+    )
+
+    try:
+        brand = _update_brand_from_form(form, slug=slug)
+    except BrandAlreadyExists as exc:
+        errors.setdefault("slug", []).append(str(exc))
+    except BrandError as exc:
+        errors.setdefault("__all__", []).append(str(exc))
+    else:
+        location = f"/brands/{brand.slug}?updated=1"
+        return RedirectResponse(url=location, status_code=status.HTTP_303_SEE_OTHER)
+
+    return _render_brand_form(
+        request,
+        title=f"Edit Brand {existing_brand.name}",
+        form_action=f"/brands/{existing_brand.slug}",
+        form_state=form_state,
+        errors=_normalise_errors(errors),
+        brand=existing_brand,
+        is_edit=True,
+        status_code=status.HTTP_400_BAD_REQUEST,
+    )
 
 
 @router.get("/brands/{slug}", response_class=HTMLResponse)
@@ -23,6 +412,7 @@ async def read_brand(request: Request, slug: str) -> HTMLResponse:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
     context = {
+        "request": request,
         "app_name": settings.app_name,
         "environment": settings.environment,
         "title": brand.name,
@@ -40,6 +430,7 @@ async def list_brands(request: Request) -> HTMLResponse:
     brands = list(brand_service.list_brands())
 
     context = {
+        "request": request,
         "app_name": settings.app_name,
         "environment": settings.environment,
         "title": "Brand Partner",

--- a/src/app/web/static/css/brand.css
+++ b/src/app/web/static/css/brand.css
@@ -198,6 +198,333 @@
   font-weight: 500;
 }
 
+/* -------------------------------------------------------------------------- */
+/* Brand form experience                                                      */
+/* -------------------------------------------------------------------------- */
+
+.brand-form-page {
+  padding: 3rem 0 5rem;
+  display: flex;
+  justify-content: center;
+}
+
+.brand-form-shell {
+  width: min(1120px, 100%);
+  padding: 2.5rem clamp(1.5rem, 4vw, 3rem);
+  display: grid;
+  gap: 2.5rem;
+}
+
+.brand-form-header {
+  display: grid;
+  gap: 1rem;
+}
+
+.brand-form-header__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.brand-form-back {
+  color: rgba(148, 163, 184, 0.9);
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+.brand-form-back:hover {
+  color: #f8fafc;
+}
+
+.brand-form-chip {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(148, 163, 184, 0.12);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.brand-form-header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.75rem);
+}
+
+.brand-form-header p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.82);
+  line-height: 1.7;
+}
+
+.brand-form-progress {
+  display: flex;
+  gap: 0.5rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  flex-wrap: wrap;
+}
+
+.brand-form-progress__item {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.brand-form-progress__item--active {
+  border-style: solid;
+  background: rgba(59, 130, 246, 0.18);
+  border-color: rgba(59, 130, 246, 0.45);
+  color: #bfdbfe;
+}
+
+.brand-form-errors {
+  background: rgba(248, 113, 113, 0.08);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.brand-form-errors h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #fecaca;
+}
+
+.brand-form-errors ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #fecaca;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.brand-form {
+  display: grid;
+  gap: 2rem;
+}
+
+.brand-form-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(260px, 0.8fr);
+  gap: clamp(2rem, 4vw, 3rem);
+}
+
+.brand-form-main {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.brand-form-section {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 1.5rem;
+  padding: clamp(1.5rem, 3vw, 2rem);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.65), rgba(15, 23, 42, 0.5));
+  display: grid;
+  gap: 1.5rem;
+}
+
+.brand-form-section legend {
+  font-size: 1.2rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.brand-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.25rem 1.5rem;
+}
+
+.brand-form-field {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.brand-form-field span {
+  font-weight: 500;
+}
+
+.brand-form-field input,
+.brand-form-field textarea,
+.brand-form-field select {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.75);
+  color: inherit;
+  font: inherit;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.brand-form-field input:focus,
+.brand-form-field textarea:focus,
+.brand-form-field select:focus {
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.55);
+  background: rgba(30, 41, 59, 0.85);
+}
+
+.brand-form-full {
+  grid-column: 1 / -1;
+}
+
+.brand-form-hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.brand-form-checkbox {
+  align-items: center;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+}
+
+.brand-form-checkbox input {
+  width: auto;
+  transform: scale(1.1);
+}
+
+.brand-form-intro {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.78);
+}
+
+.brand-member-list {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.brand-member-card {
+  position: relative;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.6);
+  display: grid;
+  gap: 1rem;
+}
+
+.brand-member-card legend {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.brand-member-remove {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  opacity: 0.8;
+}
+
+.brand-member-remove--hidden {
+  visibility: hidden;
+}
+
+.brand-member-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem 1.25rem;
+}
+
+.brand-member-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.brand-form-sidebar {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.brand-form-card {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1.25rem;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  background: rgba(15, 23, 42, 0.55);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.brand-form-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.brand-form-card p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.brand-form-card--tips ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.45rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.brand-form-sidebar-actions {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.brand-form-actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.brand-form-actions .button {
+  min-width: 180px;
+}
+
+.input-error {
+  border-color: rgba(248, 113, 113, 0.8) !important;
+  background: rgba(248, 113, 113, 0.12) !important;
+}
+
+@media (max-width: 1024px) {
+  .brand-form-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .brand-form-sidebar {
+    order: -1;
+  }
+}
+
+@media (max-width: 720px) {
+  .brand-form-grid,
+  .brand-member-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .brand-form-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .brand-form-actions .button {
+    width: 100%;
+  }
+}
+
 .chip-owner {
   background: rgba(59, 130, 246, 0.14);
   border-color: rgba(59, 130, 246, 0.45);

--- a/src/app/web/templates/pages/brand/detail.html
+++ b/src/app/web/templates/pages/brand/detail.html
@@ -70,8 +70,9 @@
         {% endif %}
       </dl>
       <div class="brand-cta">
-        <a class="button" href="/marketplace">Lihat katalog marketplace</a>
-        <a class="button button-secondary" href="/brands">Brand lainnya</a>
+        <a class="button" href="{{ request.url_for('edit_brand', slug=brand.slug) }}">Kelola brand</a>
+        <a class="button button-secondary" href="/marketplace">Lihat katalog marketplace</a>
+        <a class="button button-ghost" href="/brands">Brand lainnya</a>
       </div>
     </div>
   </header>

--- a/src/app/web/templates/pages/brand/form.html
+++ b/src/app/web/templates/pages/brand/form.html
@@ -1,0 +1,439 @@
+{% extends 'base.html' %}
+
+{% block head_extra %}
+  {{ super() }}
+  <link rel="stylesheet" href="{{ url_for('static', path='css/brand.css') }}?{{ static_asset_query }}" />
+{% endblock %}
+
+{% block content %}
+  <section class="brand-form-page">
+    <div class="brand-form-shell glass-card">
+      <header class="brand-form-header">
+        <div class="brand-form-header__top">
+          <a class="brand-form-back" href="{{ url_for('list_brands') }}">← Kembali ke direktori brand</a>
+          <span class="brand-form-chip">Brand Partner Studio</span>
+        </div>
+        <h1>{{ 'Edit Brand' if is_edit else 'Buat Brand Baru' }}</h1>
+        <p>
+          Susun identitas brand, narasi utama, visual hero, hingga kolaborator yang aktif mengelola etalase kamu.
+          Lengkapi informasi berikut agar halaman publik brand terasa hangat dan profesional.
+        </p>
+        <ol class="brand-form-progress" role="list">
+          <li class="brand-form-progress__item brand-form-progress__item--active">Identitas</li>
+          <li class="brand-form-progress__item">Narasi</li>
+          <li class="brand-form-progress__item">Kolaborator</li>
+          <li class="brand-form-progress__item">Publikasi</li>
+        </ol>
+      </header>
+
+      {% if errors %}
+        <div class="brand-form-errors" role="alert">
+          <h2>Perlu diperbaiki sebelum lanjut</h2>
+          <ul>
+            {% for field, messages in errors.items() %}
+              {% for message in messages %}
+                <li>{{ message }}</li>
+              {% endfor %}
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+
+      <form id="brand-form" class="brand-form" method="post" action="{{ form_action }}" novalidate>
+        <div class="brand-form-layout">
+          <div class="brand-form-main">
+            <fieldset class="brand-form-section">
+              <legend>Identitas Brand</legend>
+              <div class="brand-form-grid">
+                <label class="brand-form-field">
+                  <span>Nama brand</span>
+                  <input type="text" name="name" value="{{ form_state.name }}" placeholder="Misal: Langit Senja" required data-brand-name />
+                </label>
+                <label class="brand-form-field">
+                  <span>Slug (tautan)</span>
+                  <input type="text" name="slug" value="{{ form_state.slug }}" placeholder="contoh: langit-senja" required data-brand-slug aria-describedby="brand-slug-help" />
+                  <small id="brand-slug-help" class="brand-form-hint">Slug akan tampil pada URL /brands/slug. Gunakan huruf kecil dan tanda hubung.</small>
+                </label>
+                <label class="brand-form-field">
+                  <span>Tagline singkat</span>
+                  <input type="text" name="tagline" value="{{ form_state.tagline }}" maxlength="140" placeholder="Kalimat singkat yang mewakili brand" required data-counter-target="#tagline-counter" />
+                  <small id="tagline-counter" class="brand-form-hint"></small>
+                </label>
+                <label class="brand-form-field">
+                  <span>Kota asal</span>
+                  <input type="text" name="origin_city" value="{{ form_state.origin_city }}" placeholder="Misal: Bandung, Indonesia" required />
+                </label>
+                <label class="brand-form-field">
+                  <span>Tahun berdiri</span>
+                  <input type="number" name="established_year" value="{{ form_state.established_year }}" min="1900" max="2100" placeholder="YYYY" required />
+                </label>
+                <label class="brand-form-field">
+                  <span>URL hero image</span>
+                  <input type="url" name="hero_image_url" value="{{ form_state.hero_image_url }}" placeholder="https://" required />
+                  <small class="brand-form-hint">Pilih gambar horizontal terbaik untuk banner halaman brand.</small>
+                </label>
+                <label class="brand-form-field">
+                  <span>URL logo brand</span>
+                  <input type="url" name="logo_url" value="{{ form_state.logo_url }}" placeholder="https://" data-logo-field />
+                </label>
+                <label class="brand-form-field brand-form-checkbox">
+                  <input type="checkbox" name="is_verified" value="1" {% if form_state.is_verified %}checked{% endif %} />
+                  <span>Tandai brand sebagai terverifikasi</span>
+                </label>
+              </div>
+            </fieldset>
+
+            <fieldset class="brand-form-section">
+              <legend>Narasi &amp; Karakter</legend>
+              <div class="brand-form-grid">
+                <label class="brand-form-field brand-form-full">
+                  <span>Ringkasan brand</span>
+                  <textarea name="summary" rows="4" placeholder="Ceritakan misi utama dan keunikan brand" required data-counter-target="#summary-counter">{{ form_state.summary }}</textarea>
+                  <small id="summary-counter" class="brand-form-hint"></small>
+                </label>
+                <label class="brand-form-field brand-form-full">
+                  <span>Fokus aroma (pisahkan dengan koma atau baris baru)</span>
+                  <textarea name="aroma_focus" rows="3" placeholder="Contoh: Rempah hangat, Floral tropis">{{ form_state.aroma_focus }}</textarea>
+                </label>
+                <label class="brand-form-field brand-form-full">
+                  <span>Story points (satu poin per baris)</span>
+                  <textarea name="story_points" rows="4" placeholder="Bagikan highlight perjalanan brand">{{ form_state.story_points }}</textarea>
+                </label>
+              </div>
+            </fieldset>
+
+            <fieldset class="brand-form-section" id="brand-members">
+              <legend>Tim &amp; Kolaborator</legend>
+              <p class="brand-form-intro">Tambahkan owner aktif dan co-owner brand. Baris pertama dianjurkan untuk owner utama.</p>
+              <div class="brand-member-list" data-member-list>
+                {% for member in form_state.members %}
+                  {% set index = loop.index0 %}
+                  <fieldset class="brand-member-card" data-member-row data-member-index="{{ index }}">
+                    <legend>Anggota #{{ loop.index }}</legend>
+                    <button type="button" class="brand-member-remove button button-ghost button-small" data-remove-member aria-label="Hapus anggota #{{ loop.index }}">Hapus</button>
+                    <div class="brand-member-grid">
+                      <label>
+                        <span>Nama lengkap</span>
+                        <input type="text" name="members-{{ index }}-full_name" data-field-name="full_name" value="{{ member.full_name }}" placeholder="Misal: Sinta Prameswari" />
+                      </label>
+                      <label>
+                        <span>Username</span>
+                        <input type="text" name="members-{{ index }}-username" data-field-name="username" value="{{ member.username }}" placeholder="contoh: sinta-prameswari" />
+                      </label>
+                      <label>
+                        <span>Role</span>
+                        <select name="members-{{ index }}-role" data-field-name="role">
+                          <option value="owner" {% if member.role == 'owner' %}selected{% endif %}>Owner</option>
+                          <option value="co-owner" {% if member.role == 'co-owner' %}selected{% endif %}>Co-owner</option>
+                          <option value="team" {% if member.role == 'team' %}selected{% endif %}>Tim</option>
+                        </select>
+                      </label>
+                      <label>
+                        <span>Status</span>
+                        <select name="members-{{ index }}-status" data-field-name="status">
+                          <option value="active" {% if member.status == 'active' %}selected{% endif %}>Aktif</option>
+                          <option value="pending" {% if member.status == 'pending' %}selected{% endif %}>Pending</option>
+                          <option value="inactive" {% if member.status == 'inactive' %}selected{% endif %}>Non-aktif</option>
+                        </select>
+                      </label>
+                      <label>
+                        <span>Profile ID</span>
+                        <input type="text" name="members-{{ index }}-profile_id" data-field-name="profile_id" value="{{ member.profile_id }}" placeholder="Otomatis jika dikosongkan" />
+                      </label>
+                      <label>
+                        <span>Avatar URL</span>
+                        <input type="url" name="members-{{ index }}-avatar_url" data-field-name="avatar_url" value="{{ member.avatar_url }}" placeholder="https://" />
+                      </label>
+                      <label>
+                        <span>Keahlian / catatan</span>
+                        <input type="text" name="members-{{ index }}-expertise" data-field-name="expertise" value="{{ member.expertise }}" placeholder="Misal: Kurator komunitas" />
+                      </label>
+                      <label>
+                        <span>Diundang oleh</span>
+                        <input type="text" name="members-{{ index }}-invited_by" data-field-name="invited_by" value="{{ member.invited_by }}" placeholder="Nama pengundang" />
+                      </label>
+                    </div>
+                  </fieldset>
+                {% endfor %}
+              </div>
+              <div class="brand-member-actions">
+                <button type="button" class="button button-secondary" data-add-member>Undang kolaborator</button>
+                <p class="brand-form-hint">Kolaborator baru otomatis berstatus pending hingga disetujui.</p>
+              </div>
+            </fieldset>
+          </div>
+
+          <aside class="brand-form-sidebar">
+            <section class="brand-form-card brand-form-card--actions">
+              <h3>Quick actions</h3>
+              <p>Gunakan tombol berikut untuk mengisi bagian penting tanpa menggulir terlalu jauh.</p>
+              <div class="brand-form-sidebar-actions">
+                <button type="button" class="button button-secondary" data-focus-logo>Unggah logo</button>
+                <button type="button" class="button button-secondary" data-jump-members>Kelola co-owner</button>
+                {% if brand %}
+                  <a class="button button-ghost" href="{{ url_for('read_brand', slug=brand.slug) }}">Lihat halaman brand</a>
+                {% endif %}
+              </div>
+            </section>
+            <section class="brand-form-card brand-form-card--tips">
+              <h3>Tips pengisian</h3>
+              <ul>
+                <li>Gunakan tagline maksimal 140 karakter agar tetap mudah diingat.</li>
+                <li>Story points membantu calon kolaborator mengenal perjalanan brand.</li>
+                <li>Pastikan ada minimal satu owner aktif untuk menjaga kredibilitas.</li>
+              </ul>
+            </section>
+          </aside>
+        </div>
+
+        <footer class="brand-form-actions">
+          <button type="submit" class="button">Simpan perubahan</button>
+          <a class="button button-ghost" href="{{ url_for('list_brands') }}">Batal</a>
+        </footer>
+      </form>
+    </div>
+  </section>
+{% endblock %}
+
+{% block body_scripts %}
+  {{ super() }}
+  <script>
+    (function () {
+      const form = document.getElementById("brand-form");
+      if (!form) {
+        return;
+      }
+
+      function normaliseSlug(value) {
+        return value
+          .toLowerCase()
+          .normalize("NFD")
+          .replace(/[^\w\s-]/g, "")
+          .replace(/\s+/g, "-")
+          .replace(/-+/g, "-")
+          .replace(/^-+|-+$/g, "");
+      }
+
+      const nameField = form.querySelector("[data-brand-name]");
+      const slugField = form.querySelector("[data-brand-slug]");
+      const slugHint = document.getElementById("brand-slug-help");
+      const slugHintDefault = slugHint ? slugHint.textContent : "";
+      let slugTouched = slugField && slugField.value.trim().length > 0;
+
+      if (slugField) {
+        slugField.addEventListener("input", function () {
+          slugTouched = slugField.value.trim().length > 0;
+          slugField.classList.remove("input-error");
+          if (slugHint) {
+            slugHint.textContent = slugHintDefault;
+          }
+        });
+      }
+
+      if (nameField && slugField) {
+        nameField.addEventListener("input", function () {
+          if (slugTouched) {
+            return;
+          }
+          slugField.value = normaliseSlug(nameField.value);
+        });
+      }
+
+      form.addEventListener("submit", function (event) {
+        if (!slugField) {
+          return;
+        }
+        const slugValue = slugField.value.trim();
+        const isValid = /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slugValue);
+        if (!isValid) {
+          event.preventDefault();
+          slugField.classList.add("input-error");
+          slugField.focus();
+          if (slugHint) {
+            slugHint.textContent = "Slug hanya boleh berisi huruf kecil, angka, dan tanda hubung.";
+          }
+        }
+      });
+
+      function updateCounter(field) {
+        const selector = field.dataset.counterTarget;
+        if (!selector) {
+          return;
+        }
+        const target = document.querySelector(selector);
+        if (!target) {
+          return;
+        }
+        const maxLength = field.getAttribute("maxlength");
+        const current = field.value.length;
+        const label = maxLength ? `${current}/${maxLength} karakter` : `${current} karakter`;
+        target.textContent = label;
+      }
+
+      form.querySelectorAll("[data-counter-target]").forEach(function (field) {
+        updateCounter(field);
+      });
+
+      form.addEventListener("input", function (event) {
+        const field = event.target.closest("[data-counter-target]");
+        if (!field) {
+          return;
+        }
+        updateCounter(field);
+      });
+
+      const memberList = form.querySelector("[data-member-list]");
+      const addMemberButton = form.querySelector("[data-add-member]");
+      const template = document.getElementById("brand-member-template");
+
+      function renumberMembers() {
+        if (!memberList) {
+          return;
+        }
+        memberList.querySelectorAll("[data-member-row]").forEach(function (row, index) {
+          row.setAttribute("data-member-index", String(index));
+          const legend = row.querySelector("legend");
+          if (legend) {
+            legend.textContent = `Anggota #${index + 1}`;
+          }
+          row.querySelectorAll("[data-field-name]").forEach(function (element) {
+            const fieldName = element.getAttribute("data-field-name");
+            if (!fieldName) {
+              return;
+            }
+            element.setAttribute("name", `members-${index}-${fieldName}`);
+          });
+        });
+      }
+
+      function toggleMemberRemovers() {
+        if (!memberList) {
+          return;
+        }
+        const rows = memberList.querySelectorAll("[data-member-row]");
+        rows.forEach(function (row, index) {
+          const removeButton = row.querySelector("[data-remove-member]");
+          if (!removeButton) {
+            return;
+          }
+          const shouldDisable = rows.length === 1 || index === 0;
+          removeButton.disabled = shouldDisable;
+          removeButton.classList.toggle("brand-member-remove--hidden", shouldDisable);
+        });
+      }
+
+      function initialiseMembers() {
+        renumberMembers();
+        toggleMemberRemovers();
+      }
+
+      if (memberList) {
+        initialiseMembers();
+      }
+
+      if (addMemberButton && memberList && template) {
+        addMemberButton.addEventListener("click", function (event) {
+          event.preventDefault();
+          const fragment = template.content.cloneNode(true);
+          memberList.appendChild(fragment);
+          renumberMembers();
+          toggleMemberRemovers();
+          const newestRow = memberList.querySelector("[data-member-row]:last-of-type");
+          if (newestRow) {
+            newestRow.scrollIntoView({ behavior: "smooth", block: "center" });
+            const firstInput = newestRow.querySelector("input, select, textarea");
+            if (firstInput) {
+              firstInput.focus();
+            }
+          }
+        });
+      }
+
+      form.addEventListener("click", function (event) {
+        const target = event.target.closest("[data-remove-member]");
+        if (!target || !memberList) {
+          return;
+        }
+        event.preventDefault();
+        const row = target.closest("[data-member-row]");
+        if (!row) {
+          return;
+        }
+        const rows = memberList.querySelectorAll("[data-member-row]");
+        if (rows.length === 1) {
+          return;
+        }
+        row.remove();
+        renumberMembers();
+        toggleMemberRemovers();
+      });
+
+      const focusLogoButton = form.querySelector("[data-focus-logo]");
+      const logoField = form.querySelector("[data-logo-field]");
+      if (focusLogoButton && logoField) {
+        focusLogoButton.addEventListener("click", function (event) {
+          event.preventDefault();
+          logoField.focus({ preventScroll: false });
+          logoField.scrollIntoView({ behavior: "smooth", block: "center" });
+        });
+      }
+
+      const jumpMembersButton = form.querySelector("[data-jump-members]");
+      if (jumpMembersButton && memberList) {
+        jumpMembersButton.addEventListener("click", function (event) {
+          event.preventDefault();
+          memberList.scrollIntoView({ behavior: "smooth", block: "start" });
+        });
+      }
+    })();
+  </script>
+
+  <template id="brand-member-template">
+    <fieldset class="brand-member-card" data-member-row>
+      <legend>Anggota baru</legend>
+      <button type="button" class="brand-member-remove button button-ghost button-small" data-remove-member aria-label="Hapus anggota">Hapus</button>
+      <div class="brand-member-grid">
+        <label>
+          <span>Nama lengkap</span>
+          <input type="text" data-field-name="full_name" placeholder="Misal: Bima Santosa" />
+        </label>
+        <label>
+          <span>Username</span>
+          <input type="text" data-field-name="username" placeholder="contoh: bima-santosa" />
+        </label>
+        <label>
+          <span>Role</span>
+          <select data-field-name="role">
+            <option value="owner">Owner</option>
+            <option value="co-owner" selected>Co-owner</option>
+            <option value="team">Tim</option>
+          </select>
+        </label>
+        <label>
+          <span>Status</span>
+          <select data-field-name="status">
+            <option value="active">Aktif</option>
+            <option value="pending" selected>Pending</option>
+            <option value="inactive">Non-aktif</option>
+          </select>
+        </label>
+        <label>
+          <span>Profile ID</span>
+          <input type="text" data-field-name="profile_id" placeholder="Otomatis jika kosong" />
+        </label>
+        <label>
+          <span>Avatar URL</span>
+          <input type="url" data-field-name="avatar_url" placeholder="https://" />
+        </label>
+        <label>
+          <span>Keahlian / catatan</span>
+          <input type="text" data-field-name="expertise" placeholder="Misal: Strategi brand" />
+        </label>
+        <label>
+          <span>Diundang oleh</span>
+          <input type="text" data-field-name="invited_by" placeholder="Nama pengundang" />
+        </label>
+      </div>
+    </fieldset>
+  </template>
+{% endblock %}

--- a/tests/test_brand_api.py
+++ b/tests/test_brand_api.py
@@ -1,0 +1,243 @@
+import asyncio
+from typing import Any, Dict
+from urllib.parse import urlencode, urlsplit
+
+import pytest
+
+from app.api.routes import brands as brand_routes
+from app.main import app
+from app.services import brands as brand_service_module
+from app.services.brands import Brand, BrandService
+
+
+async def _request(
+    method: str,
+    raw_path: str,
+    headers: dict[str, str] | None = None,
+    body: bytes | None = None,
+) -> tuple[int, dict[str, str], str]:
+    parsed = urlsplit(raw_path)
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": parsed.path,
+        "raw_path": raw_path.encode(),
+        "query_string": parsed.query.encode(),
+        "headers": [],
+        "client": ("127.0.0.1", 0),
+        "server": ("testserver", 80),
+    }
+
+    if headers:
+        scope["headers"] = [
+            (key.lower().encode(), value.encode()) for key, value in headers.items()
+        ]
+
+    messages: list[dict[str, Any]] = []
+
+    body_bytes = body or b""
+    body_sent = False
+
+    async def receive() -> dict[str, Any]:
+        nonlocal body_sent
+        if body_sent:
+            return {"type": "http.request", "body": b"", "more_body": False}
+        body_sent = True
+        return {"type": "http.request", "body": body_bytes, "more_body": False}
+
+    async def send(message: dict[str, Any]) -> None:
+        messages.append(message)
+
+    await app(scope, receive, send)
+
+    start_message = next(
+        message for message in messages if message["type"] == "http.response.start"
+    )
+    status = start_message["status"]
+    response_headers = {
+        key.decode(): value.decode() for key, value in start_message.get("headers", [])
+    }
+    body = b"".join(
+        message["body"] for message in messages if message["type"] == "http.response.body"
+    )
+    return status, response_headers, body.decode()
+
+
+def request(
+    method: str,
+    raw_path: str,
+    headers: dict[str, str] | None = None,
+    data: Dict[str, Any] | None = None,
+) -> tuple[int, dict[str, str], str]:
+    encoded_body: bytes | None = None
+    prepared_headers = dict(headers or {})
+    if data is not None:
+        encoded_body = urlencode(data, doseq=True).encode()
+        prepared_headers.setdefault("content-type", "application/x-www-form-urlencoded")
+    return asyncio.run(_request(method, raw_path, prepared_headers, encoded_body))
+
+
+@pytest.fixture(autouse=True)
+def reset_brand_service() -> None:
+    service = BrandService()
+    brand_service_module.brand_service = service
+    brand_routes.brand_service = service
+    yield
+    refreshed = BrandService()
+    brand_service_module.brand_service = refreshed
+    brand_routes.brand_service = refreshed
+
+
+def build_form_payload(brand: Brand, overrides: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "name": brand.name,
+        "slug": brand.slug,
+        "tagline": brand.tagline,
+        "summary": brand.summary,
+        "origin_city": brand.origin_city,
+        "established_year": str(brand.established_year),
+        "hero_image_url": brand.hero_image_url,
+        "logo_url": brand.logo_url or "",
+        "aroma_focus": "\n".join(brand.aroma_focus),
+        "story_points": "\n".join(brand.story_points),
+    }
+    if brand.is_verified:
+        payload["is_verified"] = "1"
+
+    for index, member in enumerate(brand.members):
+        prefix = f"members-{index}-"
+        payload[f"{prefix}profile_id"] = member.profile_id
+        payload[f"{prefix}full_name"] = member.full_name
+        payload[f"{prefix}username"] = member.username
+        payload[f"{prefix}role"] = member.role
+        payload[f"{prefix}status"] = member.status
+        payload[f"{prefix}avatar_url"] = member.avatar_url or ""
+        payload[f"{prefix}expertise"] = member.expertise or ""
+        payload[f"{prefix}invited_by"] = member.invited_by or ""
+
+    if overrides:
+        payload.update(overrides)
+
+    return payload
+
+
+def test_new_brand_form_renders(reset_brand_service: None) -> None:
+    status, _, body = request("GET", "/brands/new")
+
+    assert status == 200
+    assert "Buat Brand Baru" in body
+    assert "Nama brand" in body
+
+
+def test_create_brand_flow(reset_brand_service: None) -> None:
+    data = {
+        "name": "Aroma Harmoni",
+        "slug": "aroma-harmoni",
+        "tagline": "Eksplorasi aroma herbal",
+        "summary": "Brand eksperimen aroma yang fokus pada bahan botani.",
+        "origin_city": "Semarang, Indonesia",
+        "established_year": "2022",
+        "hero_image_url": "https://example.com/hero.jpg",
+        "logo_url": "https://example.com/logo.png",
+        "aroma_focus": "Herbal\nFermentasi",
+        "story_points": "Riset aroma lokal\nMengembangkan komunitas tester",
+        "is_verified": "1",
+        "members-0-profile_id": "owner_diah",
+        "members-0-full_name": "Diah Lestari",
+        "members-0-username": "diah-lestari",
+        "members-0-role": "owner",
+        "members-0-status": "active",
+        "members-0-avatar_url": "",
+        "members-0-expertise": "Pendiri",
+        "members-0-invited_by": "",
+        "members-1-profile_id": "co_harmoni",
+        "members-1-full_name": "Ari Pratama",
+        "members-1-username": "ari-pratama",
+        "members-1-role": "co-owner",
+        "members-1-status": "pending",
+        "members-1-avatar_url": "",
+        "members-1-expertise": "Community",
+        "members-1-invited_by": "Diah Lestari",
+    }
+
+    status, headers, _ = request("POST", "/brands", data=data)
+
+    assert status == 303
+    assert headers.get("location") == "/brands/aroma-harmoni"
+
+    created = brand_service_module.brand_service.get_brand("aroma-harmoni")
+    assert created.name == "Aroma Harmoni"
+    assert any(member.username == "ari-pratama" for member in created.members)
+
+
+def test_edit_brand_form_prefills_existing_data(reset_brand_service: None) -> None:
+    status, _, body = request("GET", "/brands/langit-senja/edit")
+
+    assert status == 200
+    assert "Langit Senja" in body
+    assert "langit-senja" in body
+
+
+def test_update_brand_flow_and_redirect(reset_brand_service: None) -> None:
+    service_brand = brand_service_module.brand_service.get_brand("langit-senja")
+    payload = build_form_payload(
+        service_brand,
+        overrides={
+            "name": "Langit Senja Baru",
+            "slug": "langit-senja-baru",
+            "tagline": "Cerita aroma baru",
+            "origin_city": "Bandung, Indonesia",
+            "story_points": "Cerita baru",
+            "aroma_focus": "Rempah\nGourmand",
+            "is_verified": "1",
+        },
+    )
+
+    status, headers, _ = request("POST", "/brands/langit-senja", data=payload)
+
+    assert status == 303
+    assert headers.get("location") == "/brands/langit-senja-baru?updated=1"
+
+    updated = brand_service_module.brand_service.get_brand("langit-senja-baru")
+    assert updated.name == "Langit Senja Baru"
+    assert updated.slug == "langit-senja-baru"
+
+
+def test_update_brand_duplicate_slug_validation(reset_brand_service: None) -> None:
+    service_brand = brand_service_module.brand_service.get_brand("studio-senja")
+    payload = build_form_payload(service_brand, overrides={"slug": "langit-senja"})
+
+    status, _, body = request("POST", "/brands/studio-senja", data=payload)
+
+    assert status == 400
+    assert "Slug brand sudah digunakan" in body
+    assert brand_service_module.brand_service.get_brand("studio-senja").slug == "studio-senja"
+
+
+def test_create_brand_duplicate_slug_validation(reset_brand_service: None) -> None:
+    data = {
+        "name": "Brand Duplikat",
+        "slug": "langit-senja",
+        "tagline": "Tagline",
+        "summary": "Ringkasan",
+        "origin_city": "Jakarta",
+        "established_year": "2023",
+        "hero_image_url": "https://example.com/hero.png",
+        "aroma_focus": "",
+        "story_points": "",
+        "members-0-profile_id": "owner_duplicate",
+        "members-0-full_name": "Owner Baru",
+        "members-0-username": "owner-baru",
+        "members-0-role": "owner",
+        "members-0-status": "active",
+        "members-0-avatar_url": "",
+        "members-0-expertise": "",
+        "members-0-invited_by": "",
+    }
+
+    status, _, body = request("POST", "/brands", data=data)
+
+    assert status == 400
+    assert "Nama brand sudah digunakan" in body or "Slug brand sudah digunakan" in body

--- a/tests/test_brand_service.py
+++ b/tests/test_brand_service.py
@@ -56,9 +56,9 @@ def test_create_brand_registers_owner_and_unique_slug() -> None:
             owner_username="orang-lain",
             owner_avatar=None,
             name="Aroma Harmoni",
-            tagline="",
-            summary="",
-            origin_city="",
+            tagline="Eksplorasi aroma herbal dan teh fermentasi",
+            summary="Brand eksperimen aroma yang fokus pada bahan botani hasil fermentasi.",
+            origin_city="Semarang, Indonesia",
             established_year=2022,
             hero_image_url="https://example.com/hero.jpg",
             logo_url=None,
@@ -112,4 +112,110 @@ def test_update_logo_assigns_and_replaces_brand_logo() -> None:
     cleared = service.update_logo(brand.slug, logo_url=None)
 
     assert cleared.logo_url is None
+
+
+def test_update_brand_mutates_core_fields_and_slug() -> None:
+    service = create_service()
+    brand = service.get_brand("studio-senja")
+
+    updated = service.update_brand(
+        brand.slug,
+        name="Studio Senja Baru",
+        slug="studio-senja-baru",
+        tagline="Peralatan kreatif untuk studio parfum",
+        summary="Peremajaan identitas brand dengan fokus konsultasi kreatif.",
+        origin_city="Jakarta, Indonesia",
+        established_year=2021,
+        hero_image_url="https://example.com/new-hero.jpg",
+        logo_url="https://example.com/new-logo.png",
+        aroma_focus=["Kopi", "Amber"],
+        story_points=["Merilis lini konsultasi", "Membuka studio kolaborasi"],
+        is_verified=True,
+    )
+
+    assert updated.slug == "studio-senja-baru"
+    assert updated.name == "Studio Senja Baru"
+    assert updated.origin_city == "Jakarta, Indonesia"
+    assert service.get_brand("studio-senja-baru").id == brand.id
+
+    with pytest.raises(BrandAlreadyExists):
+        service.update_brand(
+            updated.slug,
+            name="Studio Senja Baru",
+            slug="langit-senja",
+            tagline=updated.tagline,
+            summary=updated.summary,
+            origin_city=updated.origin_city,
+            established_year=updated.established_year,
+            hero_image_url=updated.hero_image_url,
+            logo_url=updated.logo_url,
+            aroma_focus=updated.aroma_focus,
+            story_points=updated.story_points,
+            is_verified=updated.is_verified,
+        )
+
+
+def test_update_members_requires_active_owner_and_unique_profiles() -> None:
+    service = create_service()
+    brand = service.get_brand("langit-senja")
+
+    members = [
+        {
+            "profile_id": "owner_langit",
+            "full_name": "Amelia Damayanti",
+            "username": "amelia-damayanti",
+            "role": "owner",
+            "status": "active",
+            "avatar_url": "https://example.com/avatar.png",
+            "expertise": "Pendiri",
+        },
+        {
+            "profile_id": "co_langit",
+            "full_name": "Satria Nusantara",
+            "username": "satria-nusantara",
+            "role": "co-owner",
+            "status": "pending",
+        },
+    ]
+
+    updated_members = service.update_members(brand.slug, members=members)
+
+    assert len(updated_members) == 2
+    assert any(member.role == "owner" for member in updated_members)
+    assert any(member.username == "satria-nusantara" for member in brand.members)
+
+    with pytest.raises(BrandError):
+        service.update_members(
+            brand.slug,
+            members=[
+                {
+                    "profile_id": "duplicate",
+                    "full_name": "Tanpa Owner",
+                    "username": "tanpa-owner",
+                    "role": "co-owner",
+                    "status": "pending",
+                }
+            ],
+        )
+
+    with pytest.raises(BrandError):
+        service.update_members(
+            brand.slug,
+            members=[
+                {
+                    "profile_id": "owner_langit",
+                    "full_name": "Amelia Damayanti",
+                    "username": "amelia-damayanti",
+                    "role": "owner",
+                    "status": "active",
+                },
+                {
+                    "profile_id": "owner_langit",
+                    "full_name": "Duplikat",
+                    "username": "duplikat",
+                    "role": "co-owner",
+                    "status": "active",
+                },
+            ],
+        )
 


### PR DESCRIPTION
## Summary
- restructure the brand form template with clearer sections, quick actions, and improved collaborator management UX
- add dedicated styling for the brand form to deliver polished responsive visuals and accessible states
- fix the API test harness imports to keep the brand workflow regression suite green

## Testing
- pytest tests/test_brand_service.py tests/test_brand_api.py

------
https://chatgpt.com/codex/tasks/task_e_68ddfd7bb2f48327892e28cefa597276