### PR TITLE
Support fallback submission for profile follow actions

### DIFF
--- a/src/app/api/routes/profile.py
+++ b/src/app/api/routes/profile.py
@@ -79,7 +79,12 @@ async def follow_profile(
     return _render_follow_button(request, profile_view)
 
 
-@router.delete("/{username}/follow", response_class=HTMLResponse, name="profile_unfollow")
+@router.api_route(
+    "/{username}/follow",
+    methods=["DELETE", "POST"],
+    response_class=HTMLResponse,
+    name="profile_unfollow",
+)
 async def unfollow_profile(
     username: str,
     request: Request,
@@ -88,6 +93,12 @@ async def unfollow_profile(
 ) -> HTMLResponse:
     if not viewer:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Viewer wajib diisi")
+
+    if request.method == "POST":
+        form = await request.form()
+        override = (form.get("_method") or form.get("intent") or "").strip().lower()
+        if override not in {"delete", "unfollow"}:
+            raise HTTPException(status_code=status.HTTP_405_METHOD_NOT_ALLOWED, detail="Metode tidak didukung")
 
     try:
         profile_view = await service.unfollow_profile(username, follower_id=viewer)

--- a/src/app/web/templates/components/profile/follow_button.html
+++ b/src/app/web/templates/components/profile/follow_button.html
@@ -9,22 +9,35 @@
   {% elif profile_view.viewer.is_following %}
     {% set unfollow_url = request.url_for('profile_unfollow', username=profile.username) %}
     <form
+      action="{{ unfollow_url }}{% if viewer_query %}?{{ viewer_query }}{% endif %}"
+      method="post"
       hx-delete="{{ unfollow_url }}{% if viewer_query %}?{{ viewer_query }}{% endif %}"
       hx-target="#profile-follow-button"
       hx-swap="outerHTML"
       class="profile-follow__form"
+      onsubmit="if (window.htmx) { return false; }"
     >
-      <button type="submit" class="profile-follow__button profile-follow__button--muted">Mengikuti</button>
+      <input type="hidden" name="_method" value="DELETE" />
+      <button
+        type="submit"
+        class="profile-follow__button profile-follow__button--muted"
+        aria-pressed="true"
+      >
+        Mengikuti
+      </button>
     </form>
   {% elif profile_view.viewer.can_follow %}
     {% set follow_url = request.url_for('profile_follow', username=profile.username) %}
     <form
+      action="{{ follow_url }}{% if viewer_query %}?{{ viewer_query }}{% endif %}"
+      method="post"
       hx-post="{{ follow_url }}{% if viewer_query %}?{{ viewer_query }}{% endif %}"
       hx-target="#profile-follow-button"
       hx-swap="outerHTML"
       class="profile-follow__form"
+      onsubmit="if (window.htmx) { return false; }"
     >
-      <button type="submit" class="profile-follow__button">Ikuti</button>
+      <button type="submit" class="profile-follow__button" aria-pressed="false">Ikuti</button>
     </form>
   {% else %}
     <a href="/auth" class="profile-follow__button profile-follow__button--ghost">Masuk untuk mengikuti</a>


### PR DESCRIPTION
## Summary
- add progressive enhancement fallbacks to the profile follow/unfollow forms, including method overrides and ARIA state
- allow the unfollow endpoint to accept POST requests when `_method=DELETE` is supplied for non-HTMX submissions

## Testing
- pytest tests/test_profile_api.py *(fails: missing dependency `email_validator`)*

------
https://chatgpt.com/codex/tasks/task_e_68e0fdd3ed4c832799fd692e1e45aaeb