### PR TITLE
Improve mobile navbar accessibility and toggling

### DIFF
--- a/src/app/web/static/css/base.css
+++ b/src/app/web/static/css/base.css
@@ -214,6 +214,13 @@ p {
   gap: 1rem;
 }
 
+.navbar-collapsible {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  margin-left: auto;
+}
+
 .navbar-brand .logo {
   font-family: "Playfair Display", "Times New Roman", serif;
   font-size: 1.4rem;
@@ -1402,16 +1409,61 @@ p {
 }
 
 @media (max-width: 1024px) {
-  .navbar-menu {
-    display: none;
+  .navbar {
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 0.75rem;
   }
 
   .navbar-toggle {
     display: flex;
+    margin-left: auto;
+  }
+
+  .navbar-collapsible {
+    display: none;
+    position: relative;
+    width: 100%;
+    margin-left: 0;
+    padding: 1.5rem 1.25rem;
+    background: rgba(15, 23, 42, 0.92);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    border-radius: var(--radius-md);
+    box-shadow: 0 18px 40px rgba(8, 15, 29, 0.4);
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .navbar[data-open="true"] .navbar-collapsible {
+    display: flex;
+  }
+
+  .navbar-menu {
+    width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.1rem;
+  }
+
+  .navbar-menu li {
+    width: 100%;
+  }
+
+  .navbar-menu a {
+    width: 100%;
+    display: block;
+    padding: 0.35rem 0;
   }
 
   .navbar-actions {
-    margin-left: auto;
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .navbar-actions .navbar-dropdown {
+    width: 100%;
   }
 
   .hero {

--- a/src/app/web/static/js/navbar.js
+++ b/src/app/web/static/js/navbar.js
@@ -1,0 +1,66 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const navbars = Array.from(document.querySelectorAll(".navbar"));
+  const configs = [];
+
+  navbars.forEach((nav) => {
+    const toggle = nav.querySelector(".navbar-toggle");
+    const collapsible = nav.querySelector(".navbar-collapsible");
+
+    if (!toggle || !collapsible) {
+      return;
+    }
+
+    const setOpenState = (isOpen) => {
+      nav.dataset.open = isOpen ? "true" : "false";
+      toggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
+      collapsible.setAttribute("aria-hidden", isOpen ? "false" : "true");
+
+      if (isOpen) {
+        nav.classList.add("navbar--open");
+      } else {
+        nav.classList.remove("navbar--open");
+      }
+    };
+
+    setOpenState(false);
+
+    const toggleOpen = () => {
+      const isOpen = nav.dataset.open === "true";
+      setOpenState(!isOpen);
+    };
+
+    const close = () => setOpenState(false);
+
+    toggle.addEventListener("click", (event) => {
+      event.preventDefault();
+      toggleOpen();
+    });
+
+    collapsible.addEventListener("click", (event) => {
+      const interactive = event.target.closest("a, button");
+      if (!interactive || interactive === toggle) {
+        return;
+      }
+      close();
+    });
+
+    configs.push({ toggle, close, nav });
+  });
+
+  if (configs.length === 0) {
+    return;
+  }
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key !== "Escape") {
+      return;
+    }
+
+    configs.forEach(({ nav, toggle, close }) => {
+      if (nav.dataset.open === "true") {
+        close();
+        toggle.focus();
+      }
+    });
+  });
+});

--- a/src/app/web/templates/base.html
+++ b/src/app/web/templates/base.html
@@ -24,7 +24,9 @@
       </main>
       {% include 'partials/footer.html' %}
     </div>
+    {% block body_scripts %}
     <script src="{{ url_for('static', path='js/session.js') }}?{{ static_asset_query }}" defer></script>
-    {% block body_scripts %}{% endblock %}
+    <script src="{{ url_for('static', path='js/navbar.js') }}?{{ static_asset_query }}" defer></script>
+    {% endblock %}
   </body>
 </html>

--- a/src/app/web/templates/partials/navbar.html
+++ b/src/app/web/templates/partials/navbar.html
@@ -1,57 +1,64 @@
-<nav class="navbar glass-surface">
+<nav class="navbar glass-surface" data-open="false">
   <a class="navbar-brand" href="{{ url_for('read_home') }}">
     <span class="logo">Sensasiwangi.id</span>
   </a>
-  <button class="navbar-toggle" aria-label="Buka navigasi">
+  <button
+    class="navbar-toggle"
+    aria-label="Buka navigasi"
+    aria-expanded="false"
+    aria-controls="navbarCollapsible"
+  >
     <span></span>
     <span></span>
     <span></span>
   </button>
-  <ul class="navbar-menu">
-    <li>
-      <a href="{{ url_for('read_marketplace') }}" class="{% if request.url.path.startswith('/marketplace') %}active{% endif %}">
-        Marketplace
-      </a>
-    </li>
-    <li>
-      <a href="{{ url_for('read_home') }}#nusantarum" class="{% if request.url.path == '/' %}active{% endif %}">
-        Nusantarum
-      </a>
-    </li>
-  </ul>
-  {% set session_user = request.session.get('user') %}
-  <div class="navbar-actions">
-    <details class="navbar-dropdown">
-      <summary class="navbar-dropdown__toggle">
-        <span>{% if session_user %}{{ session_user.full_name }}{% else %}Login{% endif %}</span>
-        <span class="navbar-dropdown__icon" aria-hidden="true">▾</span>
-      </summary>
-      <ul class="navbar-dropdown__menu">
-        {% if session_user %}
-        {% set profile_username = session_user.get('username') if session_user else None %}
-        <li>
-          {% if profile_username %}
-          <a href="{{ url_for('profile_detail', username=profile_username) }}">Profil</a>
-          {% else %}
-          <a href="{{ url_for('read_auth') }}#login">Profil</a>
+  <div class="navbar-collapsible" id="navbarCollapsible" aria-hidden="true">
+    <ul class="navbar-menu">
+      <li>
+        <a href="{{ url_for('read_marketplace') }}" class="{% if request.url.path.startswith('/marketplace') %}active{% endif %}">
+          Marketplace
+        </a>
+      </li>
+      <li>
+        <a href="{{ url_for('read_home') }}#nusantarum" class="{% if request.url.path == '/' %}active{% endif %}">
+          Nusantarum
+        </a>
+      </li>
+    </ul>
+    {% set session_user = request.session.get('user') %}
+    <div class="navbar-actions">
+      <details class="navbar-dropdown">
+        <summary class="navbar-dropdown__toggle">
+          <span>{% if session_user %}{{ session_user.full_name }}{% else %}Login{% endif %}</span>
+          <span class="navbar-dropdown__icon" aria-hidden="true">▾</span>
+        </summary>
+        <ul class="navbar-dropdown__menu">
+          {% if session_user %}
+          {% set profile_username = session_user.get('username') if session_user else None %}
+          <li>
+            {% if profile_username %}
+            <a href="{{ url_for('profile_detail', username=profile_username) }}">Profil</a>
+            {% else %}
+            <a href="{{ url_for('read_auth') }}#login">Profil</a>
+            {% endif %}
+          </li>
+          <li>
+            <a href="{{ url_for('read_brand_owner_dashboard') }}">Dashboard Brand</a>
+          </li>
+          {% if session_user.get('is_admin') %}
+          <li>
+            <a href="{{ url_for('read_moderation_dashboard') }}">Admin Menu</a>
+          </li>
           {% endif %}
-        </li>
-        <li>
-          <a href="{{ url_for('read_brand_owner_dashboard') }}">Dashboard Brand</a>
-        </li>
-        {% if session_user.get('is_admin') %}
-        <li>
-          <a href="{{ url_for('read_moderation_dashboard') }}">Admin Menu</a>
-        </li>
-        {% endif %}
-        <li>
-          <button type="button" data-action="logout">Keluar</button>
-        </li>
-        {% else %}
-        <li><a href="{{ url_for('read_auth') }}#login">Masuk</a></li>
-        <li><a href="{{ url_for('read_onboarding') }}">Daftar</a></li>
-        {% endif %}
-      </ul>
-    </details>
+          <li>
+            <button type="button" data-action="logout">Keluar</button>
+          </li>
+          {% else %}
+          <li><a href="{{ url_for('read_auth') }}#login">Masuk</a></li>
+          <li><a href="{{ url_for('read_onboarding') }}">Daftar</a></li>
+          {% endif %}
+        </ul>
+      </details>
+    </div>
   </div>
 </nav>


### PR DESCRIPTION
## Summary
- wrap the navbar menu and actions in a collapsible region with aria wiring for the toggle button
- add a navbar toggle script and load it for every page via the base template
- restyle the mobile navbar to display a full-width panel when opened

## Testing
- uvicorn main:app --host 0.0.0.0 --port 8000

------
https://chatgpt.com/codex/tasks/task_e_68e0886adff483278d3b631a853f4ff1