### PR TITLE
Improve Nusantarum tab accessibility and keyboard support

### DIFF
--- a/src/app/web/static/js/nusantarum-tabs.js
+++ b/src/app/web/static/js/nusantarum-tabs.js
@@ -1,0 +1,121 @@
+(function () {
+  function setupTabs() {
+    const tablist = document.querySelector('.nusantarum-tabs');
+    const tabPanel = document.getElementById('nusantarum-tab-content');
+    if (!tablist) {
+      return;
+    }
+
+    const tabs = Array.from(tablist.querySelectorAll('[role="tab"]'));
+    if (!tabs.length) {
+      return;
+    }
+
+    function updateTabState(selectedTab, { shouldFocus = true } = {}) {
+      if (!selectedTab) {
+        return;
+      }
+
+      tabs.forEach((tab) => {
+        const isActive = tab === selectedTab;
+        tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+        tab.setAttribute('tabindex', isActive ? '0' : '-1');
+        tab.classList.toggle('is-active', isActive);
+        if (isActive && shouldFocus) {
+          tab.focus();
+        }
+      });
+
+      if (tabPanel) {
+        tabPanel.setAttribute('aria-busy', 'true');
+      }
+    }
+
+    tabs.forEach((tab) => {
+      const isActive = tab.getAttribute('aria-selected') === 'true';
+      tab.setAttribute('tabindex', isActive ? '0' : '-1');
+      tab.classList.toggle('is-active', isActive);
+
+      if (tab.dataset.nusantarumTabsBound === 'true') {
+        return;
+      }
+      tab.dataset.nusantarumTabsBound = 'true';
+
+      tab.addEventListener('click', (event) => {
+        updateTabState(event.currentTarget);
+      });
+
+      tab.addEventListener('keydown', (event) => {
+        const currentIndex = tabs.indexOf(event.currentTarget);
+        if (currentIndex < 0) {
+          return;
+        }
+
+        let nextTab = null;
+        switch (event.key) {
+          case 'ArrowRight':
+          case 'ArrowDown':
+            nextTab = tabs[(currentIndex + 1) % tabs.length];
+            break;
+          case 'ArrowLeft':
+          case 'ArrowUp':
+            nextTab = tabs[(currentIndex - 1 + tabs.length) % tabs.length];
+            break;
+          case 'Home':
+            nextTab = tabs[0];
+            break;
+          case 'End':
+            nextTab = tabs[tabs.length - 1];
+            break;
+          default:
+            return;
+        }
+
+        if (nextTab) {
+          event.preventDefault();
+          nextTab.focus();
+          nextTab.click();
+        }
+      });
+    });
+  }
+
+  function handleBeforeRequest(event) {
+    const tabPanel = document.getElementById('nusantarum-tab-content');
+    if (!tabPanel) {
+      return;
+    }
+
+    const requestElement = event.detail ? event.detail.elt : event.target;
+    if (!requestElement) {
+      return;
+    }
+
+    const hxTarget = requestElement.getAttribute('hx-target');
+    if (hxTarget === '#nusantarum-tab-content') {
+      tabPanel.setAttribute('aria-busy', 'true');
+    }
+  }
+
+  function handleAfterSwap(event) {
+    const tabPanel = document.getElementById('nusantarum-tab-content');
+    if (!tabPanel) {
+      return;
+    }
+
+    const swapTarget = event.detail ? event.detail.target : null;
+    if (event.target === tabPanel || swapTarget === tabPanel) {
+      tabPanel.setAttribute('aria-busy', 'false');
+      setupTabs();
+    }
+  }
+
+  document.addEventListener('htmx:beforeRequest', handleBeforeRequest);
+  document.addEventListener('htmx:afterSwap', handleAfterSwap);
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setupTabs);
+  } else {
+    setupTabs();
+  }
+})();

--- a/src/app/web/templates/pages/nusantarum/index.html
+++ b/src/app/web/templates/pages/nusantarum/index.html
@@ -36,6 +36,9 @@
       class="nusantarum-tab"
       role="tab"
       aria-selected="{{ 'true' if active_tab == 'parfum' else 'false' }}"
+      id="nusantarum-tab-parfum"
+      aria-controls="nusantarum-tab-content"
+      tabindex="{{ '0' if active_tab == 'parfum' else '-1' }}"
       hx-get="/nusantarum/tab/parfum"
       hx-target="#nusantarum-tab-content"
       hx-include="#nusantarum-filter-form"
@@ -49,6 +52,9 @@
       class="nusantarum-tab"
       role="tab"
       aria-selected="{{ 'true' if active_tab == 'brand' else 'false' }}"
+      id="nusantarum-tab-brand"
+      aria-controls="nusantarum-tab-content"
+      tabindex="{{ '0' if active_tab == 'brand' else '-1' }}"
       hx-get="/nusantarum/tab/brand"
       hx-target="#nusantarum-tab-content"
       hx-include="#nusantarum-filter-form"
@@ -62,6 +68,9 @@
       class="nusantarum-tab"
       role="tab"
       aria-selected="{{ 'true' if active_tab == 'perfumer' else 'false' }}"
+      id="nusantarum-tab-perfumer"
+      aria-controls="nusantarum-tab-content"
+      tabindex="{{ '0' if active_tab == 'perfumer' else '-1' }}"
       hx-get="/nusantarum/tab/perfumer"
       hx-target="#nusantarum-tab-content"
       hx-include="#nusantarum-filter-form"
@@ -114,6 +123,7 @@
 
 {% block body_scripts %}
 {{ super() }}
+<script src="{{ url_for('static', path='js/nusantarum-tabs.js') }}?{{ static_asset_query }}" defer></script>
 <script>
   (function () {
     const searchInput = document.getElementById('nusantarum-search-input');


### PR DESCRIPTION
## Summary
- add tab IDs, aria attributes, and tabindex management for the Nusantarum navigation
- introduce a dedicated script that keeps tab state, aria flags, and focus synchronized with HTMX swaps
- ensure the tab panel exposes aria-busy while new content is loading

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0fdb7b7488327b0888a9288a0551a