### PR TITLE
Add HTMX co-owner invitation management endpoints

### DIFF
--- a/src/app/services/brands.py
+++ b/src/app/services/brands.py
@@ -500,6 +500,25 @@ class BrandService:
                 return member
         raise BrandError("Undangan co-owner tidak ditemukan untuk brand ini.")
 
+    def cancel_co_owner_invite(self, brand_slug: str, profile_id: str) -> BrandMember:
+        brand = self.get_brand(brand_slug)
+        for index, member in enumerate(brand.members):
+            if (
+                member.profile_id == profile_id
+                and member.role == "co-owner"
+                and member.status == "pending"
+            ):
+                return brand.members.pop(index)
+        raise BrandError("Undangan co-owner tidak ditemukan untuk brand ini.")
+
+    def get_team_partial_context(self, brand_slug: str) -> Dict[str, Any]:
+        brand = self.get_brand(brand_slug)
+        return {
+            "brand": brand,
+            "pending_members": brand.list_pending_members(),
+            "active_members": brand.list_active_members(),
+        }
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------

--- a/src/app/web/templates/components/brand/team_pending_column.html
+++ b/src/app/web/templates/components/brand/team_pending_column.html
@@ -1,0 +1,84 @@
+<div
+  id="brand-team-pending"
+  class="team-column"
+  hx-target="this"
+  hx-swap="outerHTML"
+>
+  <h3>Menunggu Persetujuan</h3>
+  <p
+    class="team-feedback{% if feedback_type %} team-feedback--{{ feedback_type }}{% endif %}"
+    aria-live="polite"
+    role="status"
+  >
+    {% if feedback_message %}{{ feedback_message }}{% endif %}
+  </p>
+  {% if pending_members %}
+  <ul class="team-list">
+    {% for member in pending_members %}
+    <li class="team-card glass-panel team-card--pending">
+      {% if member.avatar_url %}
+      <img src="{{ member.avatar_url }}" alt="{{ member.full_name }}" loading="lazy" />
+      {% endif %}
+      <div>
+        <p class="team-name">{{ member.full_name }}</p>
+        <p class="team-role">{{ member.role|replace('-', ' ')|title }}</p>
+        <p class="team-expertise">{{ member.expertise or 'Menunggu konfirmasi peran' }}</p>
+        {% if member.invited_by %}
+        <p class="team-invited">Diundang oleh {{ member.invited_by }}</p>
+        {% endif %}
+      </div>
+      <div class="team-actions">
+        <form
+          method="post"
+          hx-post="{{ request.url_for('approve_brand_co_owner', slug=brand.slug, profile_id=member.profile_id) }}"
+          hx-target="#brand-team-pending"
+          hx-swap="outerHTML"
+        >
+          <button type="submit" class="button button-small">Setujui</button>
+        </form>
+        <form
+          method="post"
+          hx-delete="{{ request.url_for('cancel_brand_co_owner', slug=brand.slug, profile_id=member.profile_id) }}"
+          hx-target="#brand-team-pending"
+          hx-swap="outerHTML"
+        >
+          <button type="submit" class="button button-ghost button-small">Batalkan</button>
+        </form>
+      </div>
+    </li>
+    {% endfor %}
+  </ul>
+  {% else %}
+  <p class="empty-state">Belum ada undangan co-owner yang menunggu persetujuan.</p>
+  {% endif %}
+  <form
+    class="invite-form glass-panel"
+    aria-label="Form undang co-owner"
+    method="post"
+    hx-post="{{ request.url_for('invite_brand_co_owner', slug=brand.slug) }}"
+    hx-target="#brand-team-pending"
+    hx-swap="outerHTML"
+  >
+    <h4>Undang Co-owner</h4>
+    <p>Masukkan username komunitas untuk meminta persetujuan mereka sebagai co-owner.</p>
+    <label>
+      <span>Username</span>
+      <input
+        type="text"
+        name="username"
+        placeholder="contoh: chandra-pratama"
+        value="{{ form_state.username }}"
+        required
+      />
+    </label>
+    <label>
+      <span>Catatan</span>
+      <textarea
+        name="note"
+        rows="3"
+        placeholder="Jelaskan peran atau kontribusi yang diharapkan"
+      >{{ form_state.note }}</textarea>
+    </label>
+    <button type="submit" class="button button-secondary">Kirim Undangan</button>
+  </form>
+</div>

--- a/src/app/web/templates/pages/brand/detail.html
+++ b/src/app/web/templates/pages/brand/detail.html
@@ -144,47 +144,11 @@
           {% endfor %}
         </ul>
       </div>
-      <div class="team-column">
-        <h3>Menunggu Persetujuan</h3>
-        {% if brand.list_pending_members() %}
-        <ul class="team-list">
-          {% for member in brand.list_pending_members() %}
-          <li class="team-card glass-panel team-card--pending">
-            {% if member.avatar_url %}
-            <img src="{{ member.avatar_url }}" alt="{{ member.full_name }}" loading="lazy" />
-            {% endif %}
-            <div>
-              <p class="team-name">{{ member.full_name }}</p>
-              <p class="team-role">{{ member.role|replace('-', ' ')|title }}</p>
-              <p class="team-expertise">{{ member.expertise or 'Menunggu konfirmasi peran' }}</p>
-              {% if member.invited_by %}
-              <p class="team-invited">Diundang oleh {{ member.invited_by }}</p>
-              {% endif %}
-            </div>
-            <div class="team-actions">
-              <button type="button" class="button button-small">Setujui</button>
-              <button type="button" class="button button-ghost button-small">Batalkan</button>
-            </div>
-          </li>
-          {% endfor %}
-        </ul>
-        {% else %}
-        <p class="empty-state">Belum ada undangan co-owner yang menunggu persetujuan.</p>
-        {% endif %}
-        <form class="invite-form glass-panel" aria-label="Form undang co-owner">
-          <h4>Undang Co-owner</h4>
-          <p>Masukkan username komunitas untuk meminta persetujuan mereka sebagai co-owner.</p>
-          <label>
-            <span>Username</span>
-            <input type="text" placeholder="contoh: chandra-pratama" />
-          </label>
-          <label>
-            <span>Catatan</span>
-            <textarea rows="3" placeholder="Jelaskan peran atau kontribusi yang diharapkan"></textarea>
-          </label>
-          <button type="button" class="button button-secondary">Kirim Undangan</button>
-        </form>
-      </div>
+      {% set pending_members = brand.list_pending_members() %}
+      {% set form_state = {"username": "", "note": ""} %}
+      {% set feedback_message = None %}
+      {% set feedback_type = "info" %}
+      {% include "components/brand/team_pending_column.html" %}
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- add service helpers to remove pending invites and supply team context for partial rendering
- expose HTMX endpoints to invite, approve, and cancel co-owner requests using TemplateResponse updates
- refactor the brand detail template to use HTMX forms and a reusable pending-team partial with aria-live feedback

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e19fb0333083279b19e4cf1d4799cf