### PR TITLE
Update navbar accessibility behavior

### DIFF
--- a/src/app/web/static/js/navbar.js
+++ b/src/app/web/static/js/navbar.js
@@ -1,6 +1,7 @@
 document.addEventListener("DOMContentLoaded", () => {
   const navbars = Array.from(document.querySelectorAll(".navbar"));
   const configs = [];
+  const mobileQuery = window.matchMedia("(max-width: 1024px)");
 
   navbars.forEach((nav) => {
     const toggle = nav.querySelector(".navbar-toggle");
@@ -13,7 +14,13 @@ document.addEventListener("DOMContentLoaded", () => {
     const setOpenState = (isOpen) => {
       nav.dataset.open = isOpen ? "true" : "false";
       toggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
-      collapsible.setAttribute("aria-hidden", isOpen ? "false" : "true");
+      toggle.setAttribute("aria-label", isOpen ? "Tutup navigasi" : "Buka navigasi");
+
+      if (mobileQuery.matches) {
+        collapsible.setAttribute("aria-hidden", isOpen ? "false" : "true");
+      } else {
+        collapsible.setAttribute("aria-hidden", "false");
+      }
 
       if (isOpen) {
         nav.classList.add("navbar--open");
@@ -23,6 +30,17 @@ document.addEventListener("DOMContentLoaded", () => {
     };
 
     setOpenState(false);
+
+    const handleBreakpointChange = () => {
+      const isOpen = nav.dataset.open === "true";
+      setOpenState(isOpen);
+    };
+
+    if (typeof mobileQuery.addEventListener === "function") {
+      mobileQuery.addEventListener("change", handleBreakpointChange);
+    } else if (typeof mobileQuery.addListener === "function") {
+      mobileQuery.addListener(handleBreakpointChange);
+    }
 
     const toggleOpen = () => {
       const isOpen = nav.dataset.open === "true";


### PR DESCRIPTION
## Summary
- ensure the collapsible menu only reports `aria-hidden="true"` on mobile when closed and stays visible on larger screens
- update the navbar toggle button label to reflect whether navigation is open or closed
- re-run the open state logic when the viewport crosses the mobile breakpoint so ARIA stays in sync

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e08fa1e7d88327811ab29b9f52b815