### PR TITLE
Add tertiary text token for glass surfaces

### DIFF
--- a/src/app/web/static/css/base.css
+++ b/src/app/web/static/css/base.css
@@ -7,6 +7,7 @@
   --glass-shadow: 0 25px 45px rgba(15, 23, 42, 0.45);
   --text-primary: #f8fafc;
   --text-secondary: #cbd5f5;
+  --text-tertiary: rgba(203, 213, 225, 0.78);
   --accent-primary: linear-gradient(135deg, #f97316, #c026d3);
   --accent-secondary: #38bdf8;
   --muted: #94a3b8;


### PR DESCRIPTION
## Summary
- add a dedicated `--text-tertiary` CSS custom property with a higher-contrast slate tint for glass surfaces
- ensure existing hint and empty state styles continue consuming the updated token for consistent readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e08bb9f30883278974dece67e2c5bf