### PR TITLE
Redirect home page to marketplace

### DIFF
--- a/src/app/api/routes/root.py
+++ b/src/app/api/routes/root.py
@@ -3,7 +3,7 @@
 from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 
 from app.core.config import get_settings
 from app.services.brand_dashboard import brand_dashboard_service
@@ -745,17 +745,12 @@ def _serialize_campaign_for_ui(campaign: SambatanCampaign, *, now: datetime | No
     }
 
 
-@router.get("/", response_class=HTMLResponse)
-async def read_home(request: Request) -> HTMLResponse:
-    """Render the marketplace landing page placeholder."""
+@router.get("/")
+async def read_home(request: Request) -> RedirectResponse:
+    """Redirect the home page to the marketplace catalog."""
 
-    settings = get_settings()
-    templates = request.app.state.templates
-    context = {
-        "app_name": settings.app_name,
-        "environment": settings.environment,
-    }
-    return templates.TemplateResponse(request, "index.html", context)
+    marketplace_url = request.url_for("read_marketplace")
+    return RedirectResponse(url=marketplace_url)
 
 
 MARKETPLACE_PRODUCTS = {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -27,20 +27,24 @@ def test_homepage_returns_success():
 
         await app(scope, receive, send)
 
-        status = next(
+        start_message = next(
             (
-                message["status"]
+                message
                 for message in messages
                 if message["type"] == "http.response.start"
             ),
             None,
         )
-        body = b"".join(
-            message["body"] for message in messages if message["type"] == "http.response.body"
-        )
 
-        assert status == 200
-        assert b"Sensasiwangi" in body
+        assert start_message is not None
+        status = start_message["status"]
+        headers = {
+            key.decode("latin-1"): value.decode("latin-1")
+            for key, value in start_message.get("headers", [])
+        }
+
+        assert status in {302, 307}
+        assert headers.get("location") == "http://testserver/marketplace"
 
     asyncio.run(_run())
 


### PR DESCRIPTION
## Summary
- redirect the root route to the marketplace catalog via FastAPI RedirectResponse
- update the homepage integration test to assert the redirect location

## Testing
- pytest *(fails: AuthService tests are red due to pre-existing registration expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68df0093ed44832785d33d08e581f721