### PR TITLE
Implement brand logo upload with storage fallback

### DIFF
--- a/src/app/services/storage.py
+++ b/src/app/services/storage.py
@@ -1,0 +1,112 @@
+"""Utility helpers for persisting uploaded assets such as brand logos."""
+
+from __future__ import annotations
+
+import mimetypes
+import secrets
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from app.core.config import get_settings
+
+try:  # pragma: no cover - optional dependency for Supabase integration
+    import httpx
+except ImportError:  # pragma: no cover - handled by fallback storage
+    httpx = None  # type: ignore[assignment]
+
+
+class StorageError(Exception):
+    """Base error for storage related failures."""
+
+
+class StorageUnavailable(StorageError):
+    """Raised when the primary storage backend cannot be used."""
+
+
+class StorageUploadFailed(StorageError):
+    """Raised when an upload cannot be completed in any backend."""
+
+
+@dataclass
+class LogoUpload:
+    """Structure describing an uploaded logo file."""
+
+    filename: str
+    content_type: str
+    data: bytes
+
+
+class BrandLogoStorage:
+    """Persist brand logos to Supabase Storage with a local fallback."""
+
+    def __init__(self, *, bucket: str = "brand-assets", media_root: Optional[Path] = None) -> None:
+        self._bucket = bucket
+        self._settings = get_settings()
+        self._media_root = media_root or Path("media/uploads")
+        self._media_root.mkdir(parents=True, exist_ok=True)
+
+    def store_logo(self, *, slug: str, upload: LogoUpload) -> str:
+        """Persist the provided logo and return a public URL."""
+
+        object_name = self._build_object_name(slug, upload)
+        try:
+            return self._upload_to_supabase(object_name, upload)
+        except StorageUnavailable:
+            return self._save_locally(object_name, upload)
+        except StorageUploadFailed:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive programming
+            raise StorageUploadFailed("Gagal menyimpan logo brand.") from exc
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _build_object_name(self, slug: str, upload: LogoUpload) -> str:
+        safe_slug = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "-" for ch in slug) or "brand"
+        extension = Path(upload.filename).suffix.lower()
+        if not extension:
+            guessed = mimetypes.guess_extension(upload.content_type)
+            extension = guessed or ""
+        if extension == ".jpe":  # normalise jpeg extension
+            extension = ".jpg"
+        if extension and not extension.startswith("."):
+            extension = f".{extension}"
+        if not extension:
+            extension = ".bin"
+        unique = secrets.token_hex(8)
+        return f"brand-logos/{safe_slug}-{unique}{extension}"
+
+    def _upload_to_supabase(self, object_name: str, upload: LogoUpload) -> str:
+        settings = self._settings
+        if not settings.supabase_url or not settings.supabase_service_role_key:
+            raise StorageUnavailable("Supabase Storage belum dikonfigurasi.")
+        if httpx is None:
+            raise StorageUnavailable("Dependensi httpx belum tersedia untuk Supabase Storage.")
+
+        url = f"{settings.supabase_url}/storage/v1/object/{self._bucket}/{object_name}"
+        headers = {
+            "Authorization": f"Bearer {settings.supabase_service_role_key}",
+            "Content-Type": upload.content_type,
+            "x-upsert": "true",
+        }
+        try:
+            with httpx.Client(timeout=10.0) as client:  # type: ignore[attr-defined]
+                response = client.post(url, content=upload.data, headers=headers)
+        except httpx.HTTPError as exc:  # pragma: no cover - network failures are environment specific
+            raise StorageUnavailable("Gagal terhubung ke Supabase Storage.") from exc
+
+        if response.status_code >= 400:
+            raise StorageUploadFailed("Supabase menolak unggahan logo brand.")
+
+        return f"{settings.supabase_url}/storage/v1/object/public/{self._bucket}/{object_name}"
+
+    def _save_locally(self, object_name: str, upload: LogoUpload) -> str:
+        target_path = self._media_root / object_name
+        try:
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.write_bytes(upload.data)
+        except OSError as exc:  # pragma: no cover - disk write issues are environment specific
+            raise StorageUploadFailed("Gagal menyimpan logo brand secara lokal.") from exc
+
+        return f"/media/uploads/{object_name}"

--- a/src/app/web/templates/pages/brand/detail.html
+++ b/src/app/web/templates/pages/brand/detail.html
@@ -6,76 +6,7 @@
 
 {% block content %}
 <article class="brand-page" aria-labelledby="brand-title">
-  <header class="brand-hero glass-card">
-    <div class="brand-hero__media" style="background-image: url('{{ brand.hero_image_url }}')" role="img" aria-label="Visual brand {{ brand.name }}"></div>
-    <div class="brand-hero__content">
-      <div class="brand-hero__branding">
-        {% if brand.logo_url %}
-        <img class="brand-logo" src="{{ brand.logo_url }}" alt="Logo {{ brand.name }}" loading="lazy" />
-        {% else %}
-        <div class="brand-logo brand-logo--placeholder" role="img" aria-label="Inisial brand {{ brand.name }}">
-          {{ brand.name[:2]|upper }}
-        </div>
-        {% endif %}
-        <form class="brand-logo-upload" aria-label="Form unggah logo brand" enctype="multipart/form-data">
-          <label class="brand-logo-upload__trigger">
-            <input type="file" name="logo" accept="image/*" />
-            <span>Unggah logo brand</span>
-          </label>
-          <p class="brand-logo-upload__hint">Format yang didukung: PNG, JPG, atau SVG maksimal 2MB.</p>
-        </form>
-      </div>
-      <span class="badge brand">Brand Partner</span>
-      <div class="brand-title-group">
-        <h1 id="brand-title">{{ brand.name }}</h1>
-        {% if brand.is_verified %}
-        <span class="badge verified" aria-label="Brand terverifikasi">&#10003; Verified Brand</span>
-        {% endif %}
-      </div>
-      <p class="brand-tagline">{{ brand.tagline }}</p>
-      <div class="brand-description">
-        <h2>Deskripsi Brand</h2>
-        <p>{{ brand.description }}</p>
-      </div>
-      <dl class="brand-meta">
-        <div>
-          <dt>Berbasis di</dt>
-          <dd>{{ brand.origin_city }}</dd>
-        </div>
-        <div>
-          <dt>Owner brand</dt>
-          <dd>
-            {% if brand.list_owners() %}
-            {% for owner in brand.list_owners() %}
-            <span class="chip chip-owner">{{ owner.full_name }}</span>
-            {% endfor %}
-            {% else %}
-            <span class="chip chip-muted">Belum ada owner aktif</span>
-            {% endif %}
-          </dd>
-        </div>
-        <div>
-          <dt>Tahun berdiri</dt>
-          <dd>Sejak {{ brand.established_year }}</dd>
-        </div>
-        {% if brand.aroma_focus %}
-        <div>
-          <dt>Fokus aroma</dt>
-          <dd>
-            {% for focus in brand.aroma_focus %}
-            <span class="chip">{{ focus }}</span>
-            {% endfor %}
-          </dd>
-        </div>
-        {% endif %}
-      </dl>
-      <div class="brand-cta">
-        <a class="button" href="{{ request.url_for('edit_brand', slug=brand.slug) }}">Kelola brand</a>
-        <a class="button button-secondary" href="/marketplace">Lihat katalog marketplace</a>
-        <a class="button button-ghost" href="/brands">Brand lainnya</a>
-      </div>
-    </div>
-  </header>
+  {% include 'pages/brand/partials/hero.html' %}
 
   <section class="brand-section" aria-labelledby="brand-story">
     <div class="section-header">

--- a/src/app/web/templates/pages/brand/partials/hero.html
+++ b/src/app/web/templates/pages/brand/partials/hero.html
@@ -1,0 +1,104 @@
+<header id="brand-hero" class="brand-hero glass-card">
+  <div class="brand-hero__media" style="background-image: url('{{ brand.hero_image_url }}')" role="img" aria-label="Visual brand {{ brand.name }}"></div>
+  <div class="brand-hero__content">
+    <div class="brand-hero__branding">
+      {% if brand.logo_url %}
+      <img class="brand-logo" src="{{ brand.logo_url }}" alt="Logo {{ brand.name }}" loading="lazy" />
+      {% else %}
+      <div class="brand-logo brand-logo--placeholder" role="img" aria-label="Inisial brand {{ brand.name }}">
+        {{ brand.name[:2]|upper }}
+      </div>
+      {% endif %}
+      <form
+        class="brand-logo-upload"
+        aria-label="Form unggah logo brand"
+        method="post"
+        action="{{ request.url_for('upload_brand_logo', slug=brand.slug) }}"
+        enctype="multipart/form-data"
+        hx-post="{{ request.url_for('upload_brand_logo', slug=brand.slug) }}"
+        hx-target="#brand-hero"
+        hx-swap="outerHTML"
+        hx-encoding="multipart/form-data"
+      >
+        <div class="brand-logo-upload__field">
+          <label for="logo-url-input">Gunakan URL logo</label>
+          <input
+            type="url"
+            id="logo-url-input"
+            name="logo_url"
+            placeholder="https://contoh.com/logo.svg"
+            inputmode="url"
+          />
+        </div>
+        <div class="brand-logo-upload__divider" aria-hidden="true">atau</div>
+        <div class="brand-logo-upload__field">
+          <label class="brand-logo-upload__trigger" for="logo-file-input">
+            <span>Pilih file logo</span>
+          </label>
+          <input
+            type="file"
+            id="logo-file-input"
+            name="logo_file"
+            accept=".png,.jpg,.jpeg,.svg,image/png,image/jpeg,image/svg+xml"
+          />
+        </div>
+        <p class="brand-logo-upload__hint">Format didukung: PNG, JPG, atau SVG maksimal 2MB.</p>
+        {% if logo_feedback %}
+        <p class="brand-logo-upload__status brand-logo-upload__status--{{ logo_feedback.level }}">
+          {{ logo_feedback.message }}
+        </p>
+        {% endif %}
+        <button type="submit" class="button button-secondary brand-logo-upload__submit">Perbarui logo</button>
+      </form>
+    </div>
+    <span class="badge brand">Brand Partner</span>
+    <div class="brand-title-group">
+      <h1 id="brand-title">{{ brand.name }}</h1>
+      {% if brand.is_verified %}
+      <span class="badge verified" aria-label="Brand terverifikasi">&#10003; Verified Brand</span>
+      {% endif %}
+    </div>
+    <p class="brand-tagline">{{ brand.tagline }}</p>
+    <div class="brand-description">
+      <h2>Deskripsi Brand</h2>
+      <p>{{ brand.description }}</p>
+    </div>
+    <dl class="brand-meta">
+      <div>
+        <dt>Berbasis di</dt>
+        <dd>{{ brand.origin_city }}</dd>
+      </div>
+      <div>
+        <dt>Owner brand</dt>
+        <dd>
+          {% if brand.list_owners() %}
+          {% for owner in brand.list_owners() %}
+          <span class="chip chip-owner">{{ owner.full_name }}</span>
+          {% endfor %}
+          {% else %}
+          <span class="chip chip-muted">Belum ada owner aktif</span>
+          {% endif %}
+        </dd>
+      </div>
+      <div>
+        <dt>Tahun berdiri</dt>
+        <dd>Sejak {{ brand.established_year }}</dd>
+      </div>
+      {% if brand.aroma_focus %}
+      <div>
+        <dt>Fokus aroma</dt>
+        <dd>
+          {% for focus in brand.aroma_focus %}
+          <span class="chip">{{ focus }}</span>
+          {% endfor %}
+        </dd>
+      </div>
+      {% endif %}
+    </dl>
+    <div class="brand-cta">
+      <a class="button" href="{{ request.url_for('edit_brand', slug=brand.slug) }}">Kelola brand</a>
+      <a class="button button-secondary" href="/marketplace">Lihat katalog marketplace</a>
+      <a class="button button-ghost" href="/brands">Brand lainnya</a>
+    </div>
+  </div>
+</header>


### PR DESCRIPTION
## Summary
- replace the brand hero upload form with an HTMX-enabled POST form that supports URL and file logo updates
- add a FastAPI endpoint for /brands/{slug}/logo that validates uploads, updates the logo, and returns the refreshed hero partial with feedback
- introduce a storage helper with Supabase support and local fallback and wire BrandService.update_logo to persist uploaded logos

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e19f93122c8327a54e6cd8158a50db