### PR TITLE
Refine moderation dashboard navigation semantics

### DIFF
--- a/src/app/web/static/css/moderation-dashboard.css
+++ b/src/app/web/static/css/moderation-dashboard.css
@@ -117,6 +117,7 @@
   min-width: 130px;
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
   scroll-snap-align: center;
+  text-decoration: none;
 }
 
 .mod-section-tabs .tab-link .tab-label {

--- a/src/app/web/static/js/moderation-dashboard.js
+++ b/src/app/web/static/js/moderation-dashboard.js
@@ -52,10 +52,8 @@
     var tabs = container.querySelectorAll('[data-action="jump-section"]');
     Array.prototype.forEach.call(tabs, function (tab) {
       tab.classList.remove("is-active");
-      tab.setAttribute("aria-selected", "false");
     });
     trigger.classList.add("is-active");
-    trigger.setAttribute("aria-selected", "true");
     if (!opts.silent) {
       ensureTabVisible(container, trigger);
     }
@@ -132,17 +130,13 @@
         break;
       }
       case "jump-section": {
-        if (event && typeof event.preventDefault === "function") {
-          event.preventDefault();
-        }
         var targetSelector = trigger.dataset.target || trigger.getAttribute("href");
         var scrolled = scrollToTarget(targetSelector);
-        if (scrolled) {
-          activateTab(trigger);
-        } else if (targetSelector) {
-          window.location.hash = targetSelector.replace(/^#/, "");
+        activateTab(trigger);
+        if (scrolled && event && typeof event.preventDefault === "function") {
+          event.preventDefault();
         }
-        return true;
+        return scrolled;
       }
       case "scroll-top": {
         if (event && typeof event.preventDefault === "function") {

--- a/src/app/web/templates/pages/dashboard/moderation.html
+++ b/src/app/web/templates/pages/dashboard/moderation.html
@@ -48,48 +48,48 @@
 <nav class="mod-section-tabs glass-surface" aria-label="Navigasi section dashboard" data-tab-group>
   <div class="tab-bar">
     <div class="tab-scroller">
-      <ul class="tab-list" role="tablist">
-        <li class="tab-list__item" role="presentation">
-          <button type="button" role="tab" class="tab-link is-active" aria-selected="true" data-action="jump-section" data-target="#mod-overview">
+      <ul class="tab-list">
+        <li class="tab-list__item">
+          <a class="tab-link is-active" href="#mod-overview" data-action="jump-section" data-target="#mod-overview">
             <span class="tab-label">Overview</span>
             <span class="tab-subtitle">Ringkasan</span>
-          </button>
+          </a>
         </li>
-        <li class="tab-list__item" role="presentation">
-          <button type="button" role="tab" class="tab-link" aria-selected="false" data-action="jump-section" data-target="#mod-team">
+        <li class="tab-list__item">
+          <a class="tab-link" href="#mod-team" data-action="jump-section" data-target="#mod-team">
             <span class="tab-label">Tim</span>
             <span class="tab-subtitle">Manajemen</span>
-          </button>
+          </a>
         </li>
-        <li class="tab-list__item" role="presentation">
-          <button type="button" role="tab" class="tab-link" aria-selected="false" data-action="jump-section" data-target="#mod-queues">
+        <li class="tab-list__item">
+          <a class="tab-link" href="#mod-queues" data-action="jump-section" data-target="#mod-queues">
             <span class="tab-label">Antrian</span>
             <span class="tab-subtitle">Moderasi</span>
-          </button>
+          </a>
         </li>
-        <li class="tab-list__item" role="presentation">
-          <button type="button" role="tab" class="tab-link" aria-selected="false" data-action="jump-section" data-target="#mod-curation">
+        <li class="tab-list__item">
+          <a class="tab-link" href="#mod-curation" data-action="jump-section" data-target="#mod-curation">
             <span class="tab-label">Kurasi</span>
             <span class="tab-subtitle">Konten</span>
-          </button>
+          </a>
         </li>
-        <li class="tab-list__item" role="presentation">
-          <button type="button" role="tab" class="tab-link" aria-selected="false" data-action="jump-section" data-target="#mod-analytics">
+        <li class="tab-list__item">
+          <a class="tab-link" href="#mod-analytics" data-action="jump-section" data-target="#mod-analytics">
             <span class="tab-label">Analitik</span>
             <span class="tab-subtitle">Insight</span>
-          </button>
+          </a>
         </li>
-        <li class="tab-list__item" role="presentation">
-          <button type="button" role="tab" class="tab-link" aria-selected="false" data-action="jump-section" data-target="#mod-policies">
+        <li class="tab-list__item">
+          <a class="tab-link" href="#mod-policies" data-action="jump-section" data-target="#mod-policies">
             <span class="tab-label">Kebijakan</span>
             <span class="tab-subtitle">SOP</span>
-          </button>
+          </a>
         </li>
-        <li class="tab-list__item" role="presentation">
-          <button type="button" role="tab" class="tab-link" aria-selected="false" data-action="jump-section" data-target="#mod-help">
+        <li class="tab-list__item">
+          <a class="tab-link" href="#mod-help" data-action="jump-section" data-target="#mod-help">
             <span class="tab-label">Bantuan</span>
             <span class="tab-subtitle">Support</span>
-          </button>
+          </a>
         </li>
       </ul>
       <span class="tab-indicator" aria-hidden="true"></span>


### PR DESCRIPTION
## Summary
- replace moderation dashboard tab triggers with anchor links to improve semantics for screen readers
- adjust jump-section handling to only prevent default when smooth scrolling succeeds while keeping active indicator updates
- tweak tab link styles for anchor usage without relying on legacy ARIA attributes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0e6d0bf1483278f5e9fe14b7bd756