### PR TITLE
Handle onboarding form submissions

### DIFF
--- a/src/app/web/templates/onboarding.html
+++ b/src/app/web/templates/onboarding.html
@@ -41,7 +41,13 @@
     <div id="onboarding-feedback" class="feedback" role="alert" aria-live="polite"></div>
 
     <div class="onboarding-forms">
-      <form id="registration-form" data-step="register" class="onboarding-form">
+      <form
+        id="registration-form"
+        data-step="register"
+        class="onboarding-form"
+        method="post"
+        action="/api/onboarding/register"
+      >
         <fieldset>
           <legend>1. Registrasi Pengguna</legend>
           <label>
@@ -64,7 +70,15 @@
         <button type="submit" class="btn gradient-button">Daftar &amp; Kirim Tautan</button>
       </form>
 
-      <form id="verification-form" data-step="verify" class="onboarding-form" aria-disabled="true">
+      <form
+        id="verification-form"
+        data-step="verify"
+        class="onboarding-form"
+        method="post"
+        action="/api/onboarding/verify"
+        aria-disabled="true"
+      >
+        <input type="hidden" name="onboarding_id" data-onboarding-id />
         <fieldset>
           <legend>2. Verifikasi Email</legend>
           <p class="form-help">
@@ -78,12 +92,28 @@
         </fieldset>
         <div class="form-actions">
           <button type="submit" class="btn btn-outline" disabled>Verifikasi Email</button>
-          <button type="button" class="btn btn-ghost" data-resend disabled>Kirim Ulang Tautan</button>
+          <button
+            type="submit"
+            class="btn btn-ghost"
+            data-resend
+            formaction="/api/onboarding/resend"
+            disabled
+          >
+            Kirim Ulang Tautan
+          </button>
         </div>
         <p class="debug-token" data-debug-token hidden></p>
       </form>
 
-      <form id="profile-form" data-step="profile" class="onboarding-form" aria-disabled="true">
+      <form
+        id="profile-form"
+        data-step="profile"
+        class="onboarding-form"
+        method="post"
+        action="/api/onboarding/profile"
+        aria-disabled="true"
+      >
+        <input type="hidden" name="onboarding_id" data-onboarding-id />
         <fieldset>
           <legend>3. Lengkapi Profil</legend>
           <label>
@@ -128,9 +158,26 @@
   const registrationForm = document.getElementById("registration-form");
   const verificationForm = document.getElementById("verification-form");
   const profileForm = document.getElementById("profile-form");
-  const resendButton = verificationForm.querySelector("[data-resend]");
+  const onboardingIdInputs = document.querySelectorAll("input[data-onboarding-id]");
   const debugTokenEl = verificationForm.querySelector("[data-debug-token]");
   const countdownEl = document.getElementById("verification-countdown");
+
+  function fallbackSubmit(form, submitter) {
+    if (!form) return;
+    const originalAction = form.getAttribute("action");
+    const submitterAction = submitter?.formAction;
+    if (submitterAction && submitterAction !== originalAction) {
+      form.setAttribute("action", submitterAction);
+    }
+    form.submit();
+    if (submitterAction && submitterAction !== originalAction) {
+      if (originalAction) {
+        form.setAttribute("action", originalAction);
+      } else {
+        form.removeAttribute("action");
+      }
+    }
+  }
 
   function setFeedback(message, tone = "info") {
     feedbackEl.textContent = message;
@@ -169,6 +216,11 @@
     const status = state.progress ? state.progress.status : "registered";
     enableForm(verificationForm, Boolean(state.onboardingId) && status === "registered");
     enableForm(profileForm, status === "email_verified");
+    const onboardingValue = state.onboardingId || "";
+    onboardingIdInputs.forEach((input) => {
+      input.value = onboardingValue;
+      input.defaultValue = onboardingValue;
+    });
   }
 
   function refreshCountdown(expiresAt) {
@@ -199,91 +251,140 @@
   }
 
   async function handleRegister(event) {
+    if (typeof window.fetch !== "function") {
+      return;
+    }
+
     event.preventDefault();
-    const formData = new FormData(registrationForm);
+    const form = event.target;
+    const formData = new FormData(form);
     const payload = Object.fromEntries(formData.entries());
     payload.marketing_opt_in = Boolean(payload.marketing_opt_in);
 
     setFeedback("Memproses registrasi...");
-    const response = await fetch("/api/onboarding/register", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
+    try {
+      const response = await fetch("/api/onboarding/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
 
-    if (!response.ok) {
-      const error = await response.json().catch(() => ({}));
-      setFeedback(error.detail || "Registrasi gagal", "danger");
-      return;
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({}));
+        setFeedback(error.detail || "Registrasi gagal", "danger");
+        return;
+      }
+
+      const data = await response.json();
+      state.onboardingId = data.onboarding_id;
+      state.verificationToken = data.verification_token;
+      verificationForm.reset();
+      profileForm.reset();
+      updateProgress(data.progress);
+      syncForms();
+      refreshCountdown(data.verification_expires_at);
+      debugTokenEl.textContent = `Token verifikasi (QA): ${state.verificationToken}`;
+      debugTokenEl.hidden = !state.verificationToken;
+      setFeedback("Registrasi berhasil. Tautan verifikasi telah dikirim ke email Anda.", "success");
+    } catch (error) {
+      console.error(error);
+      fallbackSubmit(form);
     }
-
-    const data = await response.json();
-    state.onboardingId = data.onboarding_id;
-    state.verificationToken = data.verification_token;
-    verificationForm.reset();
-    profileForm.reset();
-    updateProgress(data.progress);
-    syncForms();
-    refreshCountdown(data.verification_expires_at);
-    debugTokenEl.textContent = `Token verifikasi (QA): ${state.verificationToken}`;
-    debugTokenEl.hidden = !state.verificationToken;
-    setFeedback("Registrasi berhasil. Tautan verifikasi telah dikirim ke email Anda.", "success");
   }
 
   async function handleVerification(event) {
-    event.preventDefault();
-    if (!state.onboardingId) return;
+    if (typeof window.fetch !== "function") {
+      return;
+    }
 
-    const formData = new FormData(verificationForm);
+    event.preventDefault();
+    const form = event.target;
+    const submitter = event.submitter;
+
+    if (!state.onboardingId) {
+      fallbackSubmit(form, submitter);
+      return;
+    }
+
+    if (submitter && submitter.hasAttribute("data-resend")) {
+      await handleResend(event, submitter);
+      return;
+    }
+
+    const formData = new FormData(form);
     const payload = { onboarding_id: state.onboardingId, token: formData.get("token") };
 
     setFeedback("Memeriksa token...");
-    const response = await fetch("/api/onboarding/verify", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
+    try {
+      const response = await fetch("/api/onboarding/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
 
-    const data = await response.json().catch(() => ({}));
-    if (!response.ok) {
-      setFeedback(data.detail || "Token tidak valid", "danger");
-      return;
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        setFeedback(data.detail || "Token tidak valid", "danger");
+        return;
+      }
+
+      updateProgress(data.progress);
+      syncForms();
+      refreshCountdown(data.progress.verification.expires_at);
+      verificationForm.reset();
+      setFeedback("Email berhasil diverifikasi.", "success");
+    } catch (error) {
+      console.error(error);
+      fallbackSubmit(form, submitter);
     }
-
-    updateProgress(data.progress);
-    syncForms();
-    refreshCountdown(data.progress.verification.expires_at);
-    verificationForm.reset();
-    setFeedback("Email berhasil diverifikasi.", "success");
   }
 
-  async function handleResend() {
-    if (!state.onboardingId) return;
-    setFeedback("Meminta token baru...");
-    const response = await fetch("/api/onboarding/resend", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ onboarding_id: state.onboardingId }),
-    });
-    if (!response.ok) {
-      setFeedback("Gagal memperbarui token", "danger");
+  async function handleResend(event, submitter) {
+    const form = event.target;
+    if (!state.onboardingId) {
+      fallbackSubmit(form, submitter);
       return;
     }
-    const data = await response.json();
-    state.verificationToken = data.verification_token;
-    updateProgress(data.progress);
-    refreshCountdown(data.verification_expires_at);
-    debugTokenEl.textContent = `Token verifikasi (QA): ${state.verificationToken}`;
-    debugTokenEl.hidden = !state.verificationToken;
-    verificationForm.reset();
-    setFeedback("Tautan verifikasi baru dikirim. Cek email Anda.", "success");
+
+    setFeedback("Meminta token baru...");
+    try {
+      const response = await fetch("/api/onboarding/resend", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ onboarding_id: state.onboardingId }),
+      });
+      if (!response.ok) {
+        setFeedback("Gagal memperbarui token", "danger");
+        return;
+      }
+      const data = await response.json();
+      state.verificationToken = data.verification_token;
+      updateProgress(data.progress);
+      syncForms();
+      refreshCountdown(data.verification_expires_at);
+      debugTokenEl.textContent = `Token verifikasi (QA): ${state.verificationToken}`;
+      debugTokenEl.hidden = !state.verificationToken;
+      verificationForm.reset();
+      setFeedback("Tautan verifikasi baru dikirim. Cek email Anda.", "success");
+    } catch (error) {
+      console.error(error);
+      fallbackSubmit(form, submitter);
+    }
   }
 
   async function handleProfile(event) {
-    event.preventDefault();
-    if (!state.onboardingId) return;
+    if (typeof window.fetch !== "function") {
+      return;
+    }
 
-    const formData = new FormData(profileForm);
+    event.preventDefault();
+    const form = event.target;
+    if (!state.onboardingId) {
+      fallbackSubmit(form);
+      return;
+    }
+
+    const formData = new FormData(form);
     const payload = {
       onboarding_id: state.onboardingId,
       display_name: formData.get("display_name"),
@@ -292,28 +393,32 @@
     };
 
     setFeedback("Menyimpan profil...");
-    const response = await fetch("/api/onboarding/profile", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
+    try {
+      const response = await fetch("/api/onboarding/profile", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
 
-    const data = await response.json().catch(() => ({}));
-    if (!response.ok) {
-      setFeedback(data.detail || "Profil tidak valid", "danger");
-      return;
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        setFeedback(data.detail || "Profil tidak valid", "danger");
+        return;
+      }
+
+      updateProgress(data.progress);
+      syncForms();
+      setFeedback("Profil berhasil disimpan. Onboarding selesai!", "success");
+      profileForm.reset();
+    } catch (error) {
+      console.error(error);
+      fallbackSubmit(form);
     }
-
-    updateProgress(data.progress);
-    syncForms();
-    setFeedback("Profil berhasil disimpan. Onboarding selesai!", "success");
-    profileForm.reset();
   }
 
   registrationForm.addEventListener("submit", handleRegister);
   verificationForm.addEventListener("submit", handleVerification);
   profileForm.addEventListener("submit", handleProfile);
-  resendButton.addEventListener("click", handleResend);
 
   updateProgress({ step_index: 1, total_steps: 3, is_complete: false, status: "registered", verification: { active: false, expires_at: null } });
   syncForms();

--- a/tests/test_onboarding_api.py
+++ b/tests/test_onboarding_api.py
@@ -1,5 +1,8 @@
+import asyncio
+
 import pytest
 from fastapi import HTTPException
+from starlette.requests import Request
 
 from app.api.routes.onboarding import (
     RegistrationRequest,
@@ -15,70 +18,105 @@ from app.api.routes.onboarding import (
 from app.services.onboarding import OnboardingService
 
 
+def _build_request(path: str = "/") -> Request:
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": path,
+        "headers": [],
+        "client": ("testclient", 1234),
+        "server": ("testserver", 80),
+    }
+    return Request(scope)
+
+
 def test_onboarding_flow_handlers():
     service = OnboardingService()
 
-    registration = register_user(
-        RegistrationRequest(
-            email="artisan@sensasiwangi.id",
-            full_name="Ayu Laras",
-            password="secret123",
-        ),
-        service=service,
-    )
+    async def run_flow() -> None:
+        registration = await register_user(
+            _build_request("/api/onboarding/register"),
+            RegistrationRequest(
+                email="artisan@sensasiwangi.id",
+                full_name="Ayu Laras",
+                password="secret123",
+            ),
+            service=service,
+        )
 
-    assert registration.status.value == "registered"
-    assert registration.verification_token is not None
+        assert registration.status.value == "registered"
+        assert registration.verification_token is not None
 
-    verification = verify_email(
-        VerificationRequest(onboarding_id=registration.onboarding_id, token=registration.verification_token or ""),
-        service=service,
-    )
+        verification = await verify_email(
+            _build_request("/api/onboarding/verify"),
+            VerificationRequest(onboarding_id=registration.onboarding_id, token=registration.verification_token or ""),
+            service=service,
+        )
 
-    assert verification.status.value == "email_verified"
+        assert verification.status.value == "email_verified"
 
-    profile = complete_profile(
-        ProfileRequest(
-            onboarding_id=registration.onboarding_id,
-            display_name="Studio Senja",
-            business_goal="Skala produksi parfum",
-            experience_level="Eksperimen Mandiri",
-        ),
-        service=service,
-    )
+        profile = await complete_profile(
+            _build_request("/api/onboarding/profile"),
+            ProfileRequest(
+                onboarding_id=registration.onboarding_id,
+                display_name="Studio Senja",
+                business_goal="Skala produksi parfum",
+                experience_level="Eksperimen Mandiri",
+            ),
+            service=service,
+        )
 
-    assert profile.progress["is_complete"] is True
+        assert profile.progress["is_complete"] is True
 
-    events = get_event_log(registration.onboarding_id, service=service)
-    event_names = [event["event"] for event in events.events]
-    assert "registered" in event_names
-    assert "email_verified" in event_names
-    assert "profile_completed" in event_names
+        events = get_event_log(registration.onboarding_id, service=service)
+        event_names = [event["event"] for event in events.events]
+        assert "registered" in event_names
+        assert "email_verified" in event_names
+        assert "profile_completed" in event_names
 
-    with pytest.raises(HTTPException) as excinfo:
-        resend_token(ResendRequest(onboarding_id=registration.onboarding_id), service=service)
-    assert excinfo.value.status_code == 400
+        with pytest.raises(HTTPException) as excinfo:
+            await resend_token(
+                _build_request("/api/onboarding/resend"),
+                ResendRequest(onboarding_id=registration.onboarding_id),
+                service=service,
+            )
+        assert excinfo.value.status_code == 400
+
+    asyncio.run(run_flow())
 
 
 def test_verify_email_with_invalid_token():
     service = OnboardingService()
-    registration = register_user(
-        RegistrationRequest(
-            email="artisan@sensasiwangi.id",
-            full_name="Ayu Laras",
-            password="secret123",
-        ),
-        service=service,
-    )
 
-    with pytest.raises(HTTPException) as excinfo:
-        verify_email(
-            VerificationRequest(onboarding_id=registration.onboarding_id, token="SALAH"),
+    async def run_flow() -> None:
+        registration = await register_user(
+            _build_request("/api/onboarding/register"),
+            RegistrationRequest(
+                email="artisan@sensasiwangi.id",
+                full_name="Ayu Laras",
+                password="secret123",
+            ),
             service=service,
         )
 
-    assert excinfo.value.status_code == 400
-    assert "Token" in excinfo.value.detail
+        with pytest.raises(HTTPException) as excinfo:
+            await verify_email(
+                _build_request("/api/onboarding/verify"),
+                VerificationRequest(onboarding_id=registration.onboarding_id, token="SALAH"),
+                service=service,
+            )
 
-    resend = resend_token(ResendRequest(onboarding_id=registration.onboarding_id), service=service)
-    assert resend.verification_token is not None
+        assert excinfo.value.status_code == 400
+        assert "Token" in excinfo.value.detail
+
+        resend = await resend_token(
+            _build_request("/api/onboarding/resend"),
+            ResendRequest(onboarding_id=registration.onboarding_id),
+            service=service,
+        )
+        assert resend.verification_token is not None
+
+    asyncio.run(run_flow())


### PR DESCRIPTION
## Summary
- set explicit actions for onboarding forms and keep hidden onboarding_id data when resending links
- guard fetch-driven enhancements with fallbacks and support resubmitting when AJAX fails
- convert onboarding API handlers to async, accept form payloads, and update tests for the new interface

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e124204b208327b15faf00734be9e2