### PR TITLE
Implement newsletter subscription endpoint with client feedback

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-multipart>=0.0.6
 pydantic-settings>=2.2
 aiofiles>=23.2
 httpx>=0.27
+email-validator>=2.2

--- a/src/app/web/templates/index.html
+++ b/src/app/web/templates/index.html
@@ -409,10 +409,25 @@
     <h2>Siap ikut meracik wewangian Nusantara?</h2>
     <p>Bergabung bersama komunitas perfumery Sensasiwangi.id untuk akses batch eksklusif dan sesi lokakarya.</p>
   </div>
-  <form class="newsletter-form">
-    <label for="email" class="sr-only">Email</label>
-    <input id="email" type="email" placeholder="Masukkan email kamu" required />
+  <form
+    class="newsletter-form"
+    method="post"
+    action="{{ url_for('newsletter_subscribe') }}"
+    hx-post="{{ url_for('newsletter_subscribe') }}"
+    hx-target="#newsletter-status"
+    hx-swap="innerHTML"
+  >
+    <label for="newsletter-email" class="sr-only">Email</label>
+    <input
+      id="newsletter-email"
+      type="email"
+      name="email"
+      autocomplete="email"
+      placeholder="Masukkan email kamu"
+      required
+    />
     <button type="submit" class="btn gradient-button">Daftar Newsletter</button>
+    <span id="newsletter-status" class="newsletter-status" role="status" aria-live="polite"></span>
   </form>
 </section>
 {% endblock %}
@@ -420,4 +435,63 @@
 {% block body_scripts %}
   {{ super() }}
   <script src="{{ url_for('static', path='js/home-tabs.js') }}?{{ static_asset_query }}" defer></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      const form = document.querySelector(".newsletter-form");
+      if (!form) {
+        return;
+      }
+
+      const statusRegion = form.querySelector("#newsletter-status");
+      const submitButton = form.querySelector("button[type='submit']");
+
+      const setStatus = (message, tone) => {
+        if (!statusRegion) {
+          return;
+        }
+
+        statusRegion.textContent = message;
+        statusRegion.dataset.tone = tone;
+      };
+
+      form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (!submitButton) {
+          return;
+        }
+
+        const formData = new FormData(form);
+
+        submitButton.disabled = true;
+        setStatus("Mengirim...", "pending");
+
+        try {
+          const response = await fetch(form.action, {
+            method: "POST",
+            headers: {
+              Accept: "application/json",
+            },
+            body: formData,
+          });
+
+          const payload = await response.json().catch(() => null);
+
+          if (response.ok) {
+            const successMessage = payload?.message ?? "Terima kasih! Email kamu sudah terdaftar.";
+            setStatus(successMessage, "success");
+            form.reset();
+          } else {
+            const errorMessage = payload?.message ?? "Alamat email tidak valid. Coba lagi.";
+            setStatus(errorMessage, "error");
+          }
+        } catch (error) {
+          setStatus("Terjadi kendala jaringan. Silakan coba lagi.", "error");
+        } finally {
+          submitButton.disabled = false;
+        }
+      });
+    });
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a FastAPI endpoint that validates newsletter subscription emails and returns JSON/HTML responses
- connect the landing page newsletter form to the endpoint and provide inline status messaging for submissions
- include the email-validator dependency required for EmailStr validation

## Testing
- pytest *(fails: missing `email_validator` package in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f98bcc94832787a78d603635f2b4