### PR TITLE
Allow login form fallback and accept form submissions in API

### DIFF
--- a/src/app/api/routes/auth.py
+++ b/src/app/api/routes/auth.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, Field
 
 from app.services.auth import (
@@ -126,11 +126,15 @@ def verify_user(
 
 
 @router.post("/login", response_model=AuthPayload)
-def login_user(
-    payload: LoginRequest,
+async def login_user(
     request: Request,
+    payload: LoginRequest | None = Body(None),
     service: AuthService = Depends(get_auth_service),
 ) -> AuthPayload:
+    if payload is None:
+        form = await request.form()
+        payload = LoginRequest(**dict(form))
+
     try:
         user = service.authenticate(email=payload.email, password=payload.password)
     except AuthError as exc:

--- a/src/app/web/templates/auth.html
+++ b/src/app/web/templates/auth.html
@@ -9,7 +9,13 @@
   <div class="auth-login-section" id="login">
     <div class="login-backdrop glass-surface">
       <div class="auth-feedback" data-auth-feedback role="status" aria-live="polite"></div>
-      <form id="auth-login-form" class="auth-form login-form" aria-labelledby="login-title">
+      <form
+        id="auth-login-form"
+        class="auth-form login-form"
+        aria-labelledby="login-title"
+        method="post"
+        action="{{ url_for('login_user') }}"
+      >
         <header class="login-header">
           <h2 id="login-title">Masuk</h2>
           <p>Gunakan email dan password yang sama dengan akun Sensasiwangi.id Anda. Pastikan Anda sudah mengklik tautan verifikasi yang dikirim ke email.</p>
@@ -56,16 +62,28 @@
 
     if (loginForm) {
       loginForm.addEventListener('submit', async (event) => {
+        const supportsFetch = typeof window.fetch === 'function';
+        if (!supportsFetch) {
+          return;
+        }
+
         event.preventDefault();
         const formData = new FormData(loginForm);
         const payload = Object.fromEntries(formData.entries());
 
         setFeedback('Memproses login...');
-        const response = await fetch('/api/auth/login', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload),
-        });
+        let response;
+        try {
+          response = await window.fetch(loginForm.action || '/api/auth/login', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+        } catch (error) {
+          setFeedback('Koneksi bermasalah. Mengalihkan ke metode bawaan...', 'warning');
+          window.setTimeout(() => loginForm.submit(), 0);
+          return;
+        }
 
         if (!response.ok) {
           await handleResponseError(response);


### PR DESCRIPTION
## Summary
- add method and action attributes so the login form can POST credentials natively
- guard the JavaScript handler to only intercept when fetch is available and fall back to native submit on network errors
- update the login API handler to accept both JSON and form submissions by constructing the payload from request.form when needed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e12400260c8327927473062d0ca2fa