### PR TITLE
Wrap landing search in form with submit button

### DIFF
--- a/src/app/web/static/css/base.css
+++ b/src/app/web/static/css/base.css
@@ -803,6 +803,33 @@ p {
   font-size: 0.95rem;
 }
 
+.search-box .search-submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: var(--radius-full);
+  border: none;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.9), rgba(192, 38, 211, 0.9));
+  color: #0b1120;
+  cursor: pointer;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+  box-shadow: 0 10px 24px rgba(56, 189, 248, 0.28);
+}
+
+.search-box .search-submit:hover,
+.search-box .search-submit:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 32px rgba(192, 38, 211, 0.24);
+  outline: none;
+}
+
+.search-box .search-submit svg {
+  width: 1.05rem;
+  height: 1.05rem;
+}
+
 .product-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));

--- a/src/app/web/templates/index.html
+++ b/src/app/web/templates/index.html
@@ -96,8 +96,14 @@
       <label class="filter-chip">Sort: Popular</label>
       <label class="filter-chip">Aroma: Bunga</label>
     </div>
-    <div class="search-box">
-      <label class="sr-only" for="landing-catalog-search">Cari katalog marketplace</label>
+    <form
+      class="search-box"
+      method="get"
+      action="{{ url_for('read_marketplace') }}"
+      role="search"
+      aria-label="Cari produk marketplace"
+    >
+      <label class="sr-only" for="landing-catalog-search">Cari produk marketplace</label>
       <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
         <path
           d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.71.71l.27.28v.79l5 4.99L20.49 19l-4.99-5zM5 10.5a5.5 5.5 0 1 1 11 0a5.5 5.5 0 0 1-11 0z"
@@ -107,9 +113,19 @@
       <input
         type="search"
         id="landing-catalog-search"
+        name="q"
         placeholder="Cari parfum, brand, atau bahan baku"
       />
-    </div>
+      <button type="submit" class="search-submit" aria-label="Cari">
+        <span class="sr-only">Cari</span>
+        <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.71.71l.27.28v.79l5 4.99L20.49 19l-4.99-5zM5 10.5a5.5 5.5 0 1 1 11 0a5.5 5.5 0 0 1-11 0z"
+            fill="currentColor"
+          />
+        </svg>
+      </button>
+    </form>
   </div>
 
   <div class="tab-panels">


### PR DESCRIPTION
## Summary
- wrap the landing page catalog search in a GET form that posts to the marketplace route
- align the landing search input with marketplace semantics by adding a hidden label, query name, and submit button
- style the new submit control to match the existing pill search box aesthetics

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0f81aa694832798b4bddc25f01f4f