### PR TITLE
Add test coverage for moderation dashboard route

### DIFF
--- a/tests/test_moderation_dashboard.py
+++ b/tests/test_moderation_dashboard.py
@@ -1,0 +1,17 @@
+"""Integration tests for the moderation dashboard route."""
+
+from fastapi.testclient import TestClient
+
+from app.core.application import create_app
+
+
+def test_moderation_dashboard_renders_snapshot_artifacts() -> None:
+    """The moderation dashboard should render the demo snapshot data."""
+
+    app = create_app()
+    with TestClient(app) as client:
+        response = client.get("/dashboard/moderation")
+
+    assert response.status_code == 200
+    body = response.text
+    assert "Dashboard Moderasi" in body or "Arif Santoso" in body


### PR DESCRIPTION
## Summary
- add a FastAPI TestClient-based test that exercises the moderation dashboard endpoint and checks for key snapshot content

## Testing
- pytest *(fails: tests/test_auth_service.py::test_register_and_authenticate_user, tests/test_auth_service.py::test_register_duplicate_email)*

------
https://chatgpt.com/codex/tasks/task_e_68df09f2bc2483278fdd24c36d3917a9