### PR TITLE
Convert profile badges to list semantics

### DIFF
--- a/src/app/web/static/css/profile.css
+++ b/src/app/web/static/css/profile.css
@@ -76,6 +76,9 @@
 }
 
 .profile-badges {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;

--- a/src/app/web/templates/components/profile/badge.html
+++ b/src/app/web/templates/components/profile/badge.html
@@ -1,8 +1,8 @@
-<div class="profile-badge profile-badge--{{ badge.slug }}" role="presentation">
+<li class="profile-badge profile-badge--{{ badge.slug }}">
   <span class="profile-badge__icon" aria-hidden="true">{{ badge.icon }}</span>
   <span class="profile-badge__label">{{ badge.label }}</span>
   {% if badge.count is not none %}
     <span class="profile-badge__meta">{{ badge.count }}</span>
   {% endif %}
   <span class="sr-only">{{ badge.description }}</span>
-</div>
+</li>

--- a/src/app/web/templates/pages/profile/detail.html
+++ b/src/app/web/templates/pages/profile/detail.html
@@ -264,11 +264,11 @@
           {% endif %}
         </ul>
         {% if profile_view.badges %}
-          <div class="profile-badges" role="list">
+          <ul class="profile-badges">
             {% for badge in profile_view.badges %}
               {% include 'components/profile/badge.html' with context %}
             {% endfor %}
-          </div>
+          </ul>
         {% else %}
           <div class="profile-empty profile-empty--subtle">
             <p>Belum ada badge aktif. Kolaborasi dengan brand untuk menampilkan pencapaianmu.</p>


### PR DESCRIPTION
## Summary
- swap the profile badge container to a semantic list and render each badge partial within it
- update the profile badge component to output an `<li>` while preserving its accessible text
- reset profile badge list styles to accommodate the new markup

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68e0e6c529ec83278f9a1ae6ffc9eba8